### PR TITLE
feat(conventional-commits, git, release): add git commit validator and commit-msg hook installer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -192,6 +192,7 @@
         "simple-git": "^3.36.0",
       },
       "devDependencies": {
+        "@kitz/platform": "workspace:*",
         "@kitz/test": "workspace:*",
       },
     },

--- a/packages/conventional-commits/src/_.test.ts
+++ b/packages/conventional-commits/src/_.test.ts
@@ -391,6 +391,31 @@ Test.describe('parseTitle > errors')
   .cases([['not a valid commit'], null], [['feat:'], null])
   .test()
 
+// ─── parseTitle > dotted custom types ────────────────────────────
+
+test('parseTitle > accepts dotted custom type (chore.docs)', () => {
+  const parsed = parseTitleSync('chore.docs: reconcile skills table')
+  expect(parsed).not.toBeNull()
+  expect(parsed?.type._tag).toBe('Custom')
+  expect(parsed?.type.value).toBe('chore.docs')
+  expect(parsed?.message).toBe('reconcile skills table')
+})
+
+test('parseTitle > accepts dotted custom type with scopes', () => {
+  const parsed = parseTitleSync('chore.docs(release, core): update tables')
+  expect(parsed?.type.value).toBe('chore.docs')
+  expect(parsed?.scopes).toEqual(['release', 'core'])
+})
+
+Test.describe('parseTitle > rejects malformed dotted types')
+  .on(parseTitleSync)
+  .cases(
+    [['.docs: leading dot'], null],
+    [['chore.: trailing dot'], null],
+    [['chore..docs: double dot'], null],
+  )
+  .test()
+
 // ─── parseTitle > Commit.Multi ────────────────────────────────────
 
 test('parseTitle > Commit.Multi', async () => {

--- a/packages/conventional-commits/src/parse/title.ts
+++ b/packages/conventional-commits/src/parse/title.ts
@@ -32,7 +32,13 @@ export type ParseTitleError = InstanceType<typeof ParseTitleError>
 export type ParsedTitle = Single | Multi
 
 // Regex for a single type-scope group: type(scope!, scope2)?!?
-const TYPE_SCOPE_PATTERN = /^([a-z]+)(?:\(([^)]+)\))?(!)?$/
+//
+// The type token allows dot-separated lowercase segments (`chore.docs`) so
+// dotted custom types parse to `Type.Custom` — consistent with `Type.parse`,
+// which already maps any non-standard string to `Custom`. A leading/trailing/
+// doubled dot fails to match, keeping malformed headers invalid. Which dotted
+// types are *allowed* is a consumer policy decision, not a grammar one.
+const TYPE_SCOPE_PATTERN = /^([a-z]+(?:\.[a-z]+)*)(?:\(([^)]+)\))?(!)?$/
 
 /**
  * Parse a conventional commit title line.

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -38,6 +38,7 @@
     "simple-git": "^3.36.0"
   },
   "devDependencies": {
+    "@kitz/platform": "workspace:*",
     "@kitz/test": "workspace:*"
   }
 }

--- a/packages/git/src/__.ts
+++ b/packages/git/src/__.ts
@@ -1,5 +1,7 @@
+export * as CommitMessage from './commit-message.js'
 export * from './commit.js'
 export { Gitignore } from './gitignore.js'
+export * as Hooks from './hooks.js'
 export * from './live.js'
 export * as Memory from './memory.js'
 export * as Paths from './paths.js'

--- a/packages/git/src/commit-message.test.ts
+++ b/packages/git/src/commit-message.test.ts
@@ -20,3 +20,9 @@ test('CommitMessage.subject > returns null when no subject exists', () => {
   expect(CommitMessage.subject('')).toBeNull()
   expect(CommitMessage.subject('# only a comment\n# another comment\n')).toBeNull()
 })
+
+test('CommitMessage.subject > honors a custom comment character', () => {
+  expect(CommitMessage.subject('; editor guidance\nfeat: x', ';')).toBe('feat: x')
+  // With commentChar ';', a leading '#' line is content, not a comment.
+  expect(CommitMessage.subject('# heading\nfeat: x', ';')).toBe('# heading')
+})

--- a/packages/git/src/commit-message.test.ts
+++ b/packages/git/src/commit-message.test.ts
@@ -1,0 +1,22 @@
+import { Test } from '@kitz/test'
+import { expect, test } from 'bun:test'
+import { Git } from './_.js'
+
+const { CommitMessage } = Git
+
+// oxfmt-ignore
+Test.describe('CommitMessage.subject')
+  .on(CommitMessage.subject)
+  .cases(
+    [['feat: add thing'],                       'feat: add thing'],
+    [['feat(core): add\n\nbody paragraph'],     'feat(core): add'],  // first line, body ignored
+    [['# leading comment\nfeat: add thing'],    'feat: add thing'],  // skip git comment lines
+    [['\n\nfeat: add thing'],                    'feat: add thing'],  // skip blank lines
+    [['   feat: add thing   '],                  'feat: add thing'],  // trim
+  )
+  .test()
+
+test('CommitMessage.subject > returns null when no subject exists', () => {
+  expect(CommitMessage.subject('')).toBeNull()
+  expect(CommitMessage.subject('# only a comment\n# another comment\n')).toBeNull()
+})

--- a/packages/git/src/commit-message.ts
+++ b/packages/git/src/commit-message.ts
@@ -1,0 +1,27 @@
+/**
+ * Raw git commit-message helpers.
+ *
+ * A commit message file (`COMMIT_EDITMSG`, or the path passed to a `commit-msg`
+ * hook) is plain text: a subject line, an optional body, and — for editor or
+ * template commits — `#` comment lines that git strips after the hook runs.
+ * These helpers read that format without taking a dependency on a full parser.
+ *
+ * @module
+ */
+
+/**
+ * Extract the subject line from a raw git commit message.
+ *
+ * Skips leading blank lines and `#` comment lines (git's default comment
+ * character), so it behaves the same for `-m` messages and for editor/template
+ * messages whose user text follows commented guidance. Returns `null` when the
+ * message has no subject (empty, whitespace-only, or comments-only).
+ */
+export const subject = (raw: string): string | null => {
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) continue
+    return trimmed
+  }
+  return null
+}

--- a/packages/git/src/commit-message.ts
+++ b/packages/git/src/commit-message.ts
@@ -12,15 +12,19 @@
 /**
  * Extract the subject line from a raw git commit message.
  *
- * Skips leading blank lines and `#` comment lines (git's default comment
- * character), so it behaves the same for `-m` messages and for editor/template
- * messages whose user text follows commented guidance. Returns `null` when the
- * message has no subject (empty, whitespace-only, or comments-only).
+ * Skips leading blank lines and comment lines so it behaves the same for `-m`
+ * messages and for editor/template messages whose user text follows commented
+ * guidance. Returns `null` when the message has no subject (empty,
+ * whitespace-only, or comments-only).
+ *
+ * `commentChar` is the comment prefix (default `#`, git's default). Pass the
+ * repo's `core.commentChar` when it differs; `core.commentChar=auto` is not
+ * resolved here — pass the effective character if you need it.
  */
