### PR TITLE
fix: remove circular dependency between obj and rec modules

### DIFF
--- a/src/domains/obj/merge.ts
+++ b/src/domains/obj/merge.ts
@@ -1,6 +1,5 @@
 import { Arr } from '#arr'
 import { Lang } from '#lang'
-import type { Rec } from '#rec'
 import type { Ts } from '#ts'
 import { is as isObj } from './is.js'
 import { type Any } from './type.js'
@@ -347,8 +346,8 @@ const _mergeWith = <obj1 extends Any, obj2 extends Any>(
   obj1: obj1,
   obj2: obj2,
 ): obj1 & obj2 => {
-  const obj1_AS = obj1 as Rec.Value
-  const obj2_AS = obj2 as Rec.Value
+  const obj1_AS = obj1 as Record<PropertyKey, unknown>
+  const obj2_AS = obj2 as Record<PropertyKey, unknown>
 
   for (const k2 in obj2_AS) {
     const obj1Value = obj1_AS[k2]

--- a/src/domains/obj/obj.ts
+++ b/src/domains/obj/obj.ts
@@ -1,5 +1,4 @@
 import type { Lang } from '#lang'
-import type { Rec } from '#rec'
 import type { Writable } from 'type-fest'
 import { type IsEmpty } from './diff.js'
 import { entries } from './get.js'
@@ -65,7 +64,7 @@ export function assert(value: unknown): asserts value is object {
  */
 export const isShape = <type>(spec: Record<PropertyKey, Lang.TypeofTypes>) => (value: unknown): value is type => {
   if (!isObj(value)) return false
-  const obj_ = value as Rec.Any
+  const obj_ = value as Record<PropertyKey, unknown>
 
   return entries(spec).every(([key, typeofType]) => {
     return typeof obj_[key] === typeofType


### PR DESCRIPTION
## Summary

- Removed `obj → rec` type-only dependency that inverted the conceptual hierarchy
- `obj` is the primitive (any non-null, non-array object), `rec` is the refinement (plain objects only)
- Replaced `Rec.Any` and `Rec.Value` casts with `Record<PropertyKey, unknown>`

## Changes

| File | Change |
|------|--------|
| `src/domains/obj/obj.ts` | Removed `import type { Rec }`, replaced `Rec.Any` cast |
| `src/domains/obj/merge.ts` | Removed `import type { Rec }`, replaced `Rec.Value` casts |

## Test plan

- [x] Type checks pass (`pnpm check:types`)
- [x] All 2958 tests pass
- [x] Code formatted

Closes #106