### PR TITLE
feat(conventional-commits, release): SHA-keyed commit-body overrides

### DIFF
--- a/packages/conventional-commits/src/__.ts
+++ b/packages/conventional-commits/src/__.ts
@@ -1,3 +1,4 @@
+export * as BreakingChange from './breaking-change.js'
 export * as Commit from './commit.js'
 export * as Footer from './footer.js'
 export * from './target-section.js'

--- a/packages/conventional-commits/src/breaking-change.test.ts
+++ b/packages/conventional-commits/src/breaking-change.test.ts
@@ -1,0 +1,59 @@
+import { Test } from '@kitz/test'
+import { describe, expect, test } from 'bun:test'
+import { ConventionalCommits } from './_.js'
+
+const { hasSignal } = ConventionalCommits.BreakingChange
+
+// ─── hasSignal ────────────────────────────────────────────────────
+
+// A "signal" is any conventional-commit breaking-change marker per the grammar:
+//   1. a leading `!`
+//   2. a breaking header (`type!:`, `type(scope)!:`, `type(scope!):`)
+//   3. a standard `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer token
+Test.on(hasSignal)
+  // dprint-ignore
+  .cases(
+    // No signal — ordinary corrected changelog text.
+    [['corrected wording for the parser fix'], false],
+    [['add support for nested scopes'], false],
+    [[''], false],
+    // A `!` mid-text is not a leading marker.
+    [['rename a != b helper'], false],
+    // Mentioning the words mid-sentence (lowercase, not a footer line) is not a signal.
+    [['document the breaking change policy'], false],
+    // A non-breaking CC-style header carries no breaking signal.
+    [['feat: add a thing'], false],
+    [['feat(core): add a thing'], false],
+    // Leading `!`.
+    [['!important correction'], true],
+    [['!'], true],
+    // Breaking headers.
+    [['feat!: now breaking'], true],
+    [['feat(core)!: now breaking'], true],
+    [['feat(core!): now breaking'], true],
+    // Standard breaking-change footer tokens (on their own line).
+    [['reworded summary\n\nBREAKING CHANGE: removed the old API'], true],
+    [['reworded summary\n\nBREAKING-CHANGE: removed the old API'], true],
+    // Footer token with leading indentation still counts.
+    [['reworded\n\n  BREAKING CHANGE: gone'], true],
+    // The token mid-line (not at line start) is not a footer.
+    [['see the BREAKING CHANGE: note below'], false],
+  )
+  .test()
+
+describe('BreakingChange.hasSignal — relationship to the grammar', () => {
+  test('agrees with Title parsing on breaking headers', () => {
+    // Anything the title grammar parses as breaking must be flagged.
+    const breakingTitles = ['fix!: x', 'fix(a)!: x', 'feat(a, b)!: x', 'feat(a!): x']
+    for (const title of breakingTitles) {
+      expect(hasSignal(title)).toBe(true)
+    }
+  })
+
+  test('does not flag non-breaking parsed headers', () => {
+    const nonBreaking = ['fix: x', 'feat(a): x', 'chore(a, b): x']
+    for (const title of nonBreaking) {
+      expect(hasSignal(title)).toBe(false)
+    }
+  })
+})

--- a/packages/conventional-commits/src/breaking-change.ts
+++ b/packages/conventional-commits/src/breaking-change.ts
@@ -1,0 +1,53 @@
+import { Result } from 'effect'
+import { facets } from './commit.js'
+import { StandardToken } from './footer.js'
+import { parseEither } from './title.js'
+
+/**
+ * The standard breaking-change footer tokens, sourced from the {@link StandardToken}
+ * grammar so this predicate stays in lock-step with the footer definition.
+ */
+const breakingFooterTokens: readonly string[] = Object.values(StandardToken.enums)
+
+/**
+ * Does this freeform text carry a conventional-commit breaking-change signal?
+ *
+ * Detects every CC breaking-change marker the grammar defines:
+ *
+ * 1. A **leading `!`** — text whose first non-whitespace character is `!`.
+ * 2. A **breaking header** — a leading line that parses as a conventional-commit
+ *    title denoting a breaking change (`type!:`, `type(scope)!:`, `type(scope!):`),
+ *    decided by the canonical {@link parseEither} grammar rather than an ad-hoc regex.
+ * 3. A **standard breaking-change footer** — a line beginning with a
+ *    `BREAKING CHANGE:` / `BREAKING-CHANGE:` token.
+ *
+ * The check is intentionally conservative (it owns the "no breaking content"
+ * invariant for consumers like release commit-body overrides): a leading `!` is
+ * flagged even though, on its own, it is not strictly a header marker. A `!` or
+ * the words "breaking change" appearing mid-line is **not** a signal.
+ */
+export const hasSignal = (text: string): boolean => {
+  const lines = text.split('\n')
+
+  // 3. Standard breaking-change footer token at the start of any line.
+  for (const line of lines) {
+    const trimmed = line.trimStart()
+    if (breakingFooterTokens.some((token) => trimmed.startsWith(`${token}:`))) {
+      return true
+    }
+  }
+
+  // 1. Leading `!` breaking marker.
+  if (text.trimStart().startsWith('!')) {
+    return true
+  }
+
+  // 2. Breaking header on the leading (first non-blank) line.
+  const leadingLine = lines.map((line) => line.trim()).find((line) => line.length > 0) ?? ''
+  const parsed = parseEither(leadingLine)
+  if (Result.isSuccess(parsed) && facets(parsed.success).some((facet) => facet.breaking)) {
+    return true
+  }
+
+  return false
+}