-export const subject = (raw: string): string | null => {
+export const subject = (raw: string, commentChar = '#'): string | null => {
   for (const line of raw.split('\n')) {
     const trimmed = line.trim()
-    if (trimmed === '' || trimmed.startsWith('#')) continue
+    if (trimmed === '' || trimmed.startsWith(commentChar)) continue
     return trimmed
   }
   return null

--- a/packages/git/src/hooks.test.ts
+++ b/packages/git/src/hooks.test.ts
@@ -57,6 +57,23 @@ describe('Hooks.upsertManagedSection', () => {
     expect(out).toContain(START)
     expect(countSections(out)).toBe(1)
   })
+
+  test('recovers from a corrupted block with a missing end marker (no duplication)', () => {
+    const corrupted = `#!/usr/bin/env sh\nset -eu\n\n${START}\necho stale\n` // end marker hand-deleted
+    const out = Hooks.upsertManagedSection(corrupted, MARKER, BODY)
+    expect(countSections(out)).toBe(1)
+    expect(out).toContain(BODY)
+    expect(out).not.toContain('echo stale')
+    expect(Hooks.upsertManagedSection(out, MARKER, BODY)).toBe(out) // idempotent from recovered state
+  })
+
+  test('recovers from reversed markers without duplicating the block', () => {
+    const reversed = `#!/usr/bin/env sh\n\n# <<< ${MARKER} <<<\n${START}\n`
+    const out = Hooks.upsertManagedSection(reversed, MARKER, BODY)
+    expect(countSections(out)).toBe(1)
+    expect(out).toContain(BODY)
+    expect(Hooks.upsertManagedSection(out, MARKER, BODY)).toBe(out)
+  })
 })
 
 // ─── getHooksDir (live) ─────────────────────────────────────────────

