### PR TITLE
fix: export Ware, ConfigManager, Configurator namespaces from main module

### DIFF
--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -27,6 +27,8 @@ export * from '#url'
 // Utils
 export * from '#cli'
 export * from '#codec'
+export * from '#config-manager'
+export * from '#configurator'
 export * from '#dir'
 export * from '#err'
 export * from '#fs'
@@ -50,6 +52,7 @@ export * from '#sch'
 export * from '#traitor'
 export * from '#ts'
 export * from '#value'
+export * from '#ware'
 
 // To satisfy TS
 // e.g.


### PR DESCRIPTION
## Summary
Adds namespace exports to main module exports/index.ts:
- `export * from '#ware'` (exports Ware namespace)
- `export * from '#config-manager'` (exports ConfigManager namespace)  
- `export * from '#configurator'` (exports Configurator namespace)

Subpath barrel exports remain unchanged (already pointing to $$.js).

## Pattern
This follows the standard kit pattern:
- **Main module**: `import { Ware } from '@wollybeard/kit'` → gets Ware namespace
- **Subpath**: `import { StepDefinition } from '@wollybeard/kit/ware'` → drillable barrel

## Test plan
- [ ] CI checks pass
- [ ] Verify graffle can import namespaces from main module