--- a/packages/conventional-commits/src/commit.test.ts
+++ b/packages/conventional-commits/src/commit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import { Option } from 'effect'
+import { ConventionalCommits } from './_.js'
+
+const { Commit, Footer, Target, Type } = ConventionalCommits
+
+const single = Commit.Single.make({
+  type: Type.parse('feat'),
+  scopes: ['core'],
+  breaking: true,
+  message: 'original subject',
+  body: Option.some('a body paragraph'),
+  footers: [Footer.from('Reviewed-by', 'alice')],
+})
+
+const multi = Commit.Multi.make({
+  targets: [
+    Target.make({ type: Type.parse('feat'), scope: 'core', breaking: false }),
+    Target.make({ type: Type.parse('fix'), scope: 'cli', breaking: true }),
+  ],
+  message: 'original multi subject',
+  summary: Option.some('a summary'),
+  sections: {},
+})
+
+// ─── Commit.withDescription ───────────────────────────────────────
+
+describe('Commit.withDescription', () => {
+  test('replaces the description on a Single commit', () => {
+    const next = Commit.withDescription(single, 'corrected subject')
+    expect(Commit.Single.is(next)).toBe(true)
+    if (!Commit.Single.is(next)) throw new Error('expected Single')
+    expect(next.message).toBe('corrected subject')
+  })
+
+  test('preserves type/scopes/breaking/body/footers on a Single commit', () => {
+    const next = Commit.withDescription(single, 'corrected subject')
+    if (!Commit.Single.is(next)) throw new Error('expected Single')
+    expect(next.type).toEqual(single.type)
+    expect(next.scopes).toEqual(single.scopes)
+    expect(next.breaking).toBe(single.breaking)
+    expect(next.body).toEqual(single.body)
+    expect(next.footers).toEqual(single.footers)
+  })
+
+  test('replaces the description on a Multi commit', () => {
+    const next = Commit.withDescription(multi, 'corrected multi subject')
+    expect(Commit.Multi.is(next)).toBe(true)
+    if (!Commit.Multi.is(next)) throw new Error('expected Multi')
+    expect(next.message).toBe('corrected multi subject')
+  })
+
+  test('preserves targets/summary/sections on a Multi commit', () => {
+    const next = Commit.withDescription(multi, 'corrected multi subject')
+    if (!Commit.Multi.is(next)) throw new Error('expected Multi')
+    expect(next.targets).toEqual(multi.targets)
+    expect(next.summary).toEqual(multi.summary)
+    expect(next.sections).toEqual(multi.sections)
+  })
+
+  test('leaves the type/scope/breaking facets identical (zero-semantics)', () => {
+    for (const commit of [single, multi] as const) {
+      expect(Commit.facets(Commit.withDescription(commit, 'anything at all'))).toEqual(
+        Commit.facets(commit),
+      )
+    }
+  })
+
+  test('does not mutate the input commit', () => {
+    Commit.withDescription(single, 'corrected subject')
+    expect(single.message).toBe('original subject')
+  })
+})

