### PR TITLE
feat(paka): add namespace landing pages with VitePress home layout

### DIFF
--- a/src/utils/paka/extractor/__snapshots__/_.test.ts.snap
+++ b/src/utils/paka/extractor/__snapshots__/_.test.ts.snap
@@ -415,135 +415,2382 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
     '/u.ts': '/** Nested */\\nexport const a = 1'
   }
 }
-╠══════════════════════════════════════════════════╣ THEN RETURNS OBJECT
+╠══════════════════════════════════════════════════╣ THEN THROWS PARSEERROR
 {
-  name: 'x',
-  version: '0.0.0',
-  entrypoints: [
-    {
-      path: '.',
-      module: {
-        location: './i.ts',
-        docs: undefined,
-        docsProvenance: undefined,
-        category: undefined,
-        exports: [
-          {
-            name: 'U',
-            signature: {
-              text: 'export * as U',
-              _tag: 'TypeSignatureModel'
-            },
-            docs: {
-              description: 'Shadow',
-              guide: undefined
-            },
-            docsProvenance: {
-              description: {
-                shadowNamespace: true,
-                _tag: 'jsdoc'
+  issue: {
+    ast: {
+      annotations: {},
+      _tag: 'TypeLiteral',
+      propertySignatures: [
+        {
+          type: {
+            annotations: {},
+            _tag: 'StringKeyword'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'name',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [
+                                                            '[Circular]',
+                                                            {
+                                                              annotations: {},
+                                                              _tag: 'UndefinedKeyword'
+                                                            }
+                                                          ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'constraint',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'default',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'typeParameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'type',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          annotations: {},
+                                                          _tag: 'BooleanKeyword'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'optional',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'rest',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'defaultValue',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'description',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'parameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'returnType',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'returnDoc',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: '[Circular]',
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'throws',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'overloads',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'FunctionSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
               },
-              guide: undefined
-            },
-            examples: [],
-            deprecated: undefined,
-            category: 'C',
-            tags: {},
-            sourceLocation: {
-              file: './i.ts',
-              line: 2
-            },
-            type: 'namespace',
-            module: {
-              location: './u.ts',
-              docs: {
-                description: 'Nested',
-                guide: undefined
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'typeName',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          typeParameters: [
+                            {
+                              annotations: '[Circular]',
+                              _tag: 'TypeLiteral',
+                              propertySignatures: [
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'typeParameters',
+                                  isReadonly: true
+                                },
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'parameters',
+                                  isReadonly: true
+                                },
+                                '[Circular]',
+                                '[Circular]',
+                                '[Circular]'
+                              ],
+                              indexSignatures: '[Circular]'
+                            }
+                          ],
+                          decodeUnknown: [Function (anonymous)],
+                          encodeUnknown: [Function (anonymous)],
+                          annotations: '[Circular]',
+                          _tag: 'Declaration'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'entryPoint',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          enums: [ [ 'chainable', 'chainable' ], [ 'terminal', 'terminal' ], [ 'transform', 'transform' ] ],
+                                          annotations: {},
+                                          _tag: 'Enums'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'category',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'transformsTo',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'chainableMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'terminalMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'transformMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'BuilderSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
               },
-              docsProvenance: {
-                description: {
-                  shadowNamespace: false,
-                  _tag: 'jsdoc'
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'ctor',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'type',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'optional',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'readonly',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'description',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'properties',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'methods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ClassSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'text',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'TypeSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'type',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ValueSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              }
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'signature',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                types: [
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'typeParameters',
+                                            isReadonly: true
+                                          },
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'parameters',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'overloads',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          '[Circular]',
+                          {
+                            type: {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'entryPoint',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'chainableMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'terminalMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'transformMethods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'typeParameters',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'parameters',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]',
+                                        '[Circular]',
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                },
+                                '[Circular]'
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            annotations: {},
+                            isOptional: true,
+                            name: 'ctor',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: '[Circular]',
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'properties',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'methods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  '[Circular]',
+                  '[Circular]'
+                ],
+                annotations: '[Circular]',
+                _tag: 'Union'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'signatureSimple',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docs',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: '[Circular]',
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'shadowNamespace',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'jsdoc',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                },
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: {},
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  {
+                                                    type: {
+                                                      elements: [],
+                                                      rest: [
+                                                        {
+                                                          type: {
+                                                            from: {
+                                                              from: '[Circular]',
+                                                              filter: [Function: filter],
+                                                              annotations: {},
+                                                              _tag: 'Refinement'
+                                                            },
+                                                            filter: [Function: filter],
+                                                            annotations: {},
+                                                            _tag: 'Refinement'
+                                                          },
+                                                          annotations: {}
+                                                        }
+                                                      ],
+                                                      isReadonly: true,
+                                                      annotations: {},
+                                                      _tag: 'TupleType'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'segments',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      typeParameters: [
+                                                        {
+                                                          annotations: {},
+                                                          _tag: 'TypeLiteral',
+                                                          propertySignatures: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'stem',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                types: [
+                                                                  {
+                                                                    from: '[Circular]',
+                                                                    filter: [Function: filter],
+                                                                    annotations: {},
+                                                                    _tag: 'Refinement'
+                                                                  },
+                                                                  {
+                                                                    literal: null,
+                                                                    annotations: {},
+                                                                    _tag: 'Literal'
+                                                                  }
+                                                                ],
+                                                                annotations: {},
+                                                                _tag: 'Union'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'extension',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                literal: 'FileName',
+                                                                annotations: {},
+                                                                _tag: 'Literal'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: '_tag',
+                                                              isReadonly: true
+                                                            }
+                                                          ],
+                                                          indexSignatures: []
+                                                        }
+                                                      ],
+                                                      decodeUnknown: [Function (anonymous)],
+                                                      encodeUnknown: [Function (anonymous)],
+                                                      annotations: {},
+                                                      _tag: 'Declaration'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      literal: 'FsPathRelFile',
+                                                      annotations: {},
+                                                      _tag: 'Literal'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: '_tag',
+                                                    isReadonly: true
+                                                  }
+                                                ],
+                                                indexSignatures: []
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: {},
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'md-file',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: {},
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                '[Circular]',
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: '[Circular]',
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  '[Circular]',
+                                                  {
+                                                    type: '[Circular]',
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  '[Circular]'
+                                                ],
+                                                indexSignatures: '[Circular]'
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: '[Circular]',
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docsProvenance',
+          isReadonly: true
+        },
+        {
+          type: {
+            elements: [],
+            rest: [
+              {
+                type: {
+                  typeParameters: [
+                    {
+                      annotations: {},
+                      _tag: 'TypeLiteral',
+                      propertySignatures: [
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'code',
+                          isReadonly: true
+                        },
+                        {
+                          type: {
+                            types: [ '[Circular]', '[Circular]' ],
+                            annotations: {},
+                            _tag: 'Union'
+                          },
+                          annotations: {},
+                          isOptional: true,
+                          name: 'title',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'twoslashEnabled',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'language',
+                          isReadonly: true
+                        }
+                      ],
+                      indexSignatures: []
+                    }
+                  ],
+                  decodeUnknown: [Function (anonymous)],
+                  encodeUnknown: [Function (anonymous)],
+                  annotations: {},
+                  _tag: 'Declaration'
                 },
-                guide: undefined
-              },
-              category: undefined,
-              exports: [
-                {
-                  name: 'a',
-                  signature: {
-                    type: '1',
-                    _tag: 'ValueSignatureModel'
-                  },
-                  signatureSimple: undefined,
-                  docs: {
-                    description: 'Nested',
-                    guide: undefined
-                  },
-                  docsProvenance: {
-                    description: {
-                      shadowNamespace: false,
-                      _tag: 'jsdoc'
+                annotations: {}
+              }
+            ],
+            isReadonly: true,
+            annotations: {},
+            _tag: 'TupleType'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'examples',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'deprecated',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'category',
+          isReadonly: true
+        },
+        {
+          type: {
+            annotations: {},
+            _tag: 'TypeLiteral',
+            propertySignatures: [],
+            indexSignatures: [
+              {
+                type: '[Circular]',
+                isReadonly: true,
+                parameter: '[Circular]'
+              }
+            ]
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'tags',
+          isReadonly: true
+        },
+        {
+          type: {
+            typeParameters: [
+              {
+                annotations: {},
+                _tag: 'TypeLiteral',
+                propertySignatures: [
+                  {
+                    type: {
+                      typeParameters: [
+                        {
+                          annotations: '[Circular]',
+                          _tag: 'TypeLiteral',
+                          propertySignatures: [
+                            '[Circular]',
+                            {
+                              type: '[Circular]',
+                              annotations: {},
+                              isOptional: false,
+                              name: 'fileName',
+                              isReadonly: true
+                            },
+                            '[Circular]'
+                          ],
+                          indexSignatures: '[Circular]'
+                        }
+                      ],
+                      decodeUnknown: [Function (anonymous)],
+                      encodeUnknown: [Function (anonymous)],
+                      annotations: '[Circular]',
+                      _tag: 'Declaration'
                     },
-                    guide: undefined
+                    annotations: {},
+                    isOptional: false,
+                    name: 'file',
+                    isReadonly: true
                   },
-                  examples: [],
-                  deprecated: undefined,
-                  category: undefined,
-                  tags: {},
-                  sourceLocation: {
-                    file: './u.ts',
-                    line: 2
-                  },
-                  type: 'const',
-                  _tag: 'value'
-                }
-              ]
-            },
-            _tag: 'value'
-          }
-        ]
+                  {
+                    type: {
+                      annotations: {},
+                      _tag: 'NumberKeyword'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'line',
+                    isReadonly: true
+                  }
+                ],
+                indexSignatures: []
+              }
+            ],
+            decodeUnknown: [Function (anonymous)],
+            encodeUnknown: [Function (anonymous)],
+            annotations: {},
+            _tag: 'Declaration'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'sourceLocation',
+          isReadonly: true
+        },
+        {
+          type: {
+            enums: [ [ 'function', 'function' ], [ 'const', 'const' ], [ 'class', 'class' ], [ 'namespace', 'namespace' ] ],
+            annotations: {},
+            _tag: 'Enums'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'type',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                f: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Suspend'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'module',
+          isReadonly: true
+        },
+        {
+          type: {
+            literal: 'value',
+            annotations: {},
+            _tag: 'Literal'
+          },
+          annotations: {},
+          isOptional: false,
+          name: '_tag',
+          isReadonly: true
+        }
+      ],
+      indexSignatures: []
+    },
+    actual: {
+      name: 'U',
+      type: 'namespace',
+      signature: {
+        text: 'export * as U',
+        _tag: 'TypeSignatureModel'
       },
-      _tag: 'SimpleEntrypoint'
-    }
-  ],
-  metadata: {
-    extractedAt: {},
-    extractorVersion: '0.1.0'
-  }
-}
-╚══════════════════════════════════════════════════╝"
-`;
-
-exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.0.0","exports":{".":"./i.j...) 9`] = `
-"
-╔══════════════════════════════════════════════════╗ GIVEN ARGUMENTS
-{
-  files: {
-    '/package.json': '{"name":"x","version":"0.0.0","exports":{".":"./i.js"}}',
-    '/i.ts': 'export * as U from \\'./u.js\\'',
-    '/u.ts': '/** Nested */\\nexport const a = 1'
-  }
-}
-╠══════════════════════════════════════════════════╣ THEN RETURNS OBJECT
-{
-  name: 'x',
-  version: '0.0.0',
-  entrypoints: [
-    {
-      path: '.',
+      docs: {
+        description: 'Shadow',
+        guide: undefined
+      },
+      docsProvenance: {
+        description: {
+          shadowNamespace: true,
+          _tag: 'jsdoc'
+        },
+        guide: undefined
+      },
+      examples: [],
+      deprecated: undefined,
+      category: 'C',
+      tags: {},
+      sourceLocation: {
+        file: './i.ts',
+        line: 2
+      },
       module: {
-        location: './i.ts',
-        docs: undefined,
-        docsProvenance: undefined,
+        location: './u.ts',
+        docs: {
+          description: 'Nested',
+          guide: undefined,
+          home: undefined
+        },
+        docsProvenance: {
+          description: {
+            shadowNamespace: false,
+            _tag: 'jsdoc'
+          },
+          guide: undefined
+        },
         category: undefined,
         exports: [
           {
-            name: 'U',
+            name: 'a',
             signature: {
-              text: 'export * as U',
-              _tag: 'TypeSignatureModel'
+              type: '1',
+              _tag: 'ValueSignatureModel'
             },
+            signatureSimple: undefined,
             docs: {
               description: 'Nested',
               guide: undefined
@@ -560,58 +2807,2487 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
             category: undefined,
             tags: {},
             sourceLocation: {
-              file: './i.ts',
-              line: 1
+              file: './u.ts',
+              line: 2
             },
-            type: 'namespace',
-            module: {
-              location: './u.ts',
-              docs: '[Circular]',
-              docsProvenance: '[Circular]',
-              category: undefined,
-              exports: [
-                {
-                  name: 'a',
-                  signature: {
-                    type: '1',
-                    _tag: 'ValueSignatureModel'
-                  },
-                  signatureSimple: undefined,
-                  docs: {
-                    description: 'Nested',
-                    guide: undefined
-                  },
-                  docsProvenance: {
-                    description: {
-                      shadowNamespace: false,
-                      _tag: 'jsdoc'
-                    },
-                    guide: undefined
-                  },
-                  examples: [],
-                  deprecated: undefined,
-                  category: undefined,
-                  tags: {},
-                  sourceLocation: {
-                    file: './u.ts',
-                    line: 2
-                  },
-                  type: 'const',
-                  _tag: 'value'
-                }
-              ]
-            },
+            type: 'const',
             _tag: 'value'
           }
         ]
       },
-      _tag: 'SimpleEntrypoint'
-    }
-  ],
-  metadata: {
-    extractedAt: {},
-    extractorVersion: '0.1.0'
+      _tag: 'value'
+    },
+    issues: {
+      path: 'docs',
+      actual: '[Circular]',
+      issue: {
+        ast: '[Circular]',
+        actual: '[Circular]',
+        issues: [
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          },
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          }
+        ],
+        output: undefined,
+        _tag: 'Composite'
+      },
+      _tag: 'Pointer'
+    },
+    output: {
+      name: 'U',
+      signature: '[Circular]'
+    },
+    _tag: 'Composite'
+  },
+  _tag: 'ParseError'
+}
+╚══════════════════════════════════════════════════╝"
+`;
+
+exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.0.0","exports":{".":"./i.j...) 9`] = `
+"
+╔══════════════════════════════════════════════════╗ GIVEN ARGUMENTS
+{
+  files: {
+    '/package.json': '{"name":"x","version":"0.0.0","exports":{".":"./i.js"}}',
+    '/i.ts': 'export * as U from \\'./u.js\\'',
+    '/u.ts': '/** Nested */\\nexport const a = 1'
   }
+}
+╠══════════════════════════════════════════════════╣ THEN THROWS PARSEERROR
+{
+  issue: {
+    ast: {
+      annotations: {},
+      _tag: 'TypeLiteral',
+      propertySignatures: [
+        {
+          type: {
+            annotations: {},
+            _tag: 'StringKeyword'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'name',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [
+                                                            '[Circular]',
+                                                            {
+                                                              annotations: {},
+                                                              _tag: 'UndefinedKeyword'
+                                                            }
+                                                          ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'constraint',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'default',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'typeParameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'type',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          annotations: {},
+                                                          _tag: 'BooleanKeyword'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'optional',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'rest',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'defaultValue',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'description',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'parameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'returnType',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'returnDoc',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: '[Circular]',
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'throws',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'overloads',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'FunctionSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'typeName',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          typeParameters: [
+                            {
+                              annotations: '[Circular]',
+                              _tag: 'TypeLiteral',
+                              propertySignatures: [
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'typeParameters',
+                                  isReadonly: true
+                                },
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'parameters',
+                                  isReadonly: true
+                                },
+                                '[Circular]',
+                                '[Circular]',
+                                '[Circular]'
+                              ],
+                              indexSignatures: '[Circular]'
+                            }
+                          ],
+                          decodeUnknown: [Function (anonymous)],
+                          encodeUnknown: [Function (anonymous)],
+                          annotations: '[Circular]',
+                          _tag: 'Declaration'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'entryPoint',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          enums: [ [ 'chainable', 'chainable' ], [ 'terminal', 'terminal' ], [ 'transform', 'transform' ] ],
+                                          annotations: {},
+                                          _tag: 'Enums'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'category',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'transformsTo',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'chainableMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'terminalMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'transformMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'BuilderSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'ctor',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'type',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'optional',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'readonly',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'description',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'properties',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'methods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ClassSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'text',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'TypeSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'type',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ValueSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              }
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'signature',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                types: [
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'typeParameters',
+                                            isReadonly: true
+                                          },
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'parameters',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'overloads',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          '[Circular]',
+                          {
+                            type: {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'entryPoint',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'chainableMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'terminalMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'transformMethods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'typeParameters',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'parameters',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]',
+                                        '[Circular]',
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                },
+                                '[Circular]'
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            annotations: {},
+                            isOptional: true,
+                            name: 'ctor',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: '[Circular]',
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'properties',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'methods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  '[Circular]',
+                  '[Circular]'
+                ],
+                annotations: '[Circular]',
+                _tag: 'Union'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'signatureSimple',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docs',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: '[Circular]',
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'shadowNamespace',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'jsdoc',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                },
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: {},
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  {
+                                                    type: {
+                                                      elements: [],
+                                                      rest: [
+                                                        {
+                                                          type: {
+                                                            from: {
+                                                              from: '[Circular]',
+                                                              filter: [Function: filter],
+                                                              annotations: {},
+                                                              _tag: 'Refinement'
+                                                            },
+                                                            filter: [Function: filter],
+                                                            annotations: {},
+                                                            _tag: 'Refinement'
+                                                          },
+                                                          annotations: {}
+                                                        }
+                                                      ],
+                                                      isReadonly: true,
+                                                      annotations: {},
+                                                      _tag: 'TupleType'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'segments',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      typeParameters: [
+                                                        {
+                                                          annotations: {},
+                                                          _tag: 'TypeLiteral',
+                                                          propertySignatures: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'stem',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                types: [
+                                                                  {
+                                                                    from: '[Circular]',
+                                                                    filter: [Function: filter],
+                                                                    annotations: {},
+                                                                    _tag: 'Refinement'
+                                                                  },
+                                                                  {
+                                                                    literal: null,
+                                                                    annotations: {},
+                                                                    _tag: 'Literal'
+                                                                  }
+                                                                ],
+                                                                annotations: {},
+                                                                _tag: 'Union'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'extension',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                literal: 'FileName',
+                                                                annotations: {},
+                                                                _tag: 'Literal'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: '_tag',
+                                                              isReadonly: true
+                                                            }
+                                                          ],
+                                                          indexSignatures: []
+                                                        }
+                                                      ],
+                                                      decodeUnknown: [Function (anonymous)],
+                                                      encodeUnknown: [Function (anonymous)],
+                                                      annotations: {},
+                                                      _tag: 'Declaration'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      literal: 'FsPathRelFile',
+                                                      annotations: {},
+                                                      _tag: 'Literal'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: '_tag',
+                                                    isReadonly: true
+                                                  }
+                                                ],
+                                                indexSignatures: []
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: {},
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'md-file',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: {},
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                '[Circular]',
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: '[Circular]',
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  '[Circular]',
+                                                  {
+                                                    type: '[Circular]',
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  '[Circular]'
+                                                ],
+                                                indexSignatures: '[Circular]'
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: '[Circular]',
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docsProvenance',
+          isReadonly: true
+        },
+        {
+          type: {
+            elements: [],
+            rest: [
+              {
+                type: {
+                  typeParameters: [
+                    {
+                      annotations: {},
+                      _tag: 'TypeLiteral',
+                      propertySignatures: [
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'code',
+                          isReadonly: true
+                        },
+                        {
+                          type: {
+                            types: [ '[Circular]', '[Circular]' ],
+                            annotations: {},
+                            _tag: 'Union'
+                          },
+                          annotations: {},
+                          isOptional: true,
+                          name: 'title',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'twoslashEnabled',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'language',
+                          isReadonly: true
+                        }
+                      ],
+                      indexSignatures: []
+                    }
+                  ],
+                  decodeUnknown: [Function (anonymous)],
+                  encodeUnknown: [Function (anonymous)],
+                  annotations: {},
+                  _tag: 'Declaration'
+                },
+                annotations: {}
+              }
+            ],
+            isReadonly: true,
+            annotations: {},
+            _tag: 'TupleType'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'examples',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'deprecated',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'category',
+          isReadonly: true
+        },
+        {
+          type: {
+            annotations: {},
+            _tag: 'TypeLiteral',
+            propertySignatures: [],
+            indexSignatures: [
+              {
+                type: '[Circular]',
+                isReadonly: true,
+                parameter: '[Circular]'
+              }
+            ]
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'tags',
+          isReadonly: true
+        },
+        {
+          type: {
+            typeParameters: [
+              {
+                annotations: {},
+                _tag: 'TypeLiteral',
+                propertySignatures: [
+                  {
+                    type: {
+                      typeParameters: [
+                        {
+                          annotations: '[Circular]',
+                          _tag: 'TypeLiteral',
+                          propertySignatures: [
+                            '[Circular]',
+                            {
+                              type: '[Circular]',
+                              annotations: {},
+                              isOptional: false,
+                              name: 'fileName',
+                              isReadonly: true
+                            },
+                            '[Circular]'
+                          ],
+                          indexSignatures: '[Circular]'
+                        }
+                      ],
+                      decodeUnknown: [Function (anonymous)],
+                      encodeUnknown: [Function (anonymous)],
+                      annotations: '[Circular]',
+                      _tag: 'Declaration'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'file',
+                    isReadonly: true
+                  },
+                  {
+                    type: {
+                      annotations: {},
+                      _tag: 'NumberKeyword'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'line',
+                    isReadonly: true
+                  }
+                ],
+                indexSignatures: []
+              }
+            ],
+            decodeUnknown: [Function (anonymous)],
+            encodeUnknown: [Function (anonymous)],
+            annotations: {},
+            _tag: 'Declaration'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'sourceLocation',
+          isReadonly: true
+        },
+        {
+          type: {
+            enums: [ [ 'function', 'function' ], [ 'const', 'const' ], [ 'class', 'class' ], [ 'namespace', 'namespace' ] ],
+            annotations: {},
+            _tag: 'Enums'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'type',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                f: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Suspend'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'module',
+          isReadonly: true
+        },
+        {
+          type: {
+            literal: 'value',
+            annotations: {},
+            _tag: 'Literal'
+          },
+          annotations: {},
+          isOptional: false,
+          name: '_tag',
+          isReadonly: true
+        }
+      ],
+      indexSignatures: []
+    },
+    actual: {
+      name: 'U',
+      type: 'namespace',
+      signature: {
+        text: 'export * as U',
+        _tag: 'TypeSignatureModel'
+      },
+      docs: {
+        description: 'Nested',
+        guide: undefined,
+        home: undefined
+      },
+      docsProvenance: {
+        description: {
+          shadowNamespace: false,
+          _tag: 'jsdoc'
+        },
+        guide: undefined
+      },
+      examples: [],
+      deprecated: undefined,
+      category: undefined,
+      tags: {},
+      sourceLocation: {
+        file: './i.ts',
+        line: 1
+      },
+      module: {
+        location: './u.ts',
+        docs: '[Circular]',
+        docsProvenance: '[Circular]',
+        category: undefined,
+        exports: [
+          {
+            name: 'a',
+            signature: {
+              type: '1',
+              _tag: 'ValueSignatureModel'
+            },
+            signatureSimple: undefined,
+            docs: {
+              description: 'Nested',
+              guide: undefined
+            },
+            docsProvenance: {
+              description: {
+                shadowNamespace: false,
+                _tag: 'jsdoc'
+              },
+              guide: undefined
+            },
+            examples: [],
+            deprecated: undefined,
+            category: undefined,
+            tags: {},
+            sourceLocation: {
+              file: './u.ts',
+              line: 2
+            },
+            type: 'const',
+            _tag: 'value'
+          }
+        ]
+      },
+      _tag: 'value'
+    },
+    issues: {
+      path: 'docs',
+      actual: '[Circular]',
+      issue: {
+        ast: '[Circular]',
+        actual: '[Circular]',
+        issues: [
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          },
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          }
+        ],
+        output: undefined,
+        _tag: 'Composite'
+      },
+      _tag: 'Pointer'
+    },
+    output: {
+      name: 'U',
+      signature: '[Circular]'
+    },
+    _tag: 'Composite'
+  },
+  _tag: 'ParseError'
 }
 ╚══════════════════════════════════════════════════╝"
 `;
@@ -626,120 +5302,2440 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
     '/u.ts': '/** Nested */\\nexport const a = 1'
   }
 }
-╠══════════════════════════════════════════════════╣ THEN RETURNS OBJECT
+╠══════════════════════════════════════════════════╣ THEN THROWS PARSEERROR
 {
-  name: 'x',
-  version: '0.0.0',
-  entrypoints: [
-    {
-      path: '.',
+  issue: {
+    ast: {
+      annotations: {},
+      _tag: 'TypeLiteral',
+      propertySignatures: [
+        {
+          type: {
+            annotations: {},
+            _tag: 'StringKeyword'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'name',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [
+                                                            '[Circular]',
+                                                            {
+                                                              annotations: {},
+                                                              _tag: 'UndefinedKeyword'
+                                                            }
+                                                          ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'constraint',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'default',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'typeParameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'type',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          annotations: {},
+                                                          _tag: 'BooleanKeyword'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'optional',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'rest',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'defaultValue',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'description',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'parameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'returnType',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'returnDoc',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: '[Circular]',
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'throws',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'overloads',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'FunctionSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'typeName',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          typeParameters: [
+                            {
+                              annotations: '[Circular]',
+                              _tag: 'TypeLiteral',
+                              propertySignatures: [
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'typeParameters',
+                                  isReadonly: true
+                                },
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'parameters',
+                                  isReadonly: true
+                                },
+                                '[Circular]',
+                                '[Circular]',
+                                '[Circular]'
+                              ],
+                              indexSignatures: '[Circular]'
+                            }
+                          ],
+                          decodeUnknown: [Function (anonymous)],
+                          encodeUnknown: [Function (anonymous)],
+                          annotations: '[Circular]',
+                          _tag: 'Declaration'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'entryPoint',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          enums: [ [ 'chainable', 'chainable' ], [ 'terminal', 'terminal' ], [ 'transform', 'transform' ] ],
+                                          annotations: {},
+                                          _tag: 'Enums'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'category',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'transformsTo',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'chainableMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'terminalMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'transformMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'BuilderSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'ctor',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'type',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'optional',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'readonly',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'description',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'properties',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'methods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ClassSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'text',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'TypeSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'type',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ValueSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              }
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'signature',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                types: [
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'typeParameters',
+                                            isReadonly: true
+                                          },
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'parameters',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'overloads',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          '[Circular]',
+                          {
+                            type: {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'entryPoint',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'chainableMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'terminalMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'transformMethods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'typeParameters',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'parameters',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]',
+                                        '[Circular]',
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                },
+                                '[Circular]'
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            annotations: {},
+                            isOptional: true,
+                            name: 'ctor',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: '[Circular]',
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'properties',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'methods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  '[Circular]',
+                  '[Circular]'
+                ],
+                annotations: '[Circular]',
+                _tag: 'Union'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'signatureSimple',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docs',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: '[Circular]',
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'shadowNamespace',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'jsdoc',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                },
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: {},
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  {
+                                                    type: {
+                                                      elements: [],
+                                                      rest: [
+                                                        {
+                                                          type: {
+                                                            from: {
+                                                              from: '[Circular]',
+                                                              filter: [Function: filter],
+                                                              annotations: {},
+                                                              _tag: 'Refinement'
+                                                            },
+                                                            filter: [Function: filter],
+                                                            annotations: {},
+                                                            _tag: 'Refinement'
+                                                          },
+                                                          annotations: {}
+                                                        }
+                                                      ],
+                                                      isReadonly: true,
+                                                      annotations: {},
+                                                      _tag: 'TupleType'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'segments',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      typeParameters: [
+                                                        {
+                                                          annotations: {},
+                                                          _tag: 'TypeLiteral',
+                                                          propertySignatures: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'stem',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                types: [
+                                                                  {
+                                                                    from: '[Circular]',
+                                                                    filter: [Function: filter],
+                                                                    annotations: {},
+                                                                    _tag: 'Refinement'
+                                                                  },
+                                                                  {
+                                                                    literal: null,
+                                                                    annotations: {},
+                                                                    _tag: 'Literal'
+                                                                  }
+                                                                ],
+                                                                annotations: {},
+                                                                _tag: 'Union'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'extension',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                literal: 'FileName',
+                                                                annotations: {},
+                                                                _tag: 'Literal'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: '_tag',
+                                                              isReadonly: true
+                                                            }
+                                                          ],
+                                                          indexSignatures: []
+                                                        }
+                                                      ],
+                                                      decodeUnknown: [Function (anonymous)],
+                                                      encodeUnknown: [Function (anonymous)],
+                                                      annotations: {},
+                                                      _tag: 'Declaration'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      literal: 'FsPathRelFile',
+                                                      annotations: {},
+                                                      _tag: 'Literal'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: '_tag',
+                                                    isReadonly: true
+                                                  }
+                                                ],
+                                                indexSignatures: []
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: {},
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'md-file',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: {},
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                '[Circular]',
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: '[Circular]',
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  '[Circular]',
+                                                  {
+                                                    type: '[Circular]',
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  '[Circular]'
+                                                ],
+                                                indexSignatures: '[Circular]'
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: '[Circular]',
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docsProvenance',
+          isReadonly: true
+        },
+        {
+          type: {
+            elements: [],
+            rest: [
+              {
+                type: {
+                  typeParameters: [
+                    {
+                      annotations: {},
+                      _tag: 'TypeLiteral',
+                      propertySignatures: [
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'code',
+                          isReadonly: true
+                        },
+                        {
+                          type: {
+                            types: [ '[Circular]', '[Circular]' ],
+                            annotations: {},
+                            _tag: 'Union'
+                          },
+                          annotations: {},
+                          isOptional: true,
+                          name: 'title',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'twoslashEnabled',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'language',
+                          isReadonly: true
+                        }
+                      ],
+                      indexSignatures: []
+                    }
+                  ],
+                  decodeUnknown: [Function (anonymous)],
+                  encodeUnknown: [Function (anonymous)],
+                  annotations: {},
+                  _tag: 'Declaration'
+                },
+                annotations: {}
+              }
+            ],
+            isReadonly: true,
+            annotations: {},
+            _tag: 'TupleType'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'examples',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'deprecated',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'category',
+          isReadonly: true
+        },
+        {
+          type: {
+            annotations: {},
+            _tag: 'TypeLiteral',
+            propertySignatures: [],
+            indexSignatures: [
+              {
+                type: '[Circular]',
+                isReadonly: true,
+                parameter: '[Circular]'
+              }
+            ]
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'tags',
+          isReadonly: true
+        },
+        {
+          type: {
+            typeParameters: [
+              {
+                annotations: {},
+                _tag: 'TypeLiteral',
+                propertySignatures: [
+                  {
+                    type: {
+                      typeParameters: [
+                        {
+                          annotations: '[Circular]',
+                          _tag: 'TypeLiteral',
+                          propertySignatures: [
+                            '[Circular]',
+                            {
+                              type: '[Circular]',
+                              annotations: {},
+                              isOptional: false,
+                              name: 'fileName',
+                              isReadonly: true
+                            },
+                            '[Circular]'
+                          ],
+                          indexSignatures: '[Circular]'
+                        }
+                      ],
+                      decodeUnknown: [Function (anonymous)],
+                      encodeUnknown: [Function (anonymous)],
+                      annotations: '[Circular]',
+                      _tag: 'Declaration'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'file',
+                    isReadonly: true
+                  },
+                  {
+                    type: {
+                      annotations: {},
+                      _tag: 'NumberKeyword'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'line',
+                    isReadonly: true
+                  }
+                ],
+                indexSignatures: []
+              }
+            ],
+            decodeUnknown: [Function (anonymous)],
+            encodeUnknown: [Function (anonymous)],
+            annotations: {},
+            _tag: 'Declaration'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'sourceLocation',
+          isReadonly: true
+        },
+        {
+          type: {
+            enums: [ [ 'function', 'function' ], [ 'const', 'const' ], [ 'class', 'class' ], [ 'namespace', 'namespace' ] ],
+            annotations: {},
+            _tag: 'Enums'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'type',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                f: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Suspend'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'module',
+          isReadonly: true
+        },
+        {
+          type: {
+            literal: 'value',
+            annotations: {},
+            _tag: 'Literal'
+          },
+          annotations: {},
+          isOptional: false,
+          name: '_tag',
+          isReadonly: true
+        }
+      ],
+      indexSignatures: []
+    },
+    actual: {
+      name: 'U',
+      type: 'namespace',
+      signature: {
+        text: 'export * as U',
+        _tag: 'TypeSignatureModel'
+      },
+      docs: {
+        description: 'Shadow',
+        guide: undefined
+      },
+      docsProvenance: {
+        description: {
+          shadowNamespace: true,
+          _tag: 'jsdoc'
+        },
+        guide: undefined
+      },
+      examples: [],
+      deprecated: undefined,
+      category: 'C',
+      tags: {},
+      sourceLocation: {
+        file: './i.ts',
+        line: 2
+      },
       module: {
-        location: './i.ts',
-        docs: undefined,
-        docsProvenance: undefined,
+        location: './u.ts',
+        docs: {
+          description: 'Nested',
+          guide: undefined,
+          home: undefined
+        },
+        docsProvenance: {
+          description: {
+            shadowNamespace: false,
+            _tag: 'jsdoc'
+          },
+          guide: undefined
+        },
         category: undefined,
         exports: [
           {
-            name: 'U',
+            name: 'a',
             signature: {
-              text: 'export * as U',
-              _tag: 'TypeSignatureModel'
+              type: '1',
+              _tag: 'ValueSignatureModel'
             },
+            signatureSimple: undefined,
             docs: {
-              description: 'Shadow',
+              description: 'Nested',
               guide: undefined
             },
             docsProvenance: {
               description: {
-                shadowNamespace: true,
+                shadowNamespace: false,
                 _tag: 'jsdoc'
               },
               guide: undefined
             },
             examples: [],
             deprecated: undefined,
-            category: 'C',
-            tags: {},
-            sourceLocation: {
-              file: './i.ts',
-              line: 2
-            },
-            type: 'namespace',
-            module: {
-              location: './u.ts',
-              docs: {
-                description: 'Nested',
-                guide: undefined
-              },
-              docsProvenance: {
-                description: {
-                  shadowNamespace: false,
-                  _tag: 'jsdoc'
-                },
-                guide: undefined
-              },
-              category: undefined,
-              exports: [
-                {
-                  name: 'a',
-                  signature: {
-                    type: '1',
-                    _tag: 'ValueSignatureModel'
-                  },
-                  signatureSimple: undefined,
-                  docs: {
-                    description: 'Nested',
-                    guide: undefined
-                  },
-                  docsProvenance: {
-                    description: {
-                      shadowNamespace: false,
-                      _tag: 'jsdoc'
-                    },
-                    guide: undefined
-                  },
-                  examples: [],
-                  deprecated: undefined,
-                  category: undefined,
-                  tags: {},
-                  sourceLocation: {
-                    file: './u.ts',
-                    line: 2
-                  },
-                  type: 'const',
-                  _tag: 'value'
-                }
-              ]
-            },
-            _tag: 'value'
-          },
-          {
-            name: 'b',
-            signature: {
-              type: '1',
-              _tag: 'ValueSignatureModel'
-            },
-            signatureSimple: undefined,
-            examples: [],
-            deprecated: undefined,
             category: undefined,
             tags: {},
             sourceLocation: {
-              file: './i.ts',
-              line: 5
+              file: './u.ts',
+              line: 2
             },
             type: 'const',
             _tag: 'value'
           }
         ]
       },
-      _tag: 'SimpleEntrypoint'
-    }
-  ],
-  metadata: {
-    extractedAt: {},
-    extractorVersion: '0.1.0'
-  }
+      _tag: 'value'
+    },
+    issues: {
+      path: 'docs',
+      actual: '[Circular]',
+      issue: {
+        ast: '[Circular]',
+        actual: '[Circular]',
+        issues: [
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          },
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          }
+        ],
+        output: undefined,
+        _tag: 'Composite'
+      },
+      _tag: 'Pointer'
+    },
+    output: {
+      name: 'U',
+      signature: '[Circular]'
+    },
+    _tag: 'Composite'
+  },
+  _tag: 'ParseError'
 }
 ╚══════════════════════════════════════════════════╝"
 `;
@@ -942,25 +7938,2373 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
     '/u.ts': '/** N */\\nexport const a = 1'
   }
 }