--- a/packages/git/src/hooks.test.ts
+++ b/packages/git/src/hooks.test.ts
@@ -1,0 +1,175 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Platform } from '@kitz/platform'
+import { Effect } from 'effect'
+import { describe, expect, test } from 'bun:test'
+import { Git } from './_.js'
+
+const { Hooks } = Git
+
+const MARKER = 'kitz-release commit-msg'
+const BODY = 'release git commit validate --message-file "$1"'
+const START = `# >>> ${MARKER} >>>`
+
+const countSections = (content: string): number => content.split(START).length - 1
+
+// Run `git` against temp repos with a sanitized env. Inherited GIT_* vars (set
+// when these tests run inside a git hook, e.g. pre-commit) would otherwise make
+// `git init` target the ambient repo instead of the temp dir. Mirrors the
+// allowlist in `_.test.ts`.
+const gitEnv: NodeJS.ProcessEnv = {}
+for (const key of ['HOME', 'PATH', 'TMPDIR', 'TMP', 'TEMP', 'LANG', 'LC_ALL']) {
+  const value = process.env[key]
+  if (value !== undefined) gitEnv[key] = value
+}
+
+// ─── upsertManagedSection (pure) ────────────────────────────────────
+
+describe('Hooks.upsertManagedSection', () => {
+  test('creates a new hook with a shell shebang and a managed block', () => {
+    const out = Hooks.upsertManagedSection(null, MARKER, BODY)
+    expect(out.startsWith('#!/usr/bin/env sh\n')).toBe(true)
+    expect(out).toContain(START)
+    expect(out).toContain(BODY)
+    expect(out).toContain(`# <<< ${MARKER} <<<`)
+  })
+
+  test('is idempotent — re-applying the same body yields byte-identical content', () => {
+    const once = Hooks.upsertManagedSection(null, MARKER, BODY)
+    const twice = Hooks.upsertManagedSection(once, MARKER, BODY)
+    expect(twice).toBe(once)
+  })
+
+  test('replaces only the managed block when the body changes', () => {
+    const old = Hooks.upsertManagedSection(null, MARKER, 'echo old')
+    const updated = Hooks.upsertManagedSection(old, MARKER, 'echo new')
+    expect(updated).toContain('echo new')
+    expect(updated).not.toContain('echo old')
+    expect(countSections(updated)).toBe(1)
+  })
+
+  test('preserves an unrelated existing hook and appends the managed block once', () => {
+    const existing = '#!/usr/bin/env sh\necho "user hook"\n'
+    const out = Hooks.upsertManagedSection(existing, MARKER, BODY)
+    expect(out).toContain('echo "user hook"')
+    expect(out).toContain(START)
+    expect(countSections(out)).toBe(1)
+  })
+})
+
+// ─── getHooksDir (live) ─────────────────────────────────────────────
+
+const initRepo = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'kitz-hooksdir-'))
+  execFileSync('git', ['init', '-b', 'main'], { cwd: root, env: gitEnv })
+  return root
+}
+
+describe('Git.getHooksDir', () => {
+  test('Memory returns the configured hooks directory', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const git = yield* Git.Git
+        return yield* git.getHooksDir()
+      }).pipe(Effect.provide(Git.Memory.make({ hooksDir: '/repo/hooks' }))),
+    )
+    expect(result).toBe('/repo/hooks')
+  })
+
+  test('Live defaults to <gitdir>/hooks for a fresh repo', async () => {
+    const root = initRepo()
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const git = yield* Git.Git
+          return yield* git.getHooksDir()
+        }).pipe(Effect.provide(Git.makeGitLive(root))),
+      )
+      expect(result.startsWith('/')).toBe(true)
+      expect(result.endsWith(join('.git', 'hooks'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('Live honors core.hooksPath', async () => {
+    const root = initRepo()
+    try {
+      execFileSync('git', ['config', 'core.hooksPath', 'my-hooks'], { cwd: root, env: gitEnv })
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const git = yield* Git.Git
+          return yield* git.getHooksDir()
+        }).pipe(Effect.provide(Git.makeGitLive(root))),
+      )
+      expect(result.startsWith('/')).toBe(true)
+      expect(result.endsWith('my-hooks')).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// ─── install (real filesystem) ──────────────────────────────────────
+
+const runInstall = (hooksDir: string, body: string) =>
+  Effect.runPromise(
+    Hooks.install({ hookName: 'commit-msg', marker: MARKER, body }).pipe(
+      Effect.provide(Git.Memory.make({ hooksDir })),
+      Effect.provide(Platform.FileSystem.layer),
+    ),
+  )
+
+describe('Hooks.install', () => {
+  test('writes an executable commit-msg hook that invokes the body', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kitz-hooks-'))
+    const hooksDir = join(dir, 'hooks')
+    try {
+      const result = await runInstall(hooksDir, BODY)
+      expect(result.status).toBe('created')
+      expect(result.path).toBe(join(hooksDir, 'commit-msg'))
+
+      const content = readFileSync(result.path, 'utf8')
+      expect(content.startsWith('#!/usr/bin/env sh')).toBe(true)
+      expect(content).toContain(BODY)
+
+      // Executable bit set — the repo's pre-commit hook enforces this on hooks/*.
+      expect(statSync(result.path).mode & 0o111).not.toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('is idempotent: re-running reports unchanged and never duplicates the block', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kitz-hooks-'))
+    const hooksDir = join(dir, 'hooks')
+    try {
+      const first = await runInstall(hooksDir, BODY)
+      const second = await runInstall(hooksDir, BODY)
+      expect(first.status).toBe('created')
+      expect(second.status).toBe('unchanged')
+      expect(countSections(readFileSync(first.path, 'utf8'))).toBe(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('preserves a pre-existing unrelated commit-msg hook', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kitz-hooks-'))
+    const hooksDir = join(dir, 'hooks')
+    mkdirSync(hooksDir, { recursive: true })
+    writeFileSync(join(hooksDir, 'commit-msg'), '#!/usr/bin/env sh\necho keep-me\n')
+    try {
+      const result = await runInstall(hooksDir, BODY)
+      expect(result.status).toBe('updated')
+      const content = readFileSync(result.path, 'utf8')
+      expect(content).toContain('echo keep-me')
+      expect(content).toContain(BODY)
+      expect(countSections(content)).toBe(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/git/src/hooks.ts
+++ b/packages/git/src/hooks.ts
@@ -1,0 +1,100 @@
+/**
+ * Install and manage marker-delimited git hooks.
+ *
+ * A managed hook owns a single delimited block inside an otherwise hand-editable
+ * hook file, so installation is idempotent and never clobbers unrelated hook
+ * content. The hooks directory is resolved through the {@link Git} service
+ * (honoring `core.hooksPath`), and the file is always written executable.
+ *
+ * @module
+ */
+import { Effect, FileSystem, PlatformError } from 'effect'
+import { Git, type GitError } from './service.js'
+
+const SHEBANG = '#!/usr/bin/env sh'
+
+const startMarker = (marker: string): string => `# >>> ${marker} >>>`
+const endMarker = (marker: string): string => `# <<< ${marker} <<<`
+
+/**
+ * Insert or replace the `marker`-delimited managed section in a hook file body.
+ *
+ * - No existing content → a fresh hook with a shell shebang and the block.
+ * - An existing managed section → replaced in place (byte-identical when the
+ *   body is unchanged, so the operation is idempotent).
+ * - Existing content without the section → the block is appended, preserving
+ *   the original hook verbatim.
+ */
+export const upsertManagedSection = (
+  existing: string | null,
+  marker: string,
+  body: string,
+): string => {
+  const start = startMarker(marker)
+  const end = endMarker(marker)
+  const block = `${start}\n${body}\n${end}`
+
+  if (existing === null || existing.trim() === '') {
+    return `${SHEBANG}\nset -eu\n\n${block}\n`
+  }
+
+  const startIndex = existing.indexOf(start)
+  const endIndex = existing.indexOf(end)
+  if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+    const before = existing.slice(0, startIndex)
+    const after = existing.slice(endIndex + end.length)
+    return `${before}${block}${after}`
+  }
+
+  return `${existing.replace(/\n*$/, '')}\n\n${block}\n`
+}
+
+/** Outcome of {@link install}. */
+export interface InstallResult {
+  /** Absolute path of the hook file. */
+  readonly path: string
+  /** Whether the file was created, modified, or already current. */
+  readonly status: 'created' | 'updated' | 'unchanged'
+}
+
+/** Inputs for {@link install}. */
+export interface InstallOptions {
+  /** Hook file name, e.g. `commit-msg`. */
+  readonly hookName: string
+  /** Unique marker identifying this feature's managed section. */
+  readonly marker: string
+  /** Shell line(s) to run inside the managed section. */
+  readonly body: string
+}
+
+/**
+ * Install (or refresh) a managed hook in the repo's resolved hooks directory.
+ *
+ * Idempotent: re-running with the same body leaves the file byte-identical and
+ * reports `unchanged`. The file is always written executable so the repo's
+ * own hook-hygiene checks accept it.
+ */
+export const install = (
+  options: InstallOptions,
+): Effect.Effect<
+  InstallResult,
+  GitError | PlatformError.PlatformError,
+  Git | FileSystem.FileSystem
+> =>
+  Effect.gen(function* () {
+    const git = yield* Git
+    const fs = yield* FileSystem.FileSystem
+    const hooksDir = yield* git.getHooksDir()
+    const path = `${hooksDir.replace(/\/+$/, '')}/${options.hookName}`
+
+    const existing = (yield* fs.exists(path)) ? yield* fs.readFileString(path) : null
+    const next = upsertManagedSection(existing, options.marker, options.body)
+    const status: InstallResult['status'] =
+      existing === null ? 'created' : existing === next ? 'unchanged' : 'updated'
+
+    yield* fs.makeDirectory(hooksDir, { recursive: true })
+    yield* fs.writeFileString(path, next)
+    yield* fs.chmod(path, 0o755)
+
+    return { path, status }
+  })

--- a/packages/git/src/hooks.ts
+++ b/packages/git/src/hooks.ts
@@ -39,10 +39,14 @@ export const upsertManagedSection = (
   }
 
   const startIndex = existing.indexOf(start)
-  const endIndex = existing.indexOf(end)
-  if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+  if (startIndex !== -1) {
+    // Replace the managed region in place. Search for the end marker *after* the
+    // start so reversed or duplicate markers can't mis-pair; a missing end (a
+    // hand-corrupted block) means the region runs to EOF — replacing it recovers
+    // a clean, idempotent block instead of appending a duplicate.
+    const endIndex = existing.indexOf(end, startIndex + start.length)
     const before = existing.slice(0, startIndex)
-    const after = existing.slice(endIndex + end.length)
+    const after = endIndex === -1 ? '' : existing.slice(endIndex + end.length)
     return `${before}${block}${after}`
   }
 

--- a/packages/git/src/live.ts
+++ b/packages/git/src/live.ts
@@ -191,6 +191,14 @@ const makeGitService = (git: SimpleGit): GitService => ({
 
   getRoot: () => gitEffect('getRoot', async () => (await git.revparse(['--show-toplevel'])).trim()),
 
+  getHooksDir: () =>
+    gitEffect('getHooksDir', async () =>
+      // `--path-format=absolute` yields a cwd-independent absolute path and
+      // `--git-path hooks` honors `core.hooksPath` (falling back to
+      // `<git-dir>/hooks`), so git itself owns the resolution rules.
+      (await git.raw(['rev-parse', '--path-format=absolute', '--git-path', 'hooks'])).trim(),
+    ),
+
   getHeadSha: () =>
     gitEffect('getHeadSha', () => git.revparse(['--short', 'HEAD']), {
       map: (sha) => Sha.make(sha.trim()),

--- a/packages/git/src/memory.ts
+++ b/packages/git/src/memory.ts
@@ -18,6 +18,8 @@ export interface GitMemoryConfig {
   readonly isClean?: boolean
   /** Repository root path */
   readonly root?: string
+  /** Absolute hooks directory (defaults to `<root>/.git/hooks`) */
+  readonly hooksDir?: string
   /** HEAD commit SHA (short form) */
   readonly headSha?: Sha.Sha
   /** Remote URL */
@@ -43,6 +45,8 @@ export interface GitMemoryState {
   readonly isClean: Ref.Ref<boolean>
   /** Repository root */
   readonly root: Ref.Ref<string>
+  /** Absolute hooks directory */
+  readonly hooksDir: Ref.Ref<string>
   /** HEAD commit SHA */
   readonly headSha: Ref.Ref<Sha.Sha>
   /** Tags created (for verification) */
@@ -80,6 +84,7 @@ export const makeState = (config: GitMemoryConfig = {}): Effect.Effect<GitMemory
     branch: Ref.make(config.branch ?? 'main'),
     isClean: Ref.make(config.isClean ?? true),
     root: Ref.make(config.root ?? '/repo'),
+    hooksDir: Ref.make(config.hooksDir ?? `${config.root ?? '/repo'}/.git/hooks`),
     headSha: Ref.make(config.headSha ?? Sha.make('abc1234')),
     createdTags: Ref.make<Array<{ tag: string; message: string | undefined }>>([]),
     pushedTags: Ref.make<
@@ -186,6 +191,8 @@ const makeService = (state: GitMemoryState): GitService => ({
     ]).pipe(Effect.as({ stdout: `dry-run atomic ${tags.join(',')} to ${remote}` })),
 
   getRoot: () => Ref.get(state.root),
+
+  getHooksDir: () => Ref.get(state.hooksDir),
 
   getHeadSha: () => Ref.get(state.headSha),
 

--- a/packages/git/src/service.ts
+++ b/packages/git/src/service.ts
@@ -33,6 +33,7 @@ export type GitOperation =
   | 'pushTag'
   | 'deleteRemoteTag'
   | 'getRemoteUrl'
+  | 'getHooksDir'
 
 const GitOperationSchema = S.Literals([
   'getTags',
@@ -54,6 +55,7 @@ const GitOperationSchema = S.Literals([
   'pushTag',
   'deleteRemoteTag',
   'getRemoteUrl',
+  'getHooksDir',
 ])
 
 const baseTags = ['kit', 'git'] as const
@@ -150,6 +152,14 @@ export interface GitService {
 
   /** Get the repository root path */
   readonly getRoot: () => Effect.Effect<string, GitError>
+
+  /**
+   * Resolve the absolute hooks directory, honoring `core.hooksPath`.
+   *
+   * Returns the configured hooks path (absolute, or resolved against the
+   * working-tree root when relative), or `<git-dir>/hooks` when unset.
+   */
+  readonly getHooksDir: () => Effect.Effect<string, GitError>
 
   /** Get the short SHA of HEAD commit */
   readonly getHeadSha: () => Effect.Effect<Sha.Sha, GitError | GitParseError>

--- a/packages/release/src/api/__.ts
+++ b/packages/release/src/api/__.ts
@@ -46,6 +46,7 @@ export * as Forecaster from './forecaster/__.js'
 export * as Renderer from './renderer/__.js'
 
 // Supporting modules
+export * as CommitPolicy from './commit-policy.js'
 export * as Config from './config.js'
 export * as Digest from './digest.js'
 export * as Doctor from './doctor.js'

--- a/packages/release/src/api/analyzer/analyze.test.ts
+++ b/packages/release/src/api/analyzer/analyze.test.ts
@@ -182,6 +182,7 @@ describe('analyzer.analyze', () => {
       pushTag: () => Effect.void,
       deleteRemoteTag: () => Effect.void,
       getRemoteUrl: () => Effect.succeed('git@github.com:example/repo.git'),
+      getHooksDir: () => Effect.succeed('/repo/.git/hooks'),
     } satisfies Git.GitService)
 
     const result = await Effect.runPromise(

--- a/packages/release/src/api/analyzer/version.ts
+++ b/packages/release/src/api/analyzer/version.ts
@@ -55,8 +55,14 @@ export const extractImpacts = (
   resolvedConventionalCommitTypes: ResolvedConventionalCommitTypes,
 ): Effect.Effect<CommitImpact[]> =>
   Effect.gen(function* () {
-    // Parse the commit title (first line)
-    const title = gitCommit.message.split('\n')[0] ?? gitCommit.message
+    // Extract the subject line via the shared @kitz/git primitive, so version
+    // analysis, the lint rules, and the CLI validator all agree on what "the
+    // commit title" is (skipping blank/comment lead-in).
+    const title = Git.CommitMessage.subject(gitCommit.message)
+    if (title === null) {
+      // Empty or comment-only message - no impacts
+      return []
+    }
     const parseResult = yield* Effect.result(ConventionalCommits.Title.parse(title))
 
     if (Result.isFailure(parseResult)) {

--- a/packages/release/src/api/commit-policy.test.ts
+++ b/packages/release/src/api/commit-policy.test.ts
@@ -1,0 +1,90 @@
+import { ConventionalCommits } from '@kitz/conventional-commits'
+import { Result } from 'effect'
+import { describe, expect, test } from 'bun:test'
+import { findUnknownTypes, isKnownType, validateTitle } from './commit-policy.js'
+import { resolveConventionalCommitTypes } from './config.js'
+
+// Resolved types as a repo would configure them: standard defaults + custom
+// `improve` (minor) and the dotted `chore.docs` (no release impact).
+const resolved = resolveConventionalCommitTypes({ improve: 'minor', 'chore.docs': null })
+
+const parseCommit = (title: string): ConventionalCommits.Commit.Commit => {
+  const result = ConventionalCommits.Title.parseEither(title)
+  if (Result.isFailure(result)) throw new Error(`invalid fixture title: ${title}`)
+  return result.success
+}
+
+describe('isKnownType', () => {
+  test('standard angular types are known', () => {
+    expect(isKnownType(ConventionalCommits.Type.parse('feat'), resolved)).toBe(true)
+    expect(isKnownType(ConventionalCommits.Type.parse('chore'), resolved)).toBe(true)
+  })
+
+  test('configured custom types are known', () => {
+    expect(isKnownType(ConventionalCommits.Type.parse('improve'), resolved)).toBe(true)
+    expect(isKnownType(ConventionalCommits.Type.parse('chore.docs'), resolved)).toBe(true)
+  })
+
+  test('unconfigured custom types are unknown', () => {
+    expect(isKnownType(ConventionalCommits.Type.parse('wip'), resolved)).toBe(false)
+  })
+})
+
+describe('findUnknownTypes', () => {
+  test('returns empty when every type is known (incl. multi-scope)', () => {
+    expect(findUnknownTypes(parseCommit('fix(core, release): tighten'), resolved)).toEqual([])
+  })
+
+  test('returns the unknown types in first-seen order', () => {
+    expect(findUnknownTypes(parseCommit('wip: experiment'), resolved).map((t) => t.value)).toEqual([
+      'wip',
+    ])
+  })
+})
+
+describe('validateTitle', () => {
+  test('accepts a simple scoped title', () => {
+    expect(validateTitle('feat(core): add thing', resolved)).toEqual([])
+  })
+
+  test('accepts a comma-separated multi-scope title', () => {
+    expect(validateTitle('fix(core, release): correct narrowing', resolved)).toEqual([])
+  })
+
+  test('accepts docs', () => {
+    expect(validateTitle('docs: clarify rationale', resolved)).toEqual([])
+  })
+
+  test('accepts chore.docs when configured', () => {
+    expect(validateTitle('chore.docs: reconcile skills table', resolved)).toEqual([])
+  })
+
+  test('reports chore.docs as unknown when not configured', () => {
+    const bare = resolveConventionalCommitTypes({})
+    const problems = validateTitle('chore.docs: reconcile skills table', bare)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]?._tag).toBe('UnknownTypes')
+    if (problems[0]?._tag === 'UnknownTypes') {
+      expect(problems[0].types).toEqual(['chore.docs'])
+    }
+  })
+
+  test('reports an unparsable title as InvalidTitle with the parse reason', () => {
+    const problems = validateTitle('not a conventional commit', resolved)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]?._tag).toBe('InvalidTitle')
+    if (problems[0]?._tag === 'InvalidTitle') {
+      expect(problems[0].input).toBe('not a conventional commit')
+      expect(problems[0].reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('reports unknown types for a parsable-but-unrecognized title', () => {
+    const problems = validateTitle('wip(core): experiment', resolved)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]?._tag).toBe('UnknownTypes')
+    if (problems[0]?._tag === 'UnknownTypes') {
+      expect(problems[0].types).toEqual(['wip'])
+    }
+  })
+})

--- a/packages/release/src/api/commit-policy.ts
+++ b/packages/release/src/api/commit-policy.ts
@@ -1,0 +1,80 @@
+/**
+ * @module api/commit-policy
+ *
+ * Single source of truth for this repo's conventional-commit *policy*: which
+ * commit types are recognized (Angular standard or config-declared) and what
+ * counts as a valid commit title.
+ *
+ * Grammar — what a valid title or type *looks like* — is owned by
+ * `@kitz/conventional-commits`. This module owns the opinionated layer on top:
+ * the set of *allowed* types resolved from release config. Every consumer that
+ * needs the policy (the `pr.type.match-known` and `commit.type.match-known`
+ * lint rules, and the `release git commit validate` CLI command) composes these
+ * primitives rather than re-deriving the rule.
+ */
+import { ConventionalCommits } from '@kitz/conventional-commits'
+import { Result } from 'effect'
+
+/**
+ * Resolved type→impact catalog. Only the key set matters for recognition, so
+ * the value type is widened to `unknown`.
+ */
+type ResolvedTypes = Readonly<Record<string, unknown>>
+
+/**
+ * A commit type is recognized when it is an Angular standard type or has been
+ * declared in `conventionalCommitSettings.types` (release config).
+ */
+export const isKnownType = (
+  type: ConventionalCommits.Type.Type,
+  resolvedTypes: ResolvedTypes,
+): boolean => ConventionalCommits.Type.Standard.is(type) || type.value in resolvedTypes
+
+/**
+ * The types in `commit` that the policy does not recognize, in first-seen
+ * order. Empty when every type is known.
+ */
+export const findUnknownTypes = (
+  commit: ConventionalCommits.Commit.Commit,
+  resolvedTypes: ResolvedTypes,
+): readonly ConventionalCommits.Type.Type[] =>
+  ConventionalCommits.Commit.types(commit).filter((type) => !isKnownType(type, resolvedTypes))
+
+/** The title failed to parse as a conventional-commit title. */
+export interface InvalidTitle {
+  readonly _tag: 'InvalidTitle'
+  readonly reason: string
+  readonly input: string
+}
+
+/** The title parsed, but one or more of its types are not recognized. */
+export interface UnknownTypes {
+  readonly _tag: 'UnknownTypes'
+  readonly types: readonly string[]
+}
+
+/** A single commit-policy diagnostic. */
+export type Problem = InvalidTitle | UnknownTypes
+
+/**
+ * Validate a commit *title* (the subject line) against the policy.
+ *
+ * Returns diagnostics in evaluation order; an empty array means the title is
+ * valid. A title that fails to parse yields a single {@link InvalidTitle}; an
+ * otherwise-valid title carrying unrecognized types yields a single
+ * {@link UnknownTypes}.
+ */
+export const validateTitle = (
+  subject: string,
+  resolvedTypes: ResolvedTypes,
+): readonly Problem[] => {
+  const parsed = ConventionalCommits.Title.parseEither(subject)
+  if (Result.isFailure(parsed)) {
+    return [{ _tag: 'InvalidTitle', reason: parsed.failure.context.reason, input: subject }]
+  }
+  const unknown = findUnknownTypes(parsed.success, resolvedTypes)
+  if (unknown.length > 0) {
+    return [{ _tag: 'UnknownTypes', types: unknown.map((type) => type.value) }]
+  }
+  return []
+}

--- a/packages/release/src/api/lint/rules/commit-type-match-known.ts
+++ b/packages/release/src/api/lint/rules/commit-type-match-known.ts
@@ -1,6 +1,7 @@
 import { ConventionalCommits } from '@kitz/conventional-commits'
 import { Git } from '@kitz/git'
 import { Effect, Result, Schema } from 'effect'
+import * as CommitPolicy from '../../commit-policy.js'
 import { RuleId } from '../models/rule-defaults.js'
 import * as RuntimeRule from '../models/runtime-rule.js'
 import { GitHistory } from '../models/violation-location.js'
@@ -12,11 +13,6 @@ const OptionsSchema = Schema.Struct({
   since: Schema.optional(Schema.String),
 })
 type Options = typeof OptionsSchema.Type
-
-const isKnownType = (
-  type: ConventionalCommits.Type.Type,
-  resolvedTypes: Readonly<Record<string, unknown>>,
-): boolean => ConventionalCommits.Type.Standard.is(type) || type.value in resolvedTypes
 
 /** Verifies that every commit type in the analyzed range is recognized (standard or configured). */
 export const rule = RuntimeRule.create({
@@ -32,35 +28,34 @@ export const rule = RuntimeRule.create({
     const commits = yield* git.getCommitsSince(options.since)
 
     for (const commit of commits) {
-      const title = commit.message.split('\n')[0] ?? commit.message
+      const title = Git.CommitMessage.subject(commit.message)
+      if (title === null) continue
       const parseResult = yield* Effect.result(ConventionalCommits.Title.parse(title))
       if (Result.isFailure(parseResult)) continue
 
       const parsed = parseResult.success
-      const types = ConventionalCommits.Commit.types(parsed)
+      const [type] = CommitPolicy.findUnknownTypes(parsed, resolvedTypes)
 
-      for (const type of types) {
-        if (!isKnownType(type, resolvedTypes)) {
-          return Violation.make({
-            location: GitHistory.make({ sha: commit.hash }),
-            summary: `Commit ${commit.hash.slice(0, 7)} uses unrecognized type "${type.value}".`,
-            detail:
-              'Unrecognized commit types are excluded from version analysis. ' +
-              'If this type should trigger a release, add it to your release config. ' +
-              'Rewriting git history is possible but rarely recommended.',
-            fix: GuideFix.make({
-              summary: 'Add the type to release config or rewrite history.',
-              steps: [
-                FixStep.make({
-                  description: `Add \`${type.value}: '<bump>'\` to \`conventionalCommitSettings.types\` in release.config.ts (recommended).`,
-                }),
-                FixStep.make({
-                  description: `Rewrite the commit to use a recognized type (not usually recommended).`,
-                }),
-              ],
-            }),
-          })
-        }
+      if (type) {
+        return Violation.make({
+          location: GitHistory.make({ sha: commit.hash }),
+          summary: `Commit ${commit.hash.slice(0, 7)} uses unrecognized type "${type.value}".`,
+          detail:
+            'Unrecognized commit types are excluded from version analysis. ' +
+            'If this type should trigger a release, add it to your release config. ' +
+            'Rewriting git history is possible but rarely recommended.',
+          fix: GuideFix.make({
+            summary: 'Add the type to release config or rewrite history.',
+            steps: [
+              FixStep.make({
+                description: `Add \`${type.value}: '<bump>'\` to \`conventionalCommitSettings.types\` in release.config.ts (recommended).`,
+              }),
+              FixStep.make({
+                description: `Rewrite the commit to use a recognized type (not usually recommended).`,
+              }),
+            ],
+          }),
+        })
       }
     }
 

--- a/packages/release/src/api/lint/rules/pr-type-match-known.ts
+++ b/packages/release/src/api/lint/rules/pr-type-match-known.ts
@@ -1,5 +1,5 @@
-import { ConventionalCommits } from '@kitz/conventional-commits'
 import { Effect } from 'effect'
+import * as CommitPolicy from '../../commit-policy.js'
 import * as Precondition from '../models/precondition.js'
 import { RuleId } from '../models/rule-defaults.js'
 import * as RuntimeRule from '../models/runtime-rule.js'
@@ -8,11 +8,6 @@ import { FixStep, GuideFix, Violation } from '../models/violation.js'
 import { ConventionalCommitSettingsService } from '../services/conventional-commit-settings.js'
 import { getInvalidTitleViolation, getParsedCommit } from './pr-helpers.js'
 import { PrService } from '../services/pr.js'
-
-const isKnownType = (
-  type: ConventionalCommits.Type.Type,
-  resolvedTypes: Readonly<Record<string, unknown>>,
-): boolean => ConventionalCommits.Type.Standard.is(type) || type.value in resolvedTypes
 
 /** Verifies that every PR title type is recognized (standard or configured). */
 export const rule = RuntimeRule.create({
@@ -26,9 +21,7 @@ export const rule = RuntimeRule.create({
     if (invalidTitle) return invalidTitle
     const commit = getParsedCommit(pr)!
 
-    const unknownTypes = ConventionalCommits.Commit.types(commit).filter(
-      (type) => !isKnownType(type, resolvedTypes),
-    )
+    const unknownTypes = CommitPolicy.findUnknownTypes(commit, resolvedTypes)
 
     if (unknownTypes.length > 0) {
       const names = unknownTypes.map((t) => `"${t.value}"`).join(', ')

--- a/packages/release/src/api/proof.test.ts
+++ b/packages/release/src/api/proof.test.ts
@@ -161,6 +161,7 @@ const gitLayer = (overrides: Partial<Git.GitService>): Layer.Layer<Git.Git> =>
     pushTag: () => unused(),
     deleteRemoteTag: () => unused(),
     getRemoteUrl: () => unused(),
+    getHooksDir: () => unused(),
     ...overrides,
   })
 

--- a/packages/release/src/cli/cli.ts
+++ b/packages/release/src/cli/cli.ts
@@ -19,6 +19,7 @@ import { conformance } from './commands/conformance.js'
 import { doctor } from './commands/doctor.js'
 import { explain } from './commands/explain.js'
 import { forecast } from './commands/forecast.js'
+import { git } from './commands/git.js'
 import { graph } from './commands/graph.js'
 import { history } from './commands/history.js'
 import { init } from './commands/init.js'
@@ -48,6 +49,7 @@ const release = Command.make('release').pipe(
     doctor,
     explain,
     forecast,
+    git,
     graph,
     history,
     init,

--- a/packages/release/src/cli/commands/git-lib.test.ts
+++ b/packages/release/src/cli/commands/git-lib.test.ts
@@ -1,0 +1,63 @@
+import { Git } from '@kitz/git'
+import { describe, expect, test } from 'bun:test'
+import { resolveConventionalCommitTypes } from '../../api/config.js'
+import { renderInstallResult, validateCommitMessage } from './git-lib.js'
+
+// Standard defaults plus the repo's dotted docs-chore convention.
+const resolved = resolveConventionalCommitTypes({ 'chore.docs': null })
+
+describe('validateCommitMessage', () => {
+  test('accepts a standard scoped title with no diagnostics', () => {
+    expect(validateCommitMessage('feat(core): add thing', resolved)).toEqual({
+      ok: true,
+      lines: [],
+    })
+  })
+
+  test('accepts multi-scope, docs, and chore.docs titles', () => {
+    expect(validateCommitMessage('fix(core, release): tighten narrowing', resolved).ok).toBe(true)
+    expect(validateCommitMessage('docs: clarify rationale', resolved).ok).toBe(true)
+    expect(validateCommitMessage('chore.docs: reconcile skills table', resolved).ok).toBe(true)
+  })
+
+  test('extracts the subject from a full message with a body and comments', () => {
+    const raw = 'feat(core): add thing\n\nA body paragraph.\n\n# git template comment'
+    expect(validateCommitMessage(raw, resolved).ok).toBe(true)
+  })
+
+  test('rejects an invalid title, echoing the offending subject', () => {
+    const outcome = validateCommitMessage('just some prose', resolved)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.lines.join('\n')).toContain('just some prose')
+  })
+
+  test('rejects an unrecognized type and names it', () => {
+    const outcome = validateCommitMessage('wip(core): experiment', resolved)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.lines.join('\n')).toContain('wip')
+  })
+
+  test('rejects a message with no subject line', () => {
+    const outcome = validateCommitMessage('   \n# only a comment\n', resolved)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.lines.length).toBeGreaterThan(0)
+  })
+})
+
+describe('renderInstallResult', () => {
+  const path = '/repo/hooks/commit-msg'
+
+  test('reports a created hook with its path', () => {
+    const line = renderInstallResult({ path, status: 'created' })
+    expect(line).toContain(path)
+    expect(line.toLowerCase()).toContain('install')
+  })
+
+  test('reports an updated hook', () => {
+    expect(renderInstallResult({ path, status: 'updated' }).toLowerCase()).toContain('updat')
+  })
+
+  test('reports an unchanged hook as already up to date', () => {
+    expect(renderInstallResult({ path, status: 'unchanged' }).toLowerCase()).toContain('up to date')
+  })
+})

--- a/packages/release/src/cli/commands/git-lib.ts
+++ b/packages/release/src/cli/commands/git-lib.ts
@@ -1,0 +1,70 @@
+/**
+ * @module cli/commands/git-lib
+ *
+ * Pure, testable logic behind the `release git` commands. The `git.ts` command
+ * tree stays thin glue (read the message file, exit with a code); the policy
+ * decision and the human-facing rendering live here.
+ */
+import { Git } from '@kitz/git'
+import { Match } from 'effect'
+import * as CommitPolicy from '../../api/commit-policy.js'
+
+/** Marker delimiting the managed section this feature owns in `commit-msg`. */
+export const COMMIT_MSG_MARKER = 'kitz-release commit-msg'
+
+/** The line the managed `commit-msg` hook runs. `$1` is git's message-file path. */
+export const COMMIT_MSG_BODY = 'release git commit validate --message-file "$1"'
+
+const renderProblem = (problem: CommitPolicy.Problem): readonly string[] =>
+  Match.value(problem).pipe(
+    Match.tagsExhaustive({
+      InvalidTitle: (p) => [
+        'Invalid commit message — the subject is not a conventional-commit title:',
+        `  ${p.input}`,
+        `  Reason: ${p.reason}`,
+        '  Expected: <type>(<scope>): <subject>   e.g. "feat(core): add thing"',
+      ],
+      UnknownTypes: (p) => [
+        `Unrecognized commit type(s): ${p.types.map((type) => `"${type}"`).join(', ')}`,
+        '  Use a standard type (feat, fix, docs, …) or declare it under',
+        '  conventionalCommitSettings.types in release.config.ts.',
+      ],
+    }),
+  )
+
+/** Outcome of validating a raw commit message: pass/fail plus diagnostic lines. */
+export interface ValidateOutcome {
+  /** True when the message satisfies the policy (no diagnostics). */
+  readonly ok: boolean
+  /** Deterministic, hook-friendly diagnostic lines (empty when `ok`). */
+  readonly lines: readonly string[]
+}
+
+/**
+ * Validate a raw commit message (subject + body) against the resolved type
+ * policy. Composes the subject extractor and the commit policy, then renders
+ * any problems — the single decision point shared with the lint rules lives in
+ * {@link CommitPolicy}.
+ */
+export const validateCommitMessage = (
+  raw: string,
+  resolvedTypes: Readonly<Record<string, unknown>>,
+): ValidateOutcome => {
+  const subject = Git.CommitMessage.subject(raw)
+  if (subject === null) {
+    return { ok: false, lines: ['Invalid commit message — it has no subject line.'] }
+  }
+  const problems = CommitPolicy.validateTitle(subject, resolvedTypes)
+  if (problems.length === 0) return { ok: true, lines: [] }
+  return { ok: false, lines: problems.flatMap(renderProblem) }
+}
+
+const installMessage = {
+  created: 'Installed commit-msg hook',
+  updated: 'Updated commit-msg hook',
+  unchanged: 'commit-msg hook already up to date',
+} as const satisfies Record<Git.Hooks.InstallResult['status'], string>
+
+/** Render the hook-install outcome as a single status line. */
+export const renderInstallResult = (result: Git.Hooks.InstallResult): string =>
+  `${installMessage[result.status]} → ${result.path}`

--- a/packages/release/src/cli/commands/git.ts
+++ b/packages/release/src/cli/commands/git.ts
@@ -1,0 +1,79 @@
+/**
+ * @module cli/commands/git
+ *
+ * Git integration for `@kitz/release`.
+ *
+ * `release git commit validate --message-file <path>` validates a commit
+ * message against the repo's commit policy and exits non-zero on failure — the
+ * surface a `commit-msg` hook calls.
+ *
+ * `release git hooks install` installs that hook idempotently under the repo's
+ * resolved hooks directory.
+ *
+ * Both leaves are thin glue over bounded primitives: parsing/policy lives in
+ * `@kitz/conventional-commits` + {@link Api.CommitPolicy}, and hook/message
+ * mechanics live in `@kitz/git`.
+ */
+import { Env } from '@kitz/env'
+import { Git } from '@kitz/git'
+import { Console, Effect, FileSystem, Layer } from 'effect'
+import { Command, Flag } from 'effect/unstable/cli'
+import * as Api from '../../api/__.js'
+import { FileSystemLayer } from '../../platform.js'
+import {
+  COMMIT_MSG_BODY,
+  COMMIT_MSG_MARKER,
+  renderInstallResult,
+  validateCommitMessage,
+} from './git-lib.js'
+
+const gitCommitValidate = Command.make(
+  'validate',
+  {
+    messageFile: Flag.string('message-file').pipe(
+      Flag.withDescription(
+        "Path to the commit message file to validate (the commit-msg hook's $1)",
+      ),
+    ),
+  },
+  ({ messageFile }) =>
+    Effect.gen(function* () {
+      const env = yield* Env.Env
+      const fs = yield* FileSystem.FileSystem
+      const config = yield* Api.Config.load()
+
+      const raw = yield* fs.readFileString(messageFile)
+      const outcome = validateCommitMessage(raw, config.resolvedConventionalCommitTypes)
+
+      if (outcome.ok) return
+      yield* Console.error(outcome.lines.join('\n'))
+      return env.exit(1)
+    }),
+).pipe(Command.withDescription('Validate a commit message file against repo commit policy'))
+
+const gitCommit = Command.make('commit').pipe(
+  Command.withDescription('Commit-message policy commands'),
+  Command.withSubcommands([gitCommitValidate]),
+)
+
+const gitHooksInstall = Command.make('install', {}, () =>
+  Effect.gen(function* () {
+    const result = yield* Git.Hooks.install({
+      hookName: 'commit-msg',
+      marker: COMMIT_MSG_MARKER,
+      body: COMMIT_MSG_BODY,
+    })
+    yield* Console.log(renderInstallResult(result))
+  }),
+).pipe(Command.withDescription('Install the idempotent commit-msg hook that runs the validator'))
+
+const gitHooks = Command.make('hooks').pipe(
+  Command.withDescription('Manage the kitz-release git hooks'),
+  Command.withSubcommands([gitHooksInstall]),
+)
+
+export const git = Command.make('git').pipe(
+  Command.withDescription('Git integration: commit-message validation and hook installation'),
+  Command.withSubcommands([gitCommit, gitHooks]),
+  Command.provide(Layer.mergeAll(Env.Live, FileSystemLayer, Git.GitLive)),
+)

--- a/packages/release/src/cli/commands/git.ts
+++ b/packages/release/src/cli/commands/git.ts
@@ -40,8 +40,13 @@ const gitCommitValidate = Command.make(
     Effect.gen(function* () {
       const env = yield* Env.Env
       const fs = yield* FileSystem.FileSystem
-      const config = yield* Api.Config.load()
 
+      if (!(yield* fs.exists(messageFile))) {
+        yield* Console.error(`Commit message file not found: ${messageFile}`)
+        return env.exit(1)
+      }
+
+      const config = yield* Api.Config.load()
       const raw = yield* fs.readFileString(messageFile)
       const outcome = validateCommitMessage(raw, config.resolvedConventionalCommitTypes)
 

--- a/release.config.ts
+++ b/release.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   conventionalCommitSettings: {
     types: {
       improve: 'minor',
+      // Repo docs-chore convention (README/guide edits): recognized, no release.
+      'chore.docs': null,
       // Historical no-release types in existing git history.
       refator: null,
       tests: null,


### PR DESCRIPTION
Implements #207 — local commit-message policy enforcement plus a first-party
`commit-msg` hook installer, built as a strict stack of bounded-context
primitives that compose up into the opinionated `release` result.

## CLI surfaces

- `release git commit validate --message-file <path>` — reads the message file,
  validates the subject against repo policy, prints deterministic diagnostics,
  exits non-zero on failure.
- `release git hooks install` — installs an idempotent, executable `commit-msg`
  hook under the repo's resolved hooks directory.

## Abstraction layering (the point of the change)

Each layer is understandable and testable in isolation; `release` reads as
composition, not logic.

| Concern | Home | What landed |
|---|---|---|
| Conventional-commit grammar | `@kitz/conventional-commits` | Widened the title type token to dot-separated lowercase segments (`parse/title.ts`), so `chore.docs` parses to `Type.Custom` — consistent with `Type.parse`, which already maps non-standard strings to `Custom`. |
| Git message + hook mechanics | `@kitz/git` | `CommitMessage.subject` (subject extraction); `Hooks` (pure marker-delimited `upsertManagedSection` + effectful executable `install`); `getHooksDir` service op that delegates `core.hooksPath` resolution to `git rev-parse --path-format=absolute --git-path hooks`. |
| Repo commit policy | `@kitz/release` | `Api.CommitPolicy` — the **single source of truth** for known-type policy (`isKnownType` / `findUnknownTypes` / `validateTitle`). |
| CLI composition | `@kitz/release` | Thin `effect/unstable/cli` `git → commit → validate` and `git → hooks → install` tree; testable glue in `git-lib.ts`. |

### Single source of truth (issue Non-Goal)

The repo had **two** copies of the known-type check — `pr-type-match-known.ts`
*and* `commit-type-match-known.ts` each defined a private `isKnownType`. Both
now compose `Api.CommitPolicy.findUnknownTypes`; neither owns policy logic. The
new CLI command calls the same primitive, so there is no second validator.
`commit-type-match-known.ts` also now uses `Git.CommitMessage.subject` instead
of an inline `split('\n')[0]`.

## How `chore.docs` was resolved (issue Gotcha 1)

`chore.docs` is an active repo convention (`6d1bac36` on main) but was **failing
to parse entirely**: the title regex `^[a-z]+...` rejected the dot before the
known-type check ever ran. So the config route alone could not satisfy the
acceptance criterion — the parse forced a grammar fix. Two-layer resolution:

1. **Grammar** (`@kitz/conventional-commits`): the type token now allows
   `[a-z]+(?:\.[a-z]+)*`. The grammar defines the *shape* of a dotted type;
   which dotted types are *allowed* stays a consumer-policy decision.
2. **Policy** (`release.config.ts`): `chore.docs` is declared with `null`
   impact (recognized, no release), matching the existing `refator`/`tests`
   entries. This flows to both lint rules and the CLI validator via
   `resolvedConventionalCommitTypes`.

This keeps scope tight and does not touch the broader #203 rethink.

## Acceptance criteria

- [x] Valid messages pass with exit `0` — verified e2e + `git-lib.test.ts`.
- [x] Invalid titles fail with exit `1` and a clear fix message — `Invalid commit message — the subject is not a conventional-commit title: …`.
- [x] Multi-scope `fix(core, release): …` validates — `commit-policy.test.ts`, `git-lib.test.ts`.
- [x] `docs(...)` and `chore.docs` handled per repo policy — grammar + config; verified e2e from the worktree root.
- [x] `release git hooks install` writes a working `commit-msg` hook — executable, shebang, invokes `release git commit validate --message-file "$1"`.
- [x] Re-running install does not duplicate or corrupt the hook — idempotent marker-delimited section; `hooks.test.ts` + e2e (`created` → `unchanged`).
- [x] Tests cover validator success/failure + hook installation — see below.

## Tests

- `@kitz/conventional-commits`: dotted-type accept/reject cases (`_.test.ts`).
- `@kitz/git`: `CommitMessage.subject`; `Hooks.upsertManagedSection` (pure) + `Hooks.install` (real-FS executable + idempotency + foreign-hook preservation); `getHooksDir` (memory + live incl. `core.hooksPath`). Live tests run git with a sanitized env so they stay isolated from an ambient `GIT_DIR` (e.g. inside a hook).
- `@kitz/release`: `CommitPolicy` (known-type, unknown-type, validate incl. `chore.docs`); `git-lib` (validate composition + diagnostic rendering + install-result rendering). Both lint-rule suites still green after consolidation.

## Operational note

The validator resolves config via the standard `Config.load()` (cwd-based).
Git runs `commit-msg` hooks from the worktree root, where `release.config.ts`
lives, so configured types (incl. `chore.docs`) resolve correctly in the hook.

Refs #207 (left for the reviewer/merge to close).