--- a/packages/conventional-commits/src/commit.ts
+++ b/packages/conventional-commits/src/commit.ts
@@ -76,6 +76,37 @@ export const types = (commit: Commit): readonly Type[] => {
 }
 
 /**
+ * Return a copy of the commit with its rendered description (the subject line
+ * after the header) replaced.
+ *
+ * Only the human-facing description text changes; the type/scope/breaking
+ * structure — and, for the records that carry them, the body, footers, summary,
+ * and per-scope sections — are preserved verbatim. Because the breaking-change
+ * facets live in separate fields, swapping the description can never change a
+ * commit's release semantics, which is exactly what SHA-keyed changelog
+ * overrides need.
+ */
+export const withDescription = (commit: Commit, description: string): Commit => {
+  if (Commit.guards.Single(commit)) {
+    return Single.make({
+      type: commit.type,
+      scopes: commit.scopes,
+      breaking: commit.breaking,
+      message: description,
+      body: commit.body,
+      footers: commit.footers,
+    })
+  }
+
+  return Multi.make({
+    targets: commit.targets,
+    message: description,
+    summary: commit.summary,
+    sections: commit.sections,
+  })
+}
+
+/**
  * Render a canonical conventional-commit header from a parsed commit.
  */
 export const renderHeader = (commit: Commit): string => {

--- a/packages/release/src/api/analyzer/analyze.ts
+++ b/packages/release/src/api/analyzer/analyze.ts
@@ -38,6 +38,9 @@ export interface AnalyzeOptions {
   /** Resolved type→bump mapping from config. Custom types with configured bumps
    *  generate impacts; unrecognized types return null (lint catches them). */
   readonly resolvedConventionalCommitTypes: import('./version.js').ResolvedConventionalCommitTypes
+  /** SHA-keyed changelog-text overrides. Rewrites only rendered descriptions;
+   *  never affects bump/type/scope/breaking. */
+  readonly commitOverrides?: import('../config.js').CommitOverrides | undefined
 }
 
 const findLatestReleaseTag = (pkg: Package, tags: readonly string[]): string | undefined => {
@@ -168,7 +171,9 @@ export const analyze = (
     // packages.  Individual failures surface as empty impact arrays, so
     // a single malformed commit won't abort the pipeline.
     const allImpacts = yield* Effect.all(
-      commits.map((c) => extractImpacts(c, options.resolvedConventionalCommitTypes)),
+      commits.map((c) =>
+        extractImpacts(c, options.resolvedConventionalCommitTypes, options.commitOverrides),
+      ),
       { concurrency: 'unbounded' },
     )
     const flatImpacts = allImpacts.flat().filter((impact) => {

--- a/packages/release/src/api/analyzer/commit-override.test.ts
+++ b/packages/release/src/api/analyzer/commit-override.test.ts
@@ -1,0 +1,83 @@
+import { Git } from '@kitz/git'
+import { Effect } from 'effect'
+import { describe, expect, test } from 'bun:test'
+import type { CommitOverrides } from '../config.js'
+import { resolveConventionalCommitTypes } from '../config.js'
+import { resolveOverride } from './commit-override.js'
+import { extractImpacts } from './version.js'
+
+const types = resolveConventionalCommitTypes({})
+
+const runImpacts = (commit: Git.Commit, overrides?: CommitOverrides) =>
+  Effect.runSync(extractImpacts(commit, types, overrides))
+
+// ─── resolveOverride: SHA-prefix matching ─────────────────────────
+
+describe('resolveOverride', () => {
+  const overrides: CommitOverrides = { abc1234: { body: 'reworded' } }
+
+  test('returns undefined when there are no overrides', () => {
+    expect(resolveOverride(undefined, 'abc1234')).toBeUndefined()
+    expect(resolveOverride({}, 'abc1234')).toBeUndefined()
+  })
+
+  test('matches an exact SHA', () => {
+    expect(resolveOverride(overrides, 'abc1234')?.body).toBe('reworded')
+  })
+
+  test('matches a configured SHA prefix against a longer commit hash', () => {
+    expect(resolveOverride(overrides, 'abc1234def5678')?.body).toBe('reworded')
+  })
+
+  test('does not match an unrelated hash', () => {
+    expect(resolveOverride(overrides, '9999999')).toBeUndefined()
+  })
+})
+
+// ─── extractImpacts: the changelog-text overlay ───────────────────
+
+describe('extractImpacts — commit-body overlay', () => {
+  const featCore = Git.Memory.commit('feat(core): original wording', {
+    hash: Git.Sha.make('abc1234def5678'),
+  })
+  const breakingCore = Git.Memory.commit('feat(core)!: original breaking', {
+    hash: Git.Sha.make('beef123'),
+  })
+
+  test('rewrites the rendered description for a matching SHA', () => {
+    const impacts = runImpacts(featCore, { abc1234def5678: { body: 'corrected wording' } })
+    expect(impacts).toHaveLength(1)
+    expect(impacts[0]!.commit.forScope('core').description).toBe('corrected wording')
+  })
+
+  test('leaves the description untouched without a matching override', () => {
+    const impacts = runImpacts(featCore, { '9999999': { body: 'should not apply' } })
+    expect(impacts[0]!.commit.forScope('core').description).toBe('original wording')
+  })
+
+  test('a body override leaves the scope, type, and bump unchanged', () => {
+    const without = runImpacts(featCore)
+    const withOverride = runImpacts(featCore, { abc1234def5678: { body: 'corrected wording' } })
+    const project = (impacts: ReturnType<typeof runImpacts>) =>
+      impacts.map((impact) => ({
+        scope: impact.scope,
+        bump: impact.bump,
+        type: impact.commit.forScope(impact.scope).type.value,
+        breaking: impact.commit.forScope(impact.scope).breaking,
+      }))
+    expect(project(withOverride)).toEqual(project(without))
+  })
+
+  test('a non-breaking override body cannot downgrade a breaking commit', () => {
+    const impacts = runImpacts(breakingCore, { beef123: { body: 'totally innocuous wording' } })
+    expect(impacts[0]!.bump).toBe('major')
+    expect(impacts[0]!.commit.forScope('core').breaking).toBe(true)
+    expect(impacts[0]!.commit.forScope('core').description).toBe('totally innocuous wording')
+  })
+
+  test('matches the override by SHA prefix', () => {
+    // commit hash is 'abc1234def5678'; override is keyed by its 7-char prefix.
+    const impacts = runImpacts(featCore, { abc1234: { body: 'prefix matched' } })
+    expect(impacts[0]!.commit.forScope('core').description).toBe('prefix matched')
+  })
+})

--- a/packages/release/src/api/analyzer/commit-override.ts
+++ b/packages/release/src/api/analyzer/commit-override.ts
@@ -1,0 +1,30 @@
+/**
+ * SHA-keyed changelog-text overlay — the analyzer half of commit-body overrides.
+ *
+ * The config layer ({@link ../config.js}) owns the `commitOverrides` schema and
+ * its read-time breaking-change guard; this module owns *applying* a validated
+ * override to a commit's rendered description. Resolution uses the same SHA-prefix
+ * semantics (`hash.startsWith(prefix)`) the analyzer already uses for commit
+ * boundaries, so an override key behaves like every other commit reference here.
+ */
+
+import type { CommitOverride, CommitOverrides } from '../config.js'
+
+/**
+ * Resolve the changelog-text override (if any) for a commit hash.
+ *
+ * A configured key matches when it is a prefix of the commit hash, mirroring
+ * git's short-SHA references. The first configured key that matches wins;
+ * unambiguous, non-overlapping prefixes are expected (a stale override that
+ * matches nothing is surfaced separately as a doctor warning).
+ */
+export const resolveOverride = (
+  overrides: CommitOverrides | undefined,
+  hash: string,
+): CommitOverride | undefined => {
+  if (!overrides) return undefined
+  for (const [sha, override] of Object.entries(overrides)) {
+    if (hash.startsWith(sha)) return override
+  }
+  return undefined
+}

--- a/packages/release/src/api/analyzer/version.ts
+++ b/packages/release/src/api/analyzer/version.ts
@@ -7,7 +7,8 @@ import type { Candidate } from '../version/models/candidate.js'
 import { CandidateSchema } from '../version/models/candidate.js'
 import type { Ephemeral } from '../version/models/ephemeral.js'
 import { EphemeralSchema } from '../version/models/ephemeral.js'
-import type { ConventionalCommitTypeImpact } from '../config.js'
+import type { CommitOverrides, ConventionalCommitTypeImpact } from '../config.js'
+import { resolveOverride } from './commit-override.js'
 import { ReleaseCommit } from './models/commit.js'
 
 /**
@@ -49,10 +50,17 @@ const decodeExactPin = S.decodeUnknownOption(Pkg.Pin.Exact.FromString)
  * Parses the commit message as conventional commit and returns
  * which packages are affected and what bump type each needs.
  * Stores the full ReleaseCommit (not flattened per-scope).
+ *
+ * When a SHA-keyed changelog-text override matches `gitCommit.hash`, only the
+ * stored commit's rendered description is rewritten (via
+ * {@link ConventionalCommits.Commit.withDescription}); every bump below is still
+ * derived from the original parse, so type/scope/breaking/bump are provably
+ * untouched by any override.
  */
 export const extractImpacts = (
   gitCommit: Git.Commit,
   resolvedConventionalCommitTypes: ResolvedConventionalCommitTypes,
+  commitOverrides?: CommitOverrides,
 ): Effect.Effect<CommitImpact[]> =>
   Effect.gen(function* () {
     // Extract the subject line via the shared @kitz/git primitive, so version
@@ -71,11 +79,17 @@ export const extractImpacts = (
     }
 
     const parsedCC = parseResult.success
+    // Changelog-text overlay: a matching override replaces only the rendered
+    // description. The parsed header (type/scope/breaking) — and therefore every
+    // bump computed from `parsedCC` below — is left exactly as parsed.
+    const override = resolveOverride(commitOverrides, gitCommit.hash)
     const releaseCommit = ReleaseCommit.make({
       hash: gitCommit.hash,
       author: gitCommit.author,
       date: gitCommit.date,
-      message: parsedCC,
+      message: override
+        ? ConventionalCommits.Commit.withDescription(parsedCC, override.body)
+        : parsedCC,
     })
     const impacts: CommitImpact[] = []
 

--- a/packages/release/src/api/config.test.ts
+++ b/packages/release/src/api/config.test.ts
@@ -99,3 +99,68 @@ describe('release config package mappings', () => {
     })
   })
 })
+
+describe('release config commit overrides', () => {
+  test('defaults to an empty map when omitted', () => {
+    const config = Config.decodeSync({})
+    expect(config.commitOverrides).toEqual({})
+  })
+
+  test('accepts a SHA-keyed changelog-text override', () => {
+    const config = Config.decodeSync({
+      commitOverrides: {
+        abc1234: { body: 'fix(core): correct the off-by-one', reason: 'original typo' },
+      },
+    })
+
+    expect(config.commitOverrides).toEqual({
+      abc1234: { body: 'fix(core): correct the off-by-one', reason: 'original typo' },
+    })
+  })
+
+  test('reason is optional', () => {
+    const config = Config.decodeSync({
+      commitOverrides: { abc1234: { body: 'reworded changelog line' } },
+    })
+    expect(config.commitOverrides?.['abc1234']?.body).toBe('reworded changelog line')
+    expect(config.commitOverrides?.['abc1234']?.reason).toBeUndefined()
+  })
+
+  test('rejects a body carrying a breaking-change marker, naming the SHA', () => {
+    expect(() =>
+      Config.decodeSync({
+        commitOverrides: { abc1234: { body: 'feat!: sneak in a breaking change' } },
+      }),
+    ).toThrow(/commit override abc1234: breaking-change content is not supported/)
+  })
+
+  test('rejects a BREAKING CHANGE footer token in the body', () => {
+    expect(() =>
+      Config.decodeSync({
+        commitOverrides: {
+          abc1234: { body: 'BREAKING-CHANGE: removed the old API' },
+        },
+      }),
+    ).toThrow(/breaking-change content is not supported/)
+  })
+
+  test('rejects an empty body', () => {
+    expect(() => Config.decodeSync({ commitOverrides: { abc1234: { body: '   ' } } })).toThrow(
+      /commit override abc1234: body must not be empty/,
+    )
+  })
+
+  test('rejects a multi-line body', () => {
+    expect(() =>
+      Config.decodeSync({
+        commitOverrides: { abc1234: { body: 'line one\nline two' } },
+      }),
+    ).toThrow(/commit override abc1234: body must be a single line/)
+  })
+
+  test('rejects an implausibly short / non-hex SHA key', () => {
+    expect(() =>
+      Config.decodeSync({ commitOverrides: { 'nope!': { body: 'reworded' } } }),
+    ).toThrow()
+  })
+})

--- a/packages/release/src/api/config.ts
+++ b/packages/release/src/api/config.ts
@@ -1,5 +1,6 @@
 import { PlatformError, FileSystem } from 'effect'
 import { Conf } from '@kitz/conf'
+import { ConventionalCommits } from '@kitz/conventional-commits'
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
 import { Semver } from '@kitz/semver'
@@ -75,6 +76,58 @@ export const resolveConventionalCommitTypes = (
 }
 
 /**
+ * A single SHA-keyed changelog-text override.
+ *
+ * `body` replaces the rendered changelog/notes description for the matching
+ * commit and nothing else: type, scope, breaking, the computed version bump,
+ * and package attribution are all derived from the commit's parsed header,
+ * which the overlay never touches. `reason` is an optional free-form note
+ * (a mandatory-reason audit model lands with the later semantic-override phase).
+ */
+const CommitOverride = Schema.Struct({
+  body: Schema.String,
+  reason: Schema.optional(Schema.String),
+})
+export type CommitOverride = typeof CommitOverride.Type
+
+/**
+ * Commit-override SHA keys: a git short (≥7) or full (40) hex prefix. A floor of
+ * 7 hex characters matches git's default short SHA and keeps a tiny prefix from
+ * silently matching many commits.
+ */
+const CommitOverrideSha = Schema.String.check(Schema.isPattern(/^[0-9a-f]{7,40}$/i))
+
+/**
+ * Map of commit SHA-prefix → changelog-text override, validated on read.
+ *
+ * Each body is rejected at config-load time (a hard error with non-zero exit)
+ * when it is empty, spans multiple lines, or carries a breaking-change signal —
+ * a leading `!`, a breaking header, or a `BREAKING CHANGE:` / `BREAKING-CHANGE:`
+ * footer (see {@link ConventionalCommits.BreakingChange.hasSignal}). The
+ * breaking-change guard is the deliberate seam later phases widen to admit
+ * semantic overrides behind a mandatory-reason + audit model.
+ */
+const CommitOverridesSchema = Schema.Record(CommitOverrideSha, CommitOverride).check(
+  Schema.makeFilter((overrides) => {
+    const issues: Array<Schema.FilterIssue> = []
+    for (const [sha, override] of Object.entries(overrides)) {
+      const reject = (detail: string): void => {
+        issues.push({ path: [sha, 'body'], issue: `commit override ${sha}: ${detail}` })
+      }
+      if (override.body.trim().length === 0) {
+        reject('body must not be empty')
+      } else if (override.body.includes('\n')) {
+        reject('body must be a single line')
+      } else if (ConventionalCommits.BreakingChange.hasSignal(override.body)) {
+        reject('breaking-change content is not supported')
+      }
+    }
+    return issues
+  }),
+)
+export type CommitOverrides = typeof CommitOverridesSchema.Type
+
+/**
  * Release configuration schema (input from file).
  */
 export class Config extends Schema.Class<Config>('Config')({
@@ -113,6 +166,15 @@ export class Config extends Schema.Class<Config>('Config')({
     Schema.optionalKey,
     Schema.withDecodingDefaultKey(Effect.sync(defaultConventionalCommitSettings)),
   ),
+  /**
+   * SHA-keyed changelog-text overlays. Each entry rewrites only the rendered
+   * changelog description for the matching commit; release semantics are never
+   * affected. Validated on read (see {@link CommitOverridesSchema}).
+   */
+  commitOverrides: CommitOverridesSchema.pipe(
+    Schema.optionalKey,
+    Schema.withDecodingDefaultKey(Effect.sync(() => ({}) as CommitOverrides)),
+  ),
   /** Lint configuration */
   lint: Schema.optional(LintConfig.Config),
 }) {
@@ -142,6 +204,8 @@ export class ResolvedConfig extends Schema.Class<ResolvedConfig>('ResolvedConfig
   operator: ResolvedOperator,
   /** Resolved type→impact mapping (standard defaults merged with user customTypes). */
   resolvedConventionalCommitTypes: ResolvedTypesSchema,
+  /** SHA-keyed changelog-text overlays (validated at load). */
+  commitOverrides: CommitOverridesSchema,
   lint: LintConfig.ResolvedConfig,
 }) {
   static is = Schema.is(ResolvedConfig)
@@ -186,6 +250,12 @@ const ConfigFile = Conf.File.define({
  *   operator: {
  *     releaseScript: 'release',
  *     prepareScripts: [],
+ *   },
+ *   // Correct the rendered changelog text for a specific commit by SHA prefix.
+ *   // Changelog text only — never affects type/scope/breaking/bump. A `body`
+ *   // carrying a breaking-change signal is rejected at config-load time.
+ *   commitOverrides: {
+ *     e348957: { body: 'fix(core): correct the off-by-one in the cursor', reason: 'typo in original' },
  *   },
  *   lint: {
  *     rules: {
@@ -248,6 +318,7 @@ export const load = (
       resolvedConventionalCommitTypes: resolveConventionalCommitTypes(
         conventionalCommitSettings.types ?? {},
       ),
+      commitOverrides: options?.commitOverrides ?? fileConfig.commitOverrides ?? {},
       lint: LintConfig.resolveConfig({
         defaults: options?.lint?.defaults ?? fileConfig.lint?.defaults,
         rules: options?.lint?.rules ?? fileConfig.lint?.rules,

--- a/packages/release/src/api/notes/generate.test.ts
+++ b/packages/release/src/api/notes/generate.test.ts
@@ -49,6 +49,33 @@ describe('Notes.generate', () => {
     expect(result.notes[0]!.notes.markdown).not.toContain('newer change should be excluded')
   })
 
+  test('applies a SHA-keyed commit-body override to the rendered notes', async () => {
+    const hash = Git.Sha.make('abc1234')
+
+    const result = await Effect.runPromise(
+      generate({
+        packages,
+        tags: [],
+        resolvedConventionalCommitTypes: defaultTypes,
+        commitOverrides: { abc1234: { body: 'correct the wording for the core feature' } },
+      }).pipe(
+        Effect.provide(
+          Git.Memory.make({
+            commits: [Git.Memory.commit('feat(core): original muddled wording', { hash })],
+          }),
+        ),
+      ),
+    )
+
+    expect(result.notes).toHaveLength(1)
+    const markdown = result.notes[0]!.notes.markdown
+    expect(markdown).toContain('correct the wording for the core feature')
+    expect(markdown).not.toContain('original muddled wording')
+    // The override is changelog text only: the bump is still the original `feat`
+    // (minor), even though the replacement text reads like a `fix`.
+    expect(result.notes[0]!.bump).toBe('minor')
+  })
+
   test('respects tag until boundaries when building package notes', async () => {
     const result = await Effect.runPromise(
       generate({

--- a/packages/release/src/api/notes/generate.ts
+++ b/packages/release/src/api/notes/generate.ts
@@ -50,6 +50,9 @@ export interface GenerateOptions {
   readonly filter?: readonly string[] | undefined
   /** Resolved type→bump mapping from config */
   readonly resolvedConventionalCommitTypes: ResolvedConventionalCommitTypes
+  /** SHA-keyed changelog-text overrides. Rewrites only rendered descriptions;
+   *  never affects bump/type/scope/breaking. */
+  readonly commitOverrides?: import('../config.js').CommitOverrides | undefined
 }
 
 /**
@@ -170,7 +173,7 @@ export const generate = (
 
       const impactsByCommit = yield* Effect.all(
         boundedCommits.map((commit) =>
-          extractImpacts(commit, options.resolvedConventionalCommitTypes),
+          extractImpacts(commit, options.resolvedConventionalCommitTypes, options.commitOverrides),
         ),
         { concurrency: 'unbounded' },
       )

--- a/packages/release/src/api/planner/publish-contract.test.ts
+++ b/packages/release/src/api/planner/publish-contract.test.ts
@@ -36,6 +36,7 @@ const resolvedConfig = ResolvedConfig.make({
     prepareCommands: [],
   }),
   resolvedConventionalCommitTypes: {},
+  commitOverrides: {},
   lint: LintConfig.resolveConfig({}),
 })
 

--- a/packages/release/src/cli/commands/command-workspace.test.ts
+++ b/packages/release/src/cli/commands/command-workspace.test.ts
@@ -28,6 +28,7 @@ const makeResolvedConfig = (
       prepareCommands: [],
     }),
     resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+    commitOverrides: {},
     lint: Api.Lint.resolveConfig({}),
   })
 

--- a/packages/release/src/cli/commands/doctor.ts
+++ b/packages/release/src/cli/commands/doctor.ts
@@ -185,6 +185,7 @@ export const doctor = Command.make(
         packages,
         tags,
         resolvedConventionalCommitTypes: config.resolvedConventionalCommitTypes,
+        commitOverrides: config.commitOverrides,
       })
       const currentBranch = yield* git.getCurrentBranch()
       const diffRemote = resolveDiffRemote(config, args.remote)

--- a/packages/release/src/cli/commands/explain.ts
+++ b/packages/release/src/cli/commands/explain.ts
@@ -60,6 +60,7 @@ export const explain = Command.make(
           packages: [...workspace.packages],
           tags,
           resolvedConventionalCommitTypes: workspace.config.resolvedConventionalCommitTypes,
+          commitOverrides: workspace.config.commitOverrides,
         }),
         {
           packages: workspace.packages,

--- a/packages/release/src/cli/commands/forecast-lib.test.ts
+++ b/packages/release/src/cli/commands/forecast-lib.test.ts
@@ -25,6 +25,7 @@ const makeResolvedConfig = (
       prepareCommands: [],
     }),
     resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+    commitOverrides: {},
     lint: Api.Lint.resolveConfig({}),
   })
 
@@ -122,6 +123,7 @@ describe('forecast-lib', () => {
       packages: [pkg],
       tags,
       resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+      commitOverrides: {},
     })
     expect(forecastArgs).toEqual({
       analysis,

--- a/packages/release/src/cli/commands/forecast-lib.ts
+++ b/packages/release/src/cli/commands/forecast-lib.ts
@@ -80,6 +80,7 @@ export function buildForecastInput(
       packages,
       tags: resolvedTags,
       resolvedConventionalCommitTypes: config.resolvedConventionalCommitTypes,
+      commitOverrides: config.commitOverrides,
     })
     const recon = yield* explore
     const renderedForecast = forecast(analysis, recon)

--- a/packages/release/src/cli/commands/notes.ts
+++ b/packages/release/src/cli/commands/notes.ts
@@ -76,6 +76,7 @@ export const notes = Command.make(
         until: Option.getOrUndefined(until),
         filter: Option.isSome(pkg) ? [pkg.value] : undefined,
         resolvedConventionalCommitTypes: workspace.config.resolvedConventionalCommitTypes,
+        commitOverrides: workspace.config.commitOverrides,
       })
 
       if (result.notes.length === 0) {

--- a/packages/release/src/cli/commands/plan.ts
+++ b/packages/release/src/cli/commands/plan.ts
@@ -103,6 +103,7 @@ export const plan = Command.make(
         filter: filterPackages,
         exclude: excludePackages,
         resolvedConventionalCommitTypes: workspace.config.resolvedConventionalCommitTypes,
+        commitOverrides: workspace.config.commitOverrides,
       })
       const ctx = { packages }
 

--- a/packages/release/src/cli/commands/pr.ts
+++ b/packages/release/src/cli/commands/pr.ts
@@ -71,6 +71,7 @@ const preparePrTitle = Effect.gen(function* () {
     tags,
     since: `${remote}/${pullRequest.base.ref}`,
     resolvedConventionalCommitTypes: config.resolvedConventionalCommitTypes,
+    commitOverrides: config.commitOverrides,
   })
   const projectedHeader = Api.ProjectedSquashCommit.renderHeader({
     impacts: Api.ProjectedSquashCommit.collectScopeImpacts(analysis, { primaryOnly: true }),

--- a/packages/release/src/cli/commands/ui-app.test.tsx
+++ b/packages/release/src/cli/commands/ui-app.test.tsx
@@ -29,6 +29,7 @@ const config = Api.Config.ResolvedConfig.make({
     prepareCommands: [],
   }),
   resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+  commitOverrides: {},
   lint: Api.Lint.resolveConfig({}),
 })
 

--- a/packages/release/src/cli/commands/ui-atoms.ts
+++ b/packages/release/src/cli/commands/ui-atoms.ts
@@ -104,6 +104,7 @@ export const loadWorkspaceContext = Effect.gen(function* () {
     packages,
     tags,
     resolvedConventionalCommitTypes: config.resolvedConventionalCommitTypes,
+    commitOverrides: config.commitOverrides,
   }).pipe(Effect.withSpan('analyze'))
   const diffRemote = resolveDiffRemote(config)
   const pullRequestAttempt = yield* Api.Explorer.resolvePullRequest().pipe(Effect.result)

--- a/packages/release/src/cli/commands/ui-model.test.ts
+++ b/packages/release/src/cli/commands/ui-model.test.ts
@@ -27,6 +27,7 @@ const config = Api.Config.ResolvedConfig.make({
     prepareCommands: [],
   }),
   resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+  commitOverrides: {},
   lint: Api.Lint.resolveConfig({}),
 })
 

--- a/packages/release/src/cli/lint-rule-config.test.ts
+++ b/packages/release/src/cli/lint-rule-config.test.ts
@@ -21,6 +21,7 @@ const makeResolvedConfig = (
       prepareCommands: [],
     }),
     resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+    commitOverrides: {},
     lint: Api.Lint.ResolvedConfig.make({
       defaults: Api.Lint.ResolvedRuleDefaults.make({
         enabled: 'auto',

--- a/packages/release/src/cli/pr-preview.coverage.test.ts
+++ b/packages/release/src/cli/pr-preview.coverage.test.ts
@@ -52,6 +52,7 @@ const makeConfig = (
       prepareCommands: ['bun run release:build'],
     }),
     resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+    commitOverrides: {},
     lint: Api.Lint.resolveConfig({
       defaults: Api.Lint.RuleDefaults.make({
         enabled: 'auto',
@@ -770,6 +771,7 @@ describe('pr preview coverage', () => {
           prepareCommands: ['bun run release:build'],
         }),
         resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+        commitOverrides: {},
         lint: Api.Lint.resolveConfig({
           defaults: Api.Lint.RuleDefaults.make({
             enabled: 'auto',

--- a/packages/release/src/cli/pr-preview.test.ts
+++ b/packages/release/src/cli/pr-preview.test.ts
@@ -93,6 +93,7 @@ const makeResolvedConfig = (options?: {
       prepareCommands: ['bun run release:build'],
     }),
     resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
+    commitOverrides: {},
     lint: Api.Lint.resolveConfig({
       ...(options?.diffRemote
         ? {

--- a/packages/release/src/cli/pr-preview.ts
+++ b/packages/release/src/cli/pr-preview.ts
@@ -436,6 +436,7 @@ export const runPrPreview = (
       tags,
       since: `${diffRemote}/${pullRequest.base.ref}`,
       resolvedConventionalCommitTypes: config.resolvedConventionalCommitTypes,
+      commitOverrides: config.commitOverrides,
     })
     const projectedSquashCommit = Api.ProjectedSquashCommit.preview({
       actualTitle: pullRequest.title,


### PR DESCRIPTION
Closes #223.

## What & why

Shared git history is effectively immutable in a team, so a mistaken commit
message has no clean correction path. This adds **SHA-keyed commit-body
overrides** to `release.config.ts` that overlay corrected **changelog text**
onto a specific commit — with **zero impact on release semantics**. It is the
deliberately narrow beachhead for a later SHA-keyed history-overlay capability;
semantic overrides (type/scope/breaking) remain out of scope and land behind a
mandatory-reason + audit model in a future phase.

```ts
// release.config.ts
commitOverrides: {
  e348957: { body: 'fix(core): correct the off-by-one in the cursor', reason: 'typo in original' },
}
```

## Layering (strict-clean stack — each primitive owns a bounded context)

**`@kitz/conventional-commits`** (owns breaking-change grammar):
- `BreakingChange.hasSignal(text)` — the read-time guard's core predicate.
  Detects a leading `!`, a breaking header (via the canonical `Title` parse +
  `facets`), or a `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer token. Footer
  tokens are sourced from `Footer.StandardToken`, so the predicate stays in
  lock-step with the grammar instead of re-deriving it via ad-hoc regex.
- `Commit.withDescription(commit, text)` — returns a copy with only the rendered
  description replaced; type/scope/breaking/body/footers are preserved verbatim.

**`@kitz/release` config** (`config.ts`): the new `commitOverrides` area —
`Record<sha-prefix, { body, reason? }>`. Validated **on read**: the breaking-
change guard is a schema `.check(...)` (run by `Conf.File.load`'s decode), so a
disallowed body is a hard `SchemaError` with a non-zero exit.

**`@kitz/release` analyzer**: the SHA overlay (`analyzer/commit-override.ts` +
`extractImpacts`). Resolution prefix-matches `commit.hash`; on a match, the
stored `ReleaseCommit`'s description is swapped via `withDescription`. **Every
bump is computed from the original parse**, so the override can never touch
type/scope/breaking/bump.

Release stays thin composition: each `analyze()` / `Notes.generate()` call site
threads `config.commitOverrides` (optional field, additive).

## Read-time guard

At config load, an override `body` is rejected with a non-zero exit when it:
- carries a breaking-change signal → `commit override <sha>: breaking-change content is not supported`
- is empty / whitespace-only → `commit override <sha>: body must not be empty`
- spans multiple lines → `commit override <sha>: body must be a single line`

This guard is the seam later phases widen deliberately (with audit) to admit
semantic overrides.

## Acceptance criteria

- [x] An override `body` replaces the rendered changelog text for the matching
      commit — verified end-to-end through `Notes.generate` (rendered markdown)
      and applied in `analyze` (→ `forecast`).
- [x] A `body` with a breaking-change marker is rejected at config-read time
      with a clear error + non-zero exit.
- [x] **`type`/`scope`/`breaking` and the computed bump are provably unchanged
      by any body override** — direct test, plus the strongest case: a
      non-breaking override body **cannot downgrade a breaking commit's `major`**,
      and an override that reads like a `fix` leaves a `feat`'s `minor` intact.
- [x] Prefix-SHA matching works; an override SHA not in range is a no-op.
- [x] Tests cover: visible reword in notes, breaking-marker rejection on read,
      no-op/unknown SHA, and prefix matching.

## Design decision (documented per the issue's "make the call" guidance)

The issue says "apply in `analyze.ts` right after `getCommitsSince`." But
`release notes` flows through a **separate** `notes/generate.ts` pipeline that
also calls `getCommitsSince` + `extractImpacts`. Applying only in `analyze.ts`
would leave `release notes` un-overridden (failing acceptance criterion 1).
I apply once at the **shared `extractImpacts` chokepoint** — the single seam
both `analyze` (forecast/plan/pr) and `generate` (notes) flow through — covering
both with no duplication and no semantic drift between commands.

## Deferred (surfaced, not dropped)

**Stale-override doctor warning** is deferred to a fast-follow (the issue marks
it optional). Detecting it *correctly* requires the full in-range commit hash
set, which `analyze()` does not expose (only impacting commits reach
`Analysis`). A check against `Analysis.impacts[].commits` would false-positive
on valid overrides of non-impacting commits (e.g. a `chore`). Surfacing it
properly is a deliberate `Analysis`-contract change better made with the
semantic-override phase than smuggled into this beachhead.

## Non-goals respected

No changes to type/scope/breaking, the version bump, or package attribution;
no ignoring/dropping commits; `reason` stays optional this phase.

## Verification

- `bun run check:types` — 0 errors across all packages.
- `bun run check:lint` — clean (`@kitz/conventional-commits`, `@kitz/release`).
- Full `@kitz/release` suite: 744 pass, 1 skip (pre-existing `@kitz/oak` #220
  flake), 0 fail; new `@kitz/conventional-commits` tests green.