-╠══════════════════════════════════════════════════╣ THEN RETURNS OBJECT
+╠══════════════════════════════════════════════════╣ THEN THROWS PARSEERROR
 {
-  name: 'x',
-  version: '0.0.0',
-  entrypoints: [
-    {
-      path: '.',
+  issue: {
+    ast: {
+      annotations: {},
+      _tag: 'TypeLiteral',
+      propertySignatures: [
+        {
+          type: {
+            annotations: {},
+            _tag: 'StringKeyword'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'name',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [
+                                                            '[Circular]',
+                                                            {
+                                                              annotations: {},
+                                                              _tag: 'UndefinedKeyword'
+                                                            }
+                                                          ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'constraint',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'default',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'typeParameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'type',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          annotations: {},
+                                                          _tag: 'BooleanKeyword'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'optional',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'rest',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'defaultValue',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'description',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'parameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'returnType',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'returnDoc',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: '[Circular]',
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'throws',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'overloads',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'FunctionSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'typeName',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          typeParameters: [
+                            {
+                              annotations: '[Circular]',
+                              _tag: 'TypeLiteral',
+                              propertySignatures: [
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'typeParameters',
+                                  isReadonly: true
+                                },
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'parameters',
+                                  isReadonly: true
+                                },
+                                '[Circular]',
+                                '[Circular]',
+                                '[Circular]'
+                              ],
+                              indexSignatures: '[Circular]'
+                            }
+                          ],
+                          decodeUnknown: [Function (anonymous)],
+                          encodeUnknown: [Function (anonymous)],
+                          annotations: '[Circular]',
+                          _tag: 'Declaration'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'entryPoint',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          enums: [ [ 'chainable', 'chainable' ], [ 'terminal', 'terminal' ], [ 'transform', 'transform' ] ],
+                                          annotations: {},
+                                          _tag: 'Enums'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'category',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'transformsTo',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'chainableMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'terminalMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'transformMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'BuilderSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'ctor',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'type',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'optional',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'readonly',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'description',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'properties',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'methods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ClassSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'text',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'TypeSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'type',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ValueSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              }
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'signature',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                types: [
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'typeParameters',
+                                            isReadonly: true
+                                          },
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'parameters',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'overloads',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          '[Circular]',
+                          {
+                            type: {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'entryPoint',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'chainableMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'terminalMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'transformMethods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'typeParameters',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'parameters',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]',
+                                        '[Circular]',
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                },
+                                '[Circular]'
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            annotations: {},
+                            isOptional: true,
+                            name: 'ctor',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: '[Circular]',
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'properties',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'methods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  '[Circular]',
+                  '[Circular]'
+                ],
+                annotations: '[Circular]',
+                _tag: 'Union'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'signatureSimple',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docs',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: '[Circular]',
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'shadowNamespace',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'jsdoc',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                },
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: {},
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  {
+                                                    type: {
+                                                      elements: [],
+                                                      rest: [
+                                                        {
+                                                          type: {
+                                                            from: {
+                                                              from: '[Circular]',
+                                                              filter: [Function: filter],
+                                                              annotations: {},
+                                                              _tag: 'Refinement'
+                                                            },
+                                                            filter: [Function: filter],
+                                                            annotations: {},
+                                                            _tag: 'Refinement'
+                                                          },
+                                                          annotations: {}
+                                                        }
+                                                      ],
+                                                      isReadonly: true,
+                                                      annotations: {},
+                                                      _tag: 'TupleType'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'segments',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      typeParameters: [
+                                                        {
+                                                          annotations: {},
+                                                          _tag: 'TypeLiteral',
+                                                          propertySignatures: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'stem',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                types: [
+                                                                  {
+                                                                    from: '[Circular]',
+                                                                    filter: [Function: filter],
+                                                                    annotations: {},
+                                                                    _tag: 'Refinement'
+                                                                  },
+                                                                  {
+                                                                    literal: null,
+                                                                    annotations: {},
+                                                                    _tag: 'Literal'
+                                                                  }
+                                                                ],
+                                                                annotations: {},
+                                                                _tag: 'Union'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'extension',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                literal: 'FileName',
+                                                                annotations: {},
+                                                                _tag: 'Literal'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: '_tag',
+                                                              isReadonly: true
+                                                            }
+                                                          ],
+                                                          indexSignatures: []
+                                                        }
+                                                      ],
+                                                      decodeUnknown: [Function (anonymous)],
+                                                      encodeUnknown: [Function (anonymous)],
+                                                      annotations: {},
+                                                      _tag: 'Declaration'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      literal: 'FsPathRelFile',
+                                                      annotations: {},
+                                                      _tag: 'Literal'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: '_tag',
+                                                    isReadonly: true
+                                                  }
+                                                ],
+                                                indexSignatures: []
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: {},
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'md-file',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: {},
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                '[Circular]',
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: '[Circular]',
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  '[Circular]',
+                                                  {
+                                                    type: '[Circular]',
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  '[Circular]'
+                                                ],
+                                                indexSignatures: '[Circular]'
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: '[Circular]',
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docsProvenance',
+          isReadonly: true
+        },
+        {
+          type: {
+            elements: [],
+            rest: [
+              {
+                type: {
+                  typeParameters: [
+                    {
+                      annotations: {},
+                      _tag: 'TypeLiteral',
+                      propertySignatures: [
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'code',
+                          isReadonly: true
+                        },
+                        {
+                          type: {
+                            types: [ '[Circular]', '[Circular]' ],
+                            annotations: {},
+                            _tag: 'Union'
+                          },
+                          annotations: {},
+                          isOptional: true,
+                          name: 'title',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'twoslashEnabled',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'language',
+                          isReadonly: true
+                        }
+                      ],
+                      indexSignatures: []
+                    }
+                  ],
+                  decodeUnknown: [Function (anonymous)],
+                  encodeUnknown: [Function (anonymous)],
+                  annotations: {},
+                  _tag: 'Declaration'
+                },
+                annotations: {}
+              }
+            ],
+            isReadonly: true,
+            annotations: {},
+            _tag: 'TupleType'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'examples',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'deprecated',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'category',
+          isReadonly: true
+        },
+        {
+          type: {
+            annotations: {},
+            _tag: 'TypeLiteral',
+            propertySignatures: [],
+            indexSignatures: [
+              {
+                type: '[Circular]',
+                isReadonly: true,
+                parameter: '[Circular]'
+              }
+            ]
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'tags',
+          isReadonly: true
+        },
+        {
+          type: {
+            typeParameters: [
+              {
+                annotations: {},
+                _tag: 'TypeLiteral',
+                propertySignatures: [
+                  {
+                    type: {
+                      typeParameters: [
+                        {
+                          annotations: '[Circular]',
+                          _tag: 'TypeLiteral',
+                          propertySignatures: [
+                            '[Circular]',
+                            {
+                              type: '[Circular]',
+                              annotations: {},
+                              isOptional: false,
+                              name: 'fileName',
+                              isReadonly: true
+                            },
+                            '[Circular]'
+                          ],
+                          indexSignatures: '[Circular]'
+                        }
+                      ],
+                      decodeUnknown: [Function (anonymous)],
+                      encodeUnknown: [Function (anonymous)],
+                      annotations: '[Circular]',
+                      _tag: 'Declaration'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'file',
+                    isReadonly: true
+                  },
+                  {
+                    type: {
+                      annotations: {},
+                      _tag: 'NumberKeyword'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'line',
+                    isReadonly: true
+                  }
+                ],
+                indexSignatures: []
+              }
+            ],
+            decodeUnknown: [Function (anonymous)],
+            encodeUnknown: [Function (anonymous)],
+            annotations: {},
+            _tag: 'Declaration'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'sourceLocation',
+          isReadonly: true
+        },
+        {
+          type: {
+            enums: [ [ 'function', 'function' ], [ 'const', 'const' ], [ 'class', 'class' ], [ 'namespace', 'namespace' ] ],
+            annotations: {},
+            _tag: 'Enums'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'type',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                f: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Suspend'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'module',
+          isReadonly: true
+        },
+        {
+          type: {
+            literal: 'value',
+            annotations: {},
+            _tag: 'Literal'
+          },
+          annotations: {},
+          isOptional: false,
+          name: '_tag',
+          isReadonly: true
+        }
+      ],
+      indexSignatures: []
+    },
+    actual: {
+      name: 'U',
+      type: 'namespace',
+      signature: {
+        text: 'export * as U',
+        _tag: 'TypeSignatureModel'
+      },
+      docs: {
+        description: 'N',
+        guide: undefined,
+        home: undefined
+      },
+      docsProvenance: {
+        description: {
+          shadowNamespace: false,
+          _tag: 'jsdoc'
+        },
+        guide: undefined
+      },
+      examples: [],
+      deprecated: undefined,
+      category: undefined,
+      tags: {},
+      sourceLocation: {
+        file: './i.ts',
+        line: 1
+      },
       module: {
-        location: './i.ts',
-        docs: undefined,
-        docsProvenance: undefined,
+        location: './u.ts',
+        docs: '[Circular]',
+        docsProvenance: '[Circular]',
         category: undefined,
         exports: [
           {
-            name: 'U',
+            name: 'a',
             signature: {
-              text: 'export * as U',
-              _tag: 'TypeSignatureModel'
+              type: '1',
+              _tag: 'ValueSignatureModel'
             },
+            signatureSimple: undefined,
             docs: {
               description: 'N',
               guide: undefined
@@ -977,58 +10321,48 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
             category: undefined,
             tags: {},
             sourceLocation: {
-              file: './i.ts',
-              line: 1
+              file: './u.ts',
+              line: 2
             },
-            type: 'namespace',
-            module: {
-              location: './u.ts',
-              docs: '[Circular]',
-              docsProvenance: '[Circular]',
-              category: undefined,
-              exports: [
-                {
-                  name: 'a',
-                  signature: {
-                    type: '1',
-                    _tag: 'ValueSignatureModel'
-                  },
-                  signatureSimple: undefined,
-                  docs: {
-                    description: 'N',
-                    guide: undefined
-                  },
-                  docsProvenance: {
-                    description: {
-                      shadowNamespace: false,
-                      _tag: 'jsdoc'
-                    },
-                    guide: undefined
-                  },
-                  examples: [],
-                  deprecated: undefined,
-                  category: undefined,
-                  tags: {},
-                  sourceLocation: {
-                    file: './u.ts',
-                    line: 2
-                  },
-                  type: 'const',
-                  _tag: 'value'
-                }
-              ]
-            },
+            type: 'const',
             _tag: 'value'
           }
         ]
       },
-      _tag: 'SimpleEntrypoint'
-    }
-  ],
-  metadata: {
-    extractedAt: {},
-    extractorVersion: '0.1.0'
-  }
+      _tag: 'value'
+    },
+    issues: {
+      path: 'docs',
+      actual: '[Circular]',
+      issue: {
+        ast: '[Circular]',
+        actual: '[Circular]',
+        issues: [
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          },
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          }
+        ],
+        output: undefined,
+        _tag: 'Composite'
+      },
+      _tag: 'Pointer'
+    },
+    output: {
+      name: 'U',
+      signature: '[Circular]'
+    },
+    _tag: 'Composite'
+  },
+  _tag: 'ParseError'
 }
 ╚══════════════════════════════════════════════════╝"
 `;
@@ -1044,25 +10378,2373 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
     '/u.ts': '/** N */\\nexport const a = 1'
   }
 }
-╠══════════════════════════════════════════════════╣ THEN RETURNS OBJECT
+╠══════════════════════════════════════════════════╣ THEN THROWS PARSEERROR
 {
-  name: 'x',
-  version: '0.0.0',
-  entrypoints: [
-    {
-      path: '.',
+  issue: {
+    ast: {
+      annotations: {},
+      _tag: 'TypeLiteral',
+      propertySignatures: [
+        {
+          type: {
+            annotations: {},
+            _tag: 'StringKeyword'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'name',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [
+                                                            '[Circular]',
+                                                            {
+                                                              annotations: {},
+                                                              _tag: 'UndefinedKeyword'
+                                                            }
+                                                          ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'constraint',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'default',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'typeParameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'type',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          annotations: {},
+                                                          _tag: 'BooleanKeyword'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'optional',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'rest',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'defaultValue',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'description',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'parameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'returnType',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'returnDoc',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: '[Circular]',
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'throws',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'overloads',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'FunctionSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'typeName',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          typeParameters: [
+                            {
+                              annotations: '[Circular]',
+                              _tag: 'TypeLiteral',
+                              propertySignatures: [
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'typeParameters',
+                                  isReadonly: true
+                                },
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'parameters',
+                                  isReadonly: true
+                                },
+                                '[Circular]',
+                                '[Circular]',
+                                '[Circular]'
+                              ],
+                              indexSignatures: '[Circular]'
+                            }
+                          ],
+                          decodeUnknown: [Function (anonymous)],
+                          encodeUnknown: [Function (anonymous)],
+                          annotations: '[Circular]',
+                          _tag: 'Declaration'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'entryPoint',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          enums: [ [ 'chainable', 'chainable' ], [ 'terminal', 'terminal' ], [ 'transform', 'transform' ] ],
+                                          annotations: {},
+                                          _tag: 'Enums'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'category',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'transformsTo',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'chainableMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'terminalMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'transformMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'BuilderSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'ctor',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'type',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'optional',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'readonly',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'description',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'properties',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'methods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ClassSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'text',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'TypeSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'type',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ValueSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              }
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'signature',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                types: [
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'typeParameters',
+                                            isReadonly: true
+                                          },
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'parameters',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'overloads',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          '[Circular]',
+                          {
+                            type: {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'entryPoint',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'chainableMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'terminalMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'transformMethods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'typeParameters',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'parameters',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]',
+                                        '[Circular]',
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                },
+                                '[Circular]'
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            annotations: {},
+                            isOptional: true,
+                            name: 'ctor',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: '[Circular]',
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'properties',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'methods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  '[Circular]',
+                  '[Circular]'
+                ],
+                annotations: '[Circular]',
+                _tag: 'Union'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'signatureSimple',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docs',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: '[Circular]',
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'shadowNamespace',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'jsdoc',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                },
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: {},
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  {
+                                                    type: {
+                                                      elements: [],
+                                                      rest: [
+                                                        {
+                                                          type: {
+                                                            from: {
+                                                              from: '[Circular]',
+                                                              filter: [Function: filter],
+                                                              annotations: {},
+                                                              _tag: 'Refinement'
+                                                            },
+                                                            filter: [Function: filter],
+                                                            annotations: {},
+                                                            _tag: 'Refinement'
+                                                          },
+                                                          annotations: {}
+                                                        }
+                                                      ],
+                                                      isReadonly: true,
+                                                      annotations: {},
+                                                      _tag: 'TupleType'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'segments',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      typeParameters: [
+                                                        {
+                                                          annotations: {},
+                                                          _tag: 'TypeLiteral',
+                                                          propertySignatures: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'stem',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                types: [
+                                                                  {
+                                                                    from: '[Circular]',
+                                                                    filter: [Function: filter],
+                                                                    annotations: {},
+                                                                    _tag: 'Refinement'
+                                                                  },
+                                                                  {
+                                                                    literal: null,
+                                                                    annotations: {},
+                                                                    _tag: 'Literal'
+                                                                  }
+                                                                ],
+                                                                annotations: {},
+                                                                _tag: 'Union'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'extension',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                literal: 'FileName',
+                                                                annotations: {},
+                                                                _tag: 'Literal'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: '_tag',
+                                                              isReadonly: true
+                                                            }
+                                                          ],
+                                                          indexSignatures: []
+                                                        }
+                                                      ],
+                                                      decodeUnknown: [Function (anonymous)],
+                                                      encodeUnknown: [Function (anonymous)],
+                                                      annotations: {},
+                                                      _tag: 'Declaration'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      literal: 'FsPathRelFile',
+                                                      annotations: {},
+                                                      _tag: 'Literal'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: '_tag',
+                                                    isReadonly: true
+                                                  }
+                                                ],
+                                                indexSignatures: []
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: {},
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'md-file',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: {},
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                '[Circular]',
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: '[Circular]',
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  '[Circular]',
+                                                  {
+                                                    type: '[Circular]',
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  '[Circular]'
+                                                ],
+                                                indexSignatures: '[Circular]'
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: '[Circular]',
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docsProvenance',
+          isReadonly: true
+        },
+        {
+          type: {
+            elements: [],
+            rest: [
+              {
+                type: {
+                  typeParameters: [
+                    {
+                      annotations: {},
+                      _tag: 'TypeLiteral',
+                      propertySignatures: [
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'code',
+                          isReadonly: true
+                        },
+                        {
+                          type: {
+                            types: [ '[Circular]', '[Circular]' ],
+                            annotations: {},
+                            _tag: 'Union'
+                          },
+                          annotations: {},
+                          isOptional: true,
+                          name: 'title',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'twoslashEnabled',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'language',
+                          isReadonly: true
+                        }
+                      ],
+                      indexSignatures: []
+                    }
+                  ],
+                  decodeUnknown: [Function (anonymous)],
+                  encodeUnknown: [Function (anonymous)],
+                  annotations: {},
+                  _tag: 'Declaration'
+                },
+                annotations: {}
+              }
+            ],
+            isReadonly: true,
+            annotations: {},
+            _tag: 'TupleType'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'examples',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'deprecated',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'category',
+          isReadonly: true
+        },
+        {
+          type: {
+            annotations: {},
+            _tag: 'TypeLiteral',
+            propertySignatures: [],
+            indexSignatures: [
+              {
+                type: '[Circular]',
+                isReadonly: true,
+                parameter: '[Circular]'
+              }
+            ]
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'tags',
+          isReadonly: true
+        },
+        {
+          type: {
+            typeParameters: [
+              {
+                annotations: {},
+                _tag: 'TypeLiteral',
+                propertySignatures: [
+                  {
+                    type: {
+                      typeParameters: [
+                        {
+                          annotations: '[Circular]',
+                          _tag: 'TypeLiteral',
+                          propertySignatures: [
+                            '[Circular]',
+                            {
+                              type: '[Circular]',
+                              annotations: {},
+                              isOptional: false,
+                              name: 'fileName',
+                              isReadonly: true
+                            },
+                            '[Circular]'
+                          ],
+                          indexSignatures: '[Circular]'
+                        }
+                      ],
+                      decodeUnknown: [Function (anonymous)],
+                      encodeUnknown: [Function (anonymous)],
+                      annotations: '[Circular]',
+                      _tag: 'Declaration'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'file',
+                    isReadonly: true
+                  },
+                  {
+                    type: {
+                      annotations: {},
+                      _tag: 'NumberKeyword'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'line',
+                    isReadonly: true
+                  }
+                ],
+                indexSignatures: []
+              }
+            ],
+            decodeUnknown: [Function (anonymous)],
+            encodeUnknown: [Function (anonymous)],
+            annotations: {},
+            _tag: 'Declaration'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'sourceLocation',
+          isReadonly: true
+        },
+        {
+          type: {
+            enums: [ [ 'function', 'function' ], [ 'const', 'const' ], [ 'class', 'class' ], [ 'namespace', 'namespace' ] ],
+            annotations: {},
+            _tag: 'Enums'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'type',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                f: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Suspend'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'module',
+          isReadonly: true
+        },
+        {
+          type: {
+            literal: 'value',
+            annotations: {},
+            _tag: 'Literal'
+          },
+          annotations: {},
+          isOptional: false,
+          name: '_tag',
+          isReadonly: true
+        }
+      ],
+      indexSignatures: []
+    },
+    actual: {
+      name: 'U',
+      type: 'namespace',
+      signature: {
+        text: 'export * as U',
+        _tag: 'TypeSignatureModel'
+      },
+      docs: {
+        description: 'N',
+        guide: undefined,
+        home: undefined
+      },
+      docsProvenance: {
+        description: {
+          shadowNamespace: false,
+          _tag: 'jsdoc'
+        },
+        guide: undefined
+      },
+      examples: [],
+      deprecated: undefined,
+      category: undefined,
+      tags: {},
+      sourceLocation: {
+        file: './i.ts',
+        line: 1
+      },
       module: {
-        location: './i.ts',
-        docs: undefined,
-        docsProvenance: undefined,
+        location: './u.ts',
+        docs: '[Circular]',
+        docsProvenance: '[Circular]',
         category: undefined,
         exports: [
           {
-            name: 'U',
+            name: 'a',
             signature: {
-              text: 'export * as U',
-              _tag: 'TypeSignatureModel'
+              type: '1',
+              _tag: 'ValueSignatureModel'
             },
+            signatureSimple: undefined,
             docs: {
               description: 'N',
               guide: undefined
@@ -1079,62 +12761,7 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
             category: undefined,
             tags: {},
             sourceLocation: {
-              file: './i.ts',
-              line: 1
-            },
-            type: 'namespace',
-            module: {
-              location: './u.ts',
-              docs: '[Circular]',
-              docsProvenance: '[Circular]',
-              category: undefined,
-              exports: [
-                {
-                  name: 'a',
-                  signature: {
-                    type: '1',
-                    _tag: 'ValueSignatureModel'
-                  },
-                  signatureSimple: undefined,
-                  docs: {
-                    description: 'N',
-                    guide: undefined
-                  },
-                  docsProvenance: {
-                    description: {
-                      shadowNamespace: false,
-                      _tag: 'jsdoc'
-                    },
-                    guide: undefined
-                  },
-                  examples: [],
-                  deprecated: undefined,
-                  category: undefined,
-                  tags: {},
-                  sourceLocation: {
-                    file: './u.ts',
-                    line: 2
-                  },
-                  type: 'const',
-                  _tag: 'value'
-                }
-              ]
-            },
-            _tag: 'value'
-          },
-          {
-            name: 'b',
-            signature: {
-              type: '2',
-              _tag: 'ValueSignatureModel'
-            },
-            signatureSimple: undefined,
-            examples: [],
-            deprecated: undefined,
-            category: undefined,
-            tags: {},
-            sourceLocation: {
-              file: './i.ts',
+              file: './u.ts',
               line: 2
             },
             type: 'const',
@@ -1142,13 +12769,40 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
           }
         ]
       },
-      _tag: 'SimpleEntrypoint'
-    }
-  ],
-  metadata: {
-    extractedAt: {},
-    extractorVersion: '0.1.0'
-  }
+      _tag: 'value'
+    },
+    issues: {
+      path: 'docs',
+      actual: '[Circular]',
+      issue: {
+        ast: '[Circular]',
+        actual: '[Circular]',
+        issues: [
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          },
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          }
+        ],
+        output: undefined,
+        _tag: 'Composite'
+      },
+      _tag: 'Pointer'
+    },
+    output: {
+      name: 'U',
+      signature: '[Circular]'
+    },
+    _tag: 'Composite'
+  },
+  _tag: 'ParseError'
 }
 ╚══════════════════════════════════════════════════╝"
 `;
