### PR TITLE
fix: make ConfigManager browser-compatible

### DIFF
--- a/src/utils/config-manager/ConfigManager.ts
+++ b/src/utils/config-manager/ConfigManager.ts
@@ -2,7 +2,7 @@ import { Obj } from '#obj'
 import type { Ts } from '#ts'
 import type { Undefined } from '#undefined'
 import type { IsUnknown, PartialDeep } from 'type-fest'
-import { isDate } from 'util/types'
+import { isDate } from '../value/value.js'
 import { type GuardedType, isAnyFunction, type Objekt } from './_prelude.js'
 
 // dprint-ignore


### PR DESCRIPTION
## Summary

Makes ConfigManager browser-compatible by replacing Node.js-specific `util/types` import with a browser-safe alternative.

## Changes

- **Before:** `import { isDate } from 'util/types'`
- **After:** `import { isDate } from '../value/value.js'`

## Why

`util/types` is a Node.js core module that is not available in browser environments. When bundlers like Webpack (used by Next.js) try to bundle code that imports ConfigManager, they fail with:

```
Module not found: Can't resolve 'util/types'
```

The `value.isDate()` implementation uses `instanceof Date`, which:
- ✅ Is functionally equivalent for ConfigManager's use case
- ✅ Works in both Node.js and browser environments
- ✅ Is already present in the kit codebase

## Testing

- ✅ All unit tests pass (including ConfigManager.test.ts)
- ✅ Type checking passes

## Related

Fixes graffle-js/graffle#1460 - Next.js builds were failing when importing Graffle due to this Node.js-only dependency.