### PR TITLE
fix: standardize namespace exports for ware, config-manager, configurator, fn

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "./color": "./build/domains/color/$$.js",
     "./dir": "./build/utils/dir/$$.js",
     "./err": "./build/utils/err/$$.js",
-    "./fn": "./build/domains/fn/$$.js",
+    "./fn": "./build/domains/fn/$.js",
     "./fs": "./build/utils/fs/$$.js",
     "./group": "./build/domains/group/$$.js",
     "./html": "./build/utils/html/$$.js",
@@ -209,10 +209,10 @@
     "./fs-loc": "./build/utils/fs-loc/$$.js",
     "./paka": "./build/utils/paka/$$.js",
     "./log": "./build/utils/log/$$.js",
-    "./ware": "./build/utils/ware/$$.js",
+    "./ware": "./build/utils/ware/$.js",
     "./mutable-builder": "./build/utils/mutable-builder/$$.js",
-    "./configurator": "./build/utils/configurator/$$.js",
-    "./config-manager": "./build/utils/config-manager/$$.js"
+    "./configurator": "./build/utils/configurator/$.js",
+    "./config-manager": "./build/utils/config-manager/$.js"
   },
   "scripts": {
     "r": "libra refresh && pnpm fix:format",


### PR DESCRIPTION
## Summary
Changes package.json exports to use `$.js` (namespace exports) instead of `$$.js` (direct exports) for:
- ware (Anyware)
- config-manager (ConfigManager)
- configurator (Configurator)  
- fn (Fn)

This follows the standard pattern used by other kit modules like test, where `$.js` provides the namespace export pattern.

## Context
These modules were migrated from graffle to kit and already have the namespace export pattern in their `$.ts` files. This PR updates the package.json exports to point to the correct file so consumers can import using namespace syntax (e.g., `import { Ware } from '@wollybeard/kit/ware'`).

## Test plan
- [ ] Check that CI passes
- [ ] Verify namespace exports work in graffle PR #1426