@@ -1164,102 +12818,2440 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
     '/u.ts': '/** N */\\nexport const a = 1'
   }
 }
-╠══════════════════════════════════════════════════╣ THEN RETURNS OBJECT
+╠══════════════════════════════════════════════════╣ THEN THROWS PARSEERROR
 {
-  name: 'x',
-  version: '0.0.0',
-  entrypoints: [
-    {
-      path: '.',
+  issue: {
+    ast: {
+      annotations: {},
+      _tag: 'TypeLiteral',
+      propertySignatures: [
+        {
+          type: {
+            annotations: {},
+            _tag: 'StringKeyword'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'name',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [
+                                                            '[Circular]',
+                                                            {
+                                                              annotations: {},
+                                                              _tag: 'UndefinedKeyword'
+                                                            }
+                                                          ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'constraint',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'default',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'typeParameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: {},
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'name',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'type',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          annotations: {},
+                                                          _tag: 'BooleanKeyword'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'optional',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: '[Circular]',
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'rest',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'defaultValue',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          types: [ '[Circular]', '[Circular]' ],
+                                                          annotations: {},
+                                                          _tag: 'Union'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: true,
+                                                        name: 'description',
+                                                        isReadonly: true
+                                                      }
+                                                    ],
+                                                    indexSignatures: []
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: {},
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'parameters',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'returnType',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'returnDoc',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: '[Circular]',
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'throws',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'overloads',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'FunctionSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'typeName',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          typeParameters: [
+                            {
+                              annotations: '[Circular]',
+                              _tag: 'TypeLiteral',
+                              propertySignatures: [
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'typeParameters',
+                                  isReadonly: true
+                                },
+                                {
+                                  type: {
+                                    elements: '[Circular]',
+                                    rest: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {}
+                                      }
+                                    ],
+                                    isReadonly: true,
+                                    annotations: '[Circular]',
+                                    _tag: 'TupleType'
+                                  },
+                                  annotations: {},
+                                  isOptional: false,
+                                  name: 'parameters',
+                                  isReadonly: true
+                                },
+                                '[Circular]',
+                                '[Circular]',
+                                '[Circular]'
+                              ],
+                              indexSignatures: '[Circular]'
+                            }
+                          ],
+                          decodeUnknown: [Function (anonymous)],
+                          encodeUnknown: [Function (anonymous)],
+                          annotations: '[Circular]',
+                          _tag: 'Declaration'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'entryPoint',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          enums: [ [ 'chainable', 'chainable' ], [ 'terminal', 'terminal' ], [ 'transform', 'transform' ] ],
+                                          annotations: {},
+                                          _tag: 'Enums'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'category',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'transformsTo',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'chainableMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'terminalMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: '[Circular]',
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      '[Circular]',
+                                      {
+                                        type: {
+                                          elements: '[Circular]',
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: '[Circular]',
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      '[Circular]',
+                                      '[Circular]'
+                                    ],
+                                    indexSignatures: '[Circular]'
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: '[Circular]',
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'transformMethods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'BuilderSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'ctor',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'type',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'optional',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'readonly',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          types: [ '[Circular]', '[Circular]' ],
+                                          annotations: {},
+                                          _tag: 'Union'
+                                        },
+                                        annotations: {},
+                                        isOptional: true,
+                                        name: 'description',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'properties',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          elements: [],
+                          rest: [
+                            {
+                              type: {
+                                typeParameters: [
+                                  {
+                                    annotations: {},
+                                    _tag: 'TypeLiteral',
+                                    propertySignatures: [
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'name',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: {
+                                          elements: [],
+                                          rest: [
+                                            {
+                                              type: {
+                                                typeParameters: [
+                                                  {
+                                                    annotations: '[Circular]',
+                                                    _tag: 'TypeLiteral',
+                                                    propertySignatures: [
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'typeParameters',
+                                                        isReadonly: true
+                                                      },
+                                                      {
+                                                        type: {
+                                                          elements: '[Circular]',
+                                                          rest: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {}
+                                                            }
+                                                          ],
+                                                          isReadonly: true,
+                                                          annotations: '[Circular]',
+                                                          _tag: 'TupleType'
+                                                        },
+                                                        annotations: {},
+                                                        isOptional: false,
+                                                        name: 'parameters',
+                                                        isReadonly: true
+                                                      },
+                                                      '[Circular]',
+                                                      '[Circular]',
+                                                      '[Circular]'
+                                                    ],
+                                                    indexSignatures: '[Circular]'
+                                                  }
+                                                ],
+                                                decodeUnknown: [Function (anonymous)],
+                                                encodeUnknown: [Function (anonymous)],
+                                                annotations: '[Circular]',
+                                                _tag: 'Declaration'
+                                              },
+                                              annotations: {}
+                                            }
+                                          ],
+                                          isReadonly: true,
+                                          annotations: {},
+                                          _tag: 'TupleType'
+                                        },
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'overloads',
+                                        isReadonly: true
+                                      },
+                                      {
+                                        type: '[Circular]',
+                                        annotations: {},
+                                        isOptional: false,
+                                        name: 'static',
+                                        isReadonly: true
+                                      }
+                                    ],
+                                    indexSignatures: []
+                                  }
+                                ],
+                                decodeUnknown: [Function (anonymous)],
+                                encodeUnknown: [Function (anonymous)],
+                                annotations: {},
+                                _tag: 'Declaration'
+                              },
+                              annotations: {}
+                            }
+                          ],
+                          isReadonly: true,
+                          annotations: {},
+                          _tag: 'TupleType'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: 'methods',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ClassSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'text',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'TypeSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: '[Circular]',
+                        annotations: {},
+                        isOptional: false,
+                        name: 'type',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          literal: 'ValueSignatureModel',
+                          annotations: {},
+                          _tag: 'Literal'
+                        },
+                        annotations: {},
+                        isOptional: false,
+                        name: '_tag',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              }
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'signature',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                types: [
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'typeParameters',
+                                            isReadonly: true
+                                          },
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: '[Circular]',
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'parameters',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'overloads',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          '[Circular]',
+                          {
+                            type: {
+                              typeParameters: [
+                                {
+                                  annotations: '[Circular]',
+                                  _tag: 'TypeLiteral',
+                                  propertySignatures: [
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'typeParameters',
+                                      isReadonly: true
+                                    },
+                                    {
+                                      type: {
+                                        elements: '[Circular]',
+                                        rest: [
+                                          {
+                                            type: '[Circular]',
+                                            annotations: {}
+                                          }
+                                        ],
+                                        isReadonly: true,
+                                        annotations: '[Circular]',
+                                        _tag: 'TupleType'
+                                      },
+                                      annotations: {},
+                                      isOptional: false,
+                                      name: 'parameters',
+                                      isReadonly: true
+                                    },
+                                    '[Circular]',
+                                    '[Circular]',
+                                    '[Circular]'
+                                  ],
+                                  indexSignatures: '[Circular]'
+                                }
+                              ],
+                              decodeUnknown: [Function (anonymous)],
+                              encodeUnknown: [Function (anonymous)],
+                              annotations: '[Circular]',
+                              _tag: 'Declaration'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'entryPoint',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'chainableMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'terminalMethods',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]',
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'transformMethods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  {
+                    typeParameters: [
+                      {
+                        annotations: '[Circular]',
+                        _tag: 'TypeLiteral',
+                        propertySignatures: [
+                          {
+                            type: {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'typeParameters',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            elements: '[Circular]',
+                                            rest: [
+                                              {
+                                                type: '[Circular]',
+                                                annotations: {}
+                                              }
+                                            ],
+                                            isReadonly: true,
+                                            annotations: '[Circular]',
+                                            _tag: 'TupleType'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'parameters',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]',
+                                        '[Circular]',
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                },
+                                '[Circular]'
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            annotations: {},
+                            isOptional: true,
+                            name: 'ctor',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: '[Circular]',
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'properties',
+                            isReadonly: true
+                          },
+                          {
+                            type: {
+                              elements: '[Circular]',
+                              rest: [
+                                {
+                                  type: {
+                                    typeParameters: [
+                                      {
+                                        annotations: '[Circular]',
+                                        _tag: 'TypeLiteral',
+                                        propertySignatures: [
+                                          '[Circular]',
+                                          {
+                                            type: {
+                                              elements: '[Circular]',
+                                              rest: [
+                                                {
+                                                  type: {
+                                                    typeParameters: [
+                                                      {
+                                                        annotations: '[Circular]',
+                                                        _tag: 'TypeLiteral',
+                                                        propertySignatures: [
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'typeParameters',
+                                                            isReadonly: true
+                                                          },
+                                                          {
+                                                            type: {
+                                                              elements: '[Circular]',
+                                                              rest: [
+                                                                {
+                                                                  type: '[Circular]',
+                                                                  annotations: {}
+                                                                }
+                                                              ],
+                                                              isReadonly: true,
+                                                              annotations: '[Circular]',
+                                                              _tag: 'TupleType'
+                                                            },
+                                                            annotations: {},
+                                                            isOptional: false,
+                                                            name: 'parameters',
+                                                            isReadonly: true
+                                                          },
+                                                          '[Circular]',
+                                                          '[Circular]',
+                                                          '[Circular]'
+                                                        ],
+                                                        indexSignatures: '[Circular]'
+                                                      }
+                                                    ],
+                                                    decodeUnknown: [Function (anonymous)],
+                                                    encodeUnknown: [Function (anonymous)],
+                                                    annotations: '[Circular]',
+                                                    _tag: 'Declaration'
+                                                  },
+                                                  annotations: {}
+                                                }
+                                              ],
+                                              isReadonly: true,
+                                              annotations: '[Circular]',
+                                              _tag: 'TupleType'
+                                            },
+                                            annotations: {},
+                                            isOptional: false,
+                                            name: 'overloads',
+                                            isReadonly: true
+                                          },
+                                          '[Circular]'
+                                        ],
+                                        indexSignatures: '[Circular]'
+                                      }
+                                    ],
+                                    decodeUnknown: [Function (anonymous)],
+                                    encodeUnknown: [Function (anonymous)],
+                                    annotations: '[Circular]',
+                                    _tag: 'Declaration'
+                                  },
+                                  annotations: {}
+                                }
+                              ],
+                              isReadonly: true,
+                              annotations: '[Circular]',
+                              _tag: 'TupleType'
+                            },
+                            annotations: {},
+                            isOptional: false,
+                            name: 'methods',
+                            isReadonly: true
+                          },
+                          '[Circular]'
+                        ],
+                        indexSignatures: '[Circular]'
+                      }
+                    ],
+                    decodeUnknown: [Function (anonymous)],
+                    encodeUnknown: [Function (anonymous)],
+                    annotations: '[Circular]',
+                    _tag: 'Declaration'
+                  },
+                  '[Circular]',
+                  '[Circular]'
+                ],
+                annotations: '[Circular]',
+                _tag: 'Union'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'signatureSimple',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [ '[Circular]', '[Circular]' ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docs',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                typeParameters: [
+                  {
+                    annotations: {},
+                    _tag: 'TypeLiteral',
+                    propertySignatures: [
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: '[Circular]',
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'shadowNamespace',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'jsdoc',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                },
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: {},
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: {},
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  {
+                                                    type: {
+                                                      elements: [],
+                                                      rest: [
+                                                        {
+                                                          type: {
+                                                            from: {
+                                                              from: '[Circular]',
+                                                              filter: [Function: filter],
+                                                              annotations: {},
+                                                              _tag: 'Refinement'
+                                                            },
+                                                            filter: [Function: filter],
+                                                            annotations: {},
+                                                            _tag: 'Refinement'
+                                                          },
+                                                          annotations: {}
+                                                        }
+                                                      ],
+                                                      isReadonly: true,
+                                                      annotations: {},
+                                                      _tag: 'TupleType'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'segments',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      typeParameters: [
+                                                        {
+                                                          annotations: {},
+                                                          _tag: 'TypeLiteral',
+                                                          propertySignatures: [
+                                                            {
+                                                              type: '[Circular]',
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'stem',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                types: [
+                                                                  {
+                                                                    from: '[Circular]',
+                                                                    filter: [Function: filter],
+                                                                    annotations: {},
+                                                                    _tag: 'Refinement'
+                                                                  },
+                                                                  {
+                                                                    literal: null,
+                                                                    annotations: {},
+                                                                    _tag: 'Literal'
+                                                                  }
+                                                                ],
+                                                                annotations: {},
+                                                                _tag: 'Union'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: 'extension',
+                                                              isReadonly: true
+                                                            },
+                                                            {
+                                                              type: {
+                                                                literal: 'FileName',
+                                                                annotations: {},
+                                                                _tag: 'Literal'
+                                                              },
+                                                              annotations: {},
+                                                              isOptional: false,
+                                                              name: '_tag',
+                                                              isReadonly: true
+                                                            }
+                                                          ],
+                                                          indexSignatures: []
+                                                        }
+                                                      ],
+                                                      decodeUnknown: [Function (anonymous)],
+                                                      encodeUnknown: [Function (anonymous)],
+                                                      annotations: {},
+                                                      _tag: 'Declaration'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  {
+                                                    type: {
+                                                      literal: 'FsPathRelFile',
+                                                      annotations: {},
+                                                      _tag: 'Literal'
+                                                    },
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: '_tag',
+                                                    isReadonly: true
+                                                  }
+                                                ],
+                                                indexSignatures: []
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: {},
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        {
+                                          type: {
+                                            literal: 'md-file',
+                                            annotations: {},
+                                            _tag: 'Literal'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: '_tag',
+                                          isReadonly: true
+                                        }
+                                      ],
+                                      indexSignatures: []
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: {},
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: {},
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'description',
+                        isReadonly: true
+                      },
+                      {
+                        type: {
+                          types: [
+                            {
+                              types: [
+                                '[Circular]',
+                                {
+                                  typeParameters: [
+                                    {
+                                      annotations: '[Circular]',
+                                      _tag: 'TypeLiteral',
+                                      propertySignatures: [
+                                        {
+                                          type: {
+                                            typeParameters: [
+                                              {
+                                                annotations: '[Circular]',
+                                                _tag: 'TypeLiteral',
+                                                propertySignatures: [
+                                                  '[Circular]',
+                                                  {
+                                                    type: '[Circular]',
+                                                    annotations: {},
+                                                    isOptional: false,
+                                                    name: 'fileName',
+                                                    isReadonly: true
+                                                  },
+                                                  '[Circular]'
+                                                ],
+                                                indexSignatures: '[Circular]'
+                                              }
+                                            ],
+                                            decodeUnknown: [Function (anonymous)],
+                                            encodeUnknown: [Function (anonymous)],
+                                            annotations: '[Circular]',
+                                            _tag: 'Declaration'
+                                          },
+                                          annotations: {},
+                                          isOptional: false,
+                                          name: 'filePath',
+                                          isReadonly: true
+                                        },
+                                        '[Circular]'
+                                      ],
+                                      indexSignatures: '[Circular]'
+                                    }
+                                  ],
+                                  decodeUnknown: [Function (anonymous)],
+                                  encodeUnknown: [Function (anonymous)],
+                                  annotations: '[Circular]',
+                                  _tag: 'Declaration'
+                                }
+                              ],
+                              annotations: '[Circular]',
+                              _tag: 'Union'
+                            },
+                            '[Circular]'
+                          ],
+                          annotations: {},
+                          _tag: 'Union'
+                        },
+                        annotations: {},
+                        isOptional: true,
+                        name: 'guide',
+                        isReadonly: true
+                      }
+                    ],
+                    indexSignatures: []
+                  }
+                ],
+                decodeUnknown: [Function (anonymous)],
+                encodeUnknown: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Declaration'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'docsProvenance',
+          isReadonly: true
+        },
+        {
+          type: {
+            elements: [],
+            rest: [
+              {
+                type: {
+                  typeParameters: [
+                    {
+                      annotations: {},
+                      _tag: 'TypeLiteral',
+                      propertySignatures: [
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'code',
+                          isReadonly: true
+                        },
+                        {
+                          type: {
+                            types: [ '[Circular]', '[Circular]' ],
+                            annotations: {},
+                            _tag: 'Union'
+                          },
+                          annotations: {},
+                          isOptional: true,
+                          name: 'title',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'twoslashEnabled',
+                          isReadonly: true
+                        },
+                        {
+                          type: '[Circular]',
+                          annotations: {},
+                          isOptional: false,
+                          name: 'language',
+                          isReadonly: true
+                        }
+                      ],
+                      indexSignatures: []
+                    }
+                  ],
+                  decodeUnknown: [Function (anonymous)],
+                  encodeUnknown: [Function (anonymous)],
+                  annotations: {},
+                  _tag: 'Declaration'
+                },
+                annotations: {}
+              }
+            ],
+            isReadonly: true,
+            annotations: {},
+            _tag: 'TupleType'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'examples',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'deprecated',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [ '[Circular]', '[Circular]' ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'category',
+          isReadonly: true
+        },
+        {
+          type: {
+            annotations: {},
+            _tag: 'TypeLiteral',
+            propertySignatures: [],
+            indexSignatures: [
+              {
+                type: '[Circular]',
+                isReadonly: true,
+                parameter: '[Circular]'
+              }
+            ]
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'tags',
+          isReadonly: true
+        },
+        {
+          type: {
+            typeParameters: [
+              {
+                annotations: {},
+                _tag: 'TypeLiteral',
+                propertySignatures: [
+                  {
+                    type: {
+                      typeParameters: [
+                        {
+                          annotations: '[Circular]',
+                          _tag: 'TypeLiteral',
+                          propertySignatures: [
+                            '[Circular]',
+                            {
+                              type: '[Circular]',
+                              annotations: {},
+                              isOptional: false,
+                              name: 'fileName',
+                              isReadonly: true
+                            },
+                            '[Circular]'
+                          ],
+                          indexSignatures: '[Circular]'
+                        }
+                      ],
+                      decodeUnknown: [Function (anonymous)],
+                      encodeUnknown: [Function (anonymous)],
+                      annotations: '[Circular]',
+                      _tag: 'Declaration'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'file',
+                    isReadonly: true
+                  },
+                  {
+                    type: {
+                      annotations: {},
+                      _tag: 'NumberKeyword'
+                    },
+                    annotations: {},
+                    isOptional: false,
+                    name: 'line',
+                    isReadonly: true
+                  }
+                ],
+                indexSignatures: []
+              }
+            ],
+            decodeUnknown: [Function (anonymous)],
+            encodeUnknown: [Function (anonymous)],
+            annotations: {},
+            _tag: 'Declaration'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'sourceLocation',
+          isReadonly: true
+        },
+        {
+          type: {
+            enums: [ [ 'function', 'function' ], [ 'const', 'const' ], [ 'class', 'class' ], [ 'namespace', 'namespace' ] ],
+            annotations: {},
+            _tag: 'Enums'
+          },
+          annotations: {},
+          isOptional: false,
+          name: 'type',
+          isReadonly: true
+        },
+        {
+          type: {
+            types: [
+              {
+                f: [Function (anonymous)],
+                annotations: {},
+                _tag: 'Suspend'
+              },
+              '[Circular]'
+            ],
+            annotations: {},
+            _tag: 'Union'
+          },
+          annotations: {},
+          isOptional: true,
+          name: 'module',
+          isReadonly: true
+        },
+        {
+          type: {
+            literal: 'value',
+            annotations: {},
+            _tag: 'Literal'
+          },
+          annotations: {},
+          isOptional: false,
+          name: '_tag',
+          isReadonly: true
+        }
+      ],
+      indexSignatures: []
+    },
+    actual: {
+      name: 'U',
+      type: 'namespace',
+      signature: {
+        text: 'export * as U',
+        _tag: 'TypeSignatureModel'
+      },
+      docs: {
+        description: 'S',
+        guide: undefined
+      },
+      docsProvenance: {
+        description: {
+          shadowNamespace: true,
+          _tag: 'jsdoc'
+        },
+        guide: undefined
+      },
+      examples: [],
+      deprecated: undefined,
+      category: 'C',
+      tags: {},
+      sourceLocation: {
+        file: './i.ts',
+        line: 2
+      },
       module: {
-        location: './i.ts',
-        docs: undefined,
-        docsProvenance: undefined,
+        location: './u.ts',
+        docs: {
+          description: 'N',
+          guide: undefined,
+          home: undefined
+        },
+        docsProvenance: {
+          description: {
+            shadowNamespace: false,
+            _tag: 'jsdoc'
+          },
+          guide: undefined
+        },
         category: undefined,
         exports: [
           {
-            name: 'U',
+            name: 'a',
             signature: {
-              text: 'export * as U',
-              _tag: 'TypeSignatureModel'
+              type: '1',
+              _tag: 'ValueSignatureModel'
             },
+            signatureSimple: undefined,
             docs: {
-              description: 'S',
+              description: 'N',
               guide: undefined
             },
             docsProvenance: {
               description: {
-                shadowNamespace: true,
+                shadowNamespace: false,
                 _tag: 'jsdoc'
               },
               guide: undefined
             },
             examples: [],
             deprecated: undefined,
-            category: 'C',
+            category: undefined,
             tags: {},
             sourceLocation: {
-              file: './i.ts',
+              file: './u.ts',
               line: 2
             },
-            type: 'namespace',
-            module: {
-              location: './u.ts',
-              docs: {
-                description: 'N',
-                guide: undefined
-              },
-              docsProvenance: {
-                description: {
-                  shadowNamespace: false,
-                  _tag: 'jsdoc'
-                },
-                guide: undefined
-              },
-              category: undefined,
-              exports: [
-                {
-                  name: 'a',
-                  signature: {
-                    type: '1',
-                    _tag: 'ValueSignatureModel'
-                  },
-                  signatureSimple: undefined,
-                  docs: {
-                    description: 'N',
-                    guide: undefined
-                  },
-                  docsProvenance: {
-                    description: {
-                      shadowNamespace: false,
-                      _tag: 'jsdoc'
-                    },
-                    guide: undefined
-                  },
-                  examples: [],
-                  deprecated: undefined,
-                  category: undefined,
-                  tags: {},
-                  sourceLocation: {
-                    file: './u.ts',
-                    line: 2
-                  },
-                  type: 'const',
-                  _tag: 'value'
-                }
-              ]
-            },
+            type: 'const',
             _tag: 'value'
           }
         ]
       },
-      _tag: 'SimpleEntrypoint'
-    }
-  ],
-  metadata: {
-    extractedAt: {},
-    extractorVersion: '0.1.0'
-  }
+      _tag: 'value'
+    },
+    issues: {
+      path: 'docs',
+      actual: '[Circular]',
+      issue: {
+        ast: '[Circular]',
+        actual: '[Circular]',
+        issues: [
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          },
+          {
+            ast: '[Circular]',
+            actual: '[Circular]',
+            message: undefined,
+            _tag: 'Type'
+          }
+        ],
+        output: undefined,
+        _tag: 'Composite'
+      },
+      _tag: 'Pointer'
+    },
+    output: {
+      name: 'U',
+      signature: '[Circular]'
+    },
+    _tag: 'Composite'
+  },
+  _tag: 'ParseError'
 }
 ╚══════════════════════════════════════════════════╝"
 `;
@@ -1284,7 +15276,8 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
         location: './i.ts',
         docs: {
           description: 'foo \`bar\`',
-          guide: undefined
+          guide: undefined,
+          home: undefined
         },
         docsProvenance: {
           description: {
@@ -1512,7 +15505,8 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
         location: './i.ts',
         docs: {
           description: 'String utilities',
-          guide: undefined
+          guide: undefined,
+          home: undefined
         },
         docsProvenance: {
           description: {
@@ -1557,7 +15551,8 @@ exports[`extractFromFiles({ files: { '/package.json': '{"name":"x","version":"0.
         location: './i.ts',
         docs: {
           description: 'Export doc',
-          guide: undefined
+          guide: undefined,
+          home: undefined
         },
         docsProvenance: {
           description: {


### PR DESCRIPTION
## Summary

Add opt-in landing page support for namespace exports using `*.home.md` files. This feature allows library authors to create hero-style landing pages with custom highlights and structured content, rendered using VitePress's built-in `layout: home`.

## Changes

### Core Implementation
- ✅ Add markdown dependencies (unified, remark-parse, remark-stringify, remark-gfm, mdast-util-to-string)
- ✅ Create markdown AST parsing utilities in `extractor/markdown.ts`
- ✅ Add schema classes: `Feature`, `BodySection`, `Home`, `ModuleDocs`
- ✅ Migrate `Module.docs` from `Docs` to `ModuleDocs` to support `home` field
- ✅ Implement home page discovery (`findNamespaceHomePage*` functions)
- ✅ Create home page parser with strict validation (`extractor/home-page.ts`)
- ✅ Integrate home page extraction into module extraction flow
- ✅ Update VitePress adaptor to generate landing pages with `layout: home`

### File Naming Convention
- Any `*.home.md` file (e.g., `_.home.md`, `index.home.md`, `union.home.md`)
- First file alphabetically if multiple found

### Markdown Structure
Supports three top-level sections (at least one required):

**# Hero** - Hero banner section
- `## Name` - Hero title (optional, defaults to module name)
- `## Text` - Hero description (optional)
- `## Tagline` - Hero tagline (optional)

**# Highlights** - Feature cards
- Each `## Heading` becomes a feature card with title and body

**# Body** - Main content sections
- `## Exports` - Special marker to insert auto-generated exports
- `## Any Other Heading` - Custom content sections

### Example

\`\`\`markdown
# Hero

## Name
Math Utilities

## Text
Mathematical operations and functions.

## Tagline
Comprehensive math toolkit

# Highlights

## Addition
Add numbers together with high precision.

## Subtraction
Subtract values with support for negative results.

# Body

## Getting Started

Import the Math namespace:

\`\`\`typescript
import { Math } from '@wollybeard/kit'
\`\`\`

## Exports

## Advanced Usage

Complex mathematical operations...
\`\`\`

## Testing

### New Tests Added
- ✅ **15 unit tests** for home page parser (`home-page.test.ts`)
  - Valid home pages (all sections, minimal, hero only, body only, etc.)
  - Validation errors (unknown headings, invalid subsections, duplicates)
  - Edge cases (empty sections, markdown preservation, multiple exports)
- ✅ **2 integration tests** for VitePress adaptor (`vitepress.test.ts`)
  - Schema structure validation
  - Landing page detection

### Test Results
- ✅ All 17 new tests passing
- ✅ Type checking passes
- ⚠️ 6 existing extractor snapshot tests need regeneration (schema migration from `Docs` → `ModuleDocs`)

## Breaking Changes

**Schema Migration**: `Module.docs` type changed from `Docs | undefined` to `ModuleDocs | undefined`

- `ModuleDocs` extends `Docs` with additional `home?: Home` field
- Existing code using `Module.docs.description` or `Module.docs.guide` continues to work
- Only affects code that directly instantiates `Module` or `Docs` classes
- Existing snapshot tests need updating (handled separately)

## Design Decisions

1. **Optional Fields**: Made `hero`, `highlights`, and `body` all optional in schema - validation happens during parsing
2. **No Provenance for Home**: Home can ONLY come from `*.home.md` files, so no ambiguity to track
3. **Feature.body vs Feature.content**: Chose `body` for consistency with `BodySection.body`
4. **Separate from description/guide**: Home is for landing pages, description/guide remain for standard docs

## Files Changed

- **New Files**:
  - `src/utils/paka/extractor/markdown.ts` - Markdown AST utilities
  - `src/utils/paka/extractor/home-page.ts` - Home page parser
  - `src/utils/paka/extractor/home-page.test.ts` - Parser tests
  - `docs/issues/2025-10-30-namespace-landing-pages/what.md` - Spec
  - `docs/issues/2025-10-30-namespace-landing-pages/how.md` - Implementation plan

- **Modified Files**:
  - `package.json`, `pnpm-lock.yaml` - Dependencies
  - `src/utils/paka/schema.ts` - Schema classes
  - `src/utils/paka/extractor/nodes/module.ts` - Home page integration
  - `src/utils/paka/extractor/extract.ts` - Schema migration
  - `src/utils/paka/adaptors/vitepress.ts` - Landing page generation
  - `src/utils/paka/adaptors/vitepress.test.ts` - Integration tests

## Future Enhancements

- [ ] Monorepo-level landing pages
- [ ] Example landing pages in Kit documentation
- [ ] Screenshot examples in README

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jasonkuhrt/kitz/77)
<!-- Reviewable:end -->
