### PR TITLE
feat(json, release): RFC 8785 digest canonicalization + plan lifecycle integrity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -449,6 +449,7 @@
         "@kitz/fs": "workspace:*",
         "@kitz/git": "workspace:*",
         "@kitz/github": "workspace:*",
+        "@kitz/json": "workspace:*",
         "@kitz/mod": "workspace:*",
         "@kitz/monorepo": "workspace:*",
         "@kitz/npm-registry": "workspace:*",

--- a/packages/json/src/_.test.ts
+++ b/packages/json/src/_.test.ts
@@ -2,6 +2,7 @@ import { Schema } from 'effect'
 import { describe, expect, test } from 'bun:test'
 import * as JsonModule from './_.js'
 import {
+  canonicalize,
   fromString,
   is,
   isObject,
@@ -39,5 +40,118 @@ describe('json', () => {
     expect(isPrimitive(Symbol('x'))).toBe(false)
     expect(isObject({ ok: true })).toBe(true)
     expect(isObject(['not-an-object'])).toBe(false)
+  })
+})
+
+describe('canonicalize (RFC 8785 JCS)', () => {
+  // Reference vectors are the published RFC 8785 conformance suite
+  // (cyberphone/json-canonicalization `testdata`), embedded byte-for-byte as
+  // pure-ASCII \u escapes so every non-printable / combining code point stays
+  // reviewable and the expectations cannot drift on copy/paste.
+
+  test('reference vector: values (number serialization, string escaping, key order)', () => {
+    const input = fromString(
+      '{\u000a  "numbers": [333333333.33333329, 1E30, 4.50, 2e-3, 0.000000000000000000000000001],\u000a  "string": "\\u20ac$\\u000F\\u000aA\'\\u0042\\u0022\\u005c\\\\\\"\\/",\u000a  "literals": [null, true, false]\u000a}',
+    )
+    expect(canonicalize(input)).toBe(
+      '{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"\u20ac$\\u000f\\nA\'B\\"\\\\\\\\\\"/"}',
+    )
+  })
+
+  test('reference vector: french (locale-independent key order)', () => {
+    const input = fromString(
+      '{\u000a  "peach": "This sorting order",\u000a  "p\u00e9ch\u00e9": "is wrong according to French",\u000a  "p\u00eache": "but canonicalization MUST",\u000a  "sin":   "ignore locale"\u000a}\u000a',
+    )
+    expect(canonicalize(input)).toBe(
+      '{"peach":"This sorting order","p\u00e9ch\u00e9":"is wrong according to French","p\u00eache":"but canonicalization MUST","sin":"ignore locale"}',
+    )
+  })
+
+  test('reference vector: weird (UTF-16 code-unit order + control escaping)', () => {
+    const input = fromString(
+      '{\u000a  "\\u20ac": "Euro Sign",\u000a  "\\r": "Carriage Return",\u000a  "\\u000a": "Newline",\u000a  "1": "One",\u000a  "\\u0080": "Control\\u007f",\u000a  "\\ud83d\\ude02": "Smiley",\u000a  "\\u00f6": "Latin Small Letter O With Diaeresis",\u000a  "\\ufb33": "Hebrew Letter Dalet With Dagesh",\u000a  "</script>": "Browser Challenge"\u000a}\u000a',
+    )
+    expect(canonicalize(input)).toBe(
+      '{"\\n":"Newline","\\r":"Carriage Return","1":"One","</script>":"Browser Challenge","\u0080":"Control\u007f","\u00f6":"Latin Small Letter O With Diaeresis","\u20ac":"Euro Sign","\ud83d\ude02":"Smiley","\ufb33":"Hebrew Letter Dalet With Dagesh"}',
+    )
+  })
+
+  test('reference vector: unicode (keys/values are NOT NFC-normalized)', () => {
+    const input = fromString('{\u000a  "Unnormalized Unicode":"A\\u030a"\u000a}\u000a')
+    expect(canonicalize(input)).toBe('{"Unnormalized Unicode":"A\u030a"}')
+  })
+
+  test('digest({a,b}) === digest({b,a}) — output is independent of key order', () => {
+    expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }))
+    expect(canonicalize({ a: 1, b: 2 })).toBe('{"a":1,"b":2}')
+    const forward = { x: 1, y: 2, z: 3, nested: { p: 1, q: 2 } }
+    const reverse = { nested: { q: 2, p: 1 }, z: 3, y: 2, x: 1 }
+    expect(canonicalize(forward)).toBe(canonicalize(reverse))
+  })
+
+  test('orders keys by UTF-16 code units, not locale collation', () => {
+    // localeCompare in many locales orders case-insensitively ('a' before 'Z')
+    // and files accented letters next to their base. Code-unit order is strict:
+    // 'Z'(U+005A) < 'a'(U+0061); 'z'(U+007A) < U+00E4 (a-umlaut, '\u00e4').
+    expect(canonicalize({ a: 1, Z: 2 })).toBe('{"Z":2,"a":1}')
+    expect(canonicalize({ z: 1, ['\u00e4']: 2 })).toBe('{"z":1,"\u00e4":2}')
+  })
+
+  test('orders keys by UTF-16 code units, not Unicode code points (surrogate pairs)', () => {
+    // U+1F602 has UTF-16 lead unit U+D83D; U+FB33 is a single unit.
+    // Code-unit order: D83D < FB33 -> the supplementary code point sorts first.
+    // Code-point order (1F602 > FB33) would reverse them.
+    expect(canonicalize({ ['\ufb33']: 1, ['\ud83d\ude02']: 2 })).toBe(
+      '{"\ud83d\ude02":2,"\ufb33":1}',
+    )
+  })
+
+  test('does not NFC-normalize keys (decomposed and precomposed stay distinct)', () => {
+    const nfc = '\u00e9' // precomposed e-acute (single code point)
+    const nfd = 'e\u0301' // decomposed (e + combining acute accent)
+    // Both distinct keys survive as two members; NFC normalization would
+    // collide them into one. Code-unit order puts the decomposed form first
+    // ('e' = U+0065 < U+00E9).
+    expect(canonicalize({ [nfc]: 1, [nfd]: 2 })).toBe('{"e\u0301":2,"\u00e9":1}')
+    expect(canonicalize({ [nfc]: 0 })).not.toBe(canonicalize({ [nfd]: 0 }))
+  })
+
+  test('serializes numbers per RFC 8785 (ECMAScript Number::toString)', () => {
+    expect(canonicalize(1e30)).toBe('1e+30')
+    expect(canonicalize(1e-27)).toBe('1e-27')
+    expect(canonicalize(0.002)).toBe('0.002')
+    expect(canonicalize(4.5)).toBe('4.5')
+    expect(canonicalize(100)).toBe('100')
+    expect(canonicalize(-0)).toBe('0') // negative zero normalized to 0
+    expect(canonicalize([1, 2.5, -3])).toBe('[1,2.5,-3]')
+  })
+
+  test('rejects values that are not representable JSON', () => {
+    expect(() => canonicalize(Number.NaN)).toThrow()
+    expect(() => canonicalize(Number.POSITIVE_INFINITY)).toThrow()
+    expect(() => canonicalize(Number.NEGATIVE_INFINITY)).toThrow()
+    expect(() => canonicalize(1n)).toThrow() // bigint is not JSON
+    expect(() => canonicalize(undefined)).toThrow()
+  })
+
+  test('escapes strings with short escapes and lowercase \\u for other controls', () => {
+    expect(canonicalize('\b\t\n\f\r')).toBe('"\\b\\t\\n\\f\\r"')
+    expect(canonicalize('\u0000\u0001\u001f')).toBe('"\\u0000\\u0001\\u001f"')
+    expect(canonicalize('"\\')).toBe('"\\"\\\\"')
+    expect(canonicalize('/')).toBe('"/"') // forward slash is NOT escaped
+  })
+
+  test('drops undefined-valued keys and renders array holes as null', () => {
+    expect(canonicalize({ a: 1, b: undefined, c: 3 })).toBe('{"a":1,"c":3}')
+    expect(canonicalize([1, undefined, 3])).toBe('[1,null,3]')
+    expect(canonicalize({ a: 1, f: () => 1 })).toBe('{"a":1}')
+  })
+
+  test('honors toJSON (e.g. Date) like JSON.stringify', () => {
+    expect(canonicalize({ at: new Date(0) })).toBe('{"at":"1970-01-01T00:00:00.000Z"}')
+  })
+
+  test('canonicalize is reachable through the Json namespace', () => {
+    expect(JsonModule.Json.canonicalize).toBe(canonicalize)
   })
 })

--- a/packages/json/src/_.test.ts
+++ b/packages/json/src/_.test.ts
@@ -147,8 +147,23 @@ describe('canonicalize (RFC 8785 JCS)', () => {
     expect(canonicalize({ a: 1, f: () => 1 })).toBe('{"a":1}')
   })
 
+  test('renders sparse-array holes as null (never an invalid `,,`)', () => {
+    // A true hole (not an explicit `undefined`): `.map` would skip it and emit
+    // `[1,,3]`, which is not valid JSON. JSON.stringify renders holes as null.
+    const sparse = [1]
+    sparse[2] = 3
+    expect(canonicalize(sparse)).toBe('[1,null,3]')
+    expect(canonicalize(sparse)).toBe(JSON.stringify(sparse))
+  })
+
   test('honors toJSON (e.g. Date) like JSON.stringify', () => {
     expect(canonicalize({ at: new Date(0) })).toBe('{"at":"1970-01-01T00:00:00.000Z"}')
+  })
+
+  test('forwards the member key to toJSON, like JSON.stringify', () => {
+    const probe = { toJSON: (key: string) => key }
+    expect(canonicalize({ at: probe })).toBe('{"at":"at"}')
+    expect(canonicalize([probe])).toBe('["0"]') // array index is the key
   })
 
   test('canonicalize is reachable through the Json namespace', () => {

--- a/packages/json/src/json.ts
+++ b/packages/json/src/json.ts
@@ -142,3 +142,98 @@ export const fromString = S.decodeSync(Schema)
  * @category Serialization
  */
 export const toString = S.encodeSync(Schema)
+
+//
+//
+//
+//
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ • Canonicalization
+//
+//
+
+/** Compare two strings by UTF-16 code unit (RFC 8785 member ordering). */
+const compareCodeUnits = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
+/**
+ * Serialize one value, or return `undefined` when it has no JSON
+ * representation (matching `JSON.stringify`: `undefined`, functions, and
+ * symbols are absent). Throws for values that JSON cannot represent but that
+ * must not silently degrade in a digest (`NaN`/`Infinity`/`bigint`).
+ */
+const serialize = (input: unknown): string | undefined => {
+  // Honor `toJSON` (Date, Effect Inspectable, …) exactly like `JSON.stringify`.
+  const value =
+    input !== null &&
+    typeof input === 'object' &&
+    typeof (input as { toJSON?: unknown }).toJSON === 'function'
+      ? (input as { toJSON: (key: string) => unknown }).toJSON('')
+      : input
+
+  if (value === null) return 'null'
+
+  switch (typeof value) {
+    case 'boolean':
+      return value ? 'true' : 'false'
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new TypeError(`Cannot canonicalize the non-finite number ${String(value)}`)
+      }
+      // ECMAScript `Number::toString` is exactly RFC 8785 number serialization.
+      return JSON.stringify(value)
+    case 'string':
+      // `JSON.stringify` string escaping is exactly RFC 8785 string
+      // serialization: short escapes (\b \t \n \f \r), lowercase `\u` for
+      // other control characters, and no escaping of `/` or non-ASCII.
+      return JSON.stringify(value)
+    case 'bigint':
+      throw new TypeError('Cannot canonicalize a bigint')
+    case 'object': {
+      if (Array.isArray(value)) {
+        return `[${value.map((item) => serialize(item) ?? 'null').join(',')}]`
+      }
+      const record = value as Record<string, unknown>
+      const members: string[] = []
+      for (const key of Object.keys(record).sort(compareCodeUnits)) {
+        const serialized = serialize(record[key])
+        if (serialized === undefined) continue
+        members.push(`${JSON.stringify(key)}:${serialized}`)
+      }
+      return `{${members.join(',')}}`
+    }
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Canonicalize a JSON value to its RFC 8785 (JSON Canonicalization Scheme)
+ * serialization — a deterministic, byte-stable string suitable for hashing and
+ * signing.
+ *
+ * Object members are emitted sorted by UTF-16 code unit (NOT locale-sensitive
+ * collation, and keys are NOT Unicode-normalized). Numbers use the ECMAScript
+ * `Number::toString` form and strings use minimal JSON escaping, so the output
+ * is identical across machines and locales.
+ *
+ * `toJSON` is honored, so `Date` (and other inspectable values) serialize as
+ * under `JSON.stringify`. `undefined`-valued members are dropped and
+ * `undefined`/function/symbol array elements become `null`, also matching
+ * `JSON.stringify`. Throws on values with no JSON representation: a non-finite
+ * number, a `bigint`, or a bare `undefined`/function/symbol.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8785
+ *
+ * @example
+ * ```ts
+ * Json.canonicalize({ b: 2, a: 1 }) // '{"a":1,"b":2}'
+ * ```
+ *
+ * @category Serialization
+ */
+export const canonicalize = (value: unknown): string => {
+  const serialized = serialize(value)
+  if (serialized === undefined) {
+    throw new TypeError(`Cannot canonicalize a value of type ${typeof value}`)
+  }
+  return serialized
+}

--- a/packages/json/src/json.ts
+++ b/packages/json/src/json.ts
@@ -159,14 +159,18 @@ const compareCodeUnits = (a: string, b: string): number => (a < b ? -1 : a > b ?
  * representation (matching `JSON.stringify`: `undefined`, functions, and
  * symbols are absent). Throws for values that JSON cannot represent but that
  * must not silently degrade in a digest (`NaN`/`Infinity`/`bigint`).
+ *
+ * `key` is the member key (object property name, array index string, or `''`
+ * at the root) and is forwarded to `toJSON`, exactly as `JSON.stringify` does.
  */
-const serialize = (input: unknown): string | undefined => {
-  // Honor `toJSON` (Date, Effect Inspectable, …) exactly like `JSON.stringify`.
+const serialize = (input: unknown, key: string): string | undefined => {
+  // Honor `toJSON` (Date, Effect Inspectable, …) exactly like `JSON.stringify`:
+  // any value carrying a callable `toJSON` is replaced by `toJSON(key)`.
   const value =
     input !== null &&
-    typeof input === 'object' &&
+    (typeof input === 'object' || typeof input === 'function') &&
     typeof (input as { toJSON?: unknown }).toJSON === 'function'
-      ? (input as { toJSON: (key: string) => unknown }).toJSON('')
+      ? (input as { toJSON: (key: string) => unknown }).toJSON(key)
       : input
 
   if (value === null) return 'null'
@@ -189,14 +193,21 @@ const serialize = (input: unknown): string | undefined => {
       throw new TypeError('Cannot canonicalize a bigint')
     case 'object': {
       if (Array.isArray(value)) {
-        return `[${value.map((item) => serialize(item) ?? 'null').join(',')}]`
+        // Index loop, not `.map`: `.map` skips array holes, which would emit
+        // invalid `,,`. Holes and `undefined`/function/symbol elements become
+        // `null`, matching `JSON.stringify`.
+        const items: string[] = []
+        for (let index = 0; index < value.length; index++) {
+          items.push(serialize(value[index], String(index)) ?? 'null')
+        }
+        return `[${items.join(',')}]`
       }
       const record = value as Record<string, unknown>
       const members: string[] = []
-      for (const key of Object.keys(record).sort(compareCodeUnits)) {
-        const serialized = serialize(record[key])
+      for (const memberKey of Object.keys(record).sort(compareCodeUnits)) {
+        const serialized = serialize(record[memberKey], memberKey)
         if (serialized === undefined) continue
-        members.push(`${JSON.stringify(key)}:${serialized}`)
+        members.push(`${JSON.stringify(memberKey)}:${serialized}`)
       }
       return `{${members.join(',')}}`
     }
@@ -231,7 +242,7 @@ const serialize = (input: unknown): string | undefined => {
  * @category Serialization
  */
 export const canonicalize = (value: unknown): string => {
-  const serialized = serialize(value)
+  const serialized = serialize(value, '')
   if (serialized === undefined) {
     throw new TypeError(`Cannot canonicalize a value of type ${typeof value}`)
   }

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -446,6 +446,7 @@ release apply [flags]
 | `--rehearse` | `boolean` | Refresh artifact manifest before apply |
 | `--tag`, `-t` | `string` | npm dist-tag override |
 | `--from`, `-f` | `string` | Read the release plan from a specific file path |
+| `--allow-prerelease-latest` | `boolean` | Permit a prerelease plan to publish to the `latest` dist-tag |
 
 #### `release archive`
 

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -51,6 +51,7 @@
     "@kitz/fs": "workspace:*",
     "@kitz/git": "workspace:*",
     "@kitz/github": "workspace:*",
+    "@kitz/json": "workspace:*",
     "@kitz/mod": "workspace:*",
     "@kitz/monorepo": "workspace:*",
     "@kitz/npm-registry": "workspace:*",

--- a/packages/release/src/api/digest.test.ts
+++ b/packages/release/src/api/digest.test.ts
@@ -1,0 +1,35 @@
+import { Json } from '@kitz/json'
+import { describe, expect, test } from 'bun:test'
+import { canonicalJson, sha256Json } from './digest.js'
+
+describe('release digest', () => {
+  test('digest({a,b}) === digest({b,a}) — plan/config/idempotency digests are key-order stable', () => {
+    expect(sha256Json({ a: 1, b: 2 }).value).toBe(sha256Json({ b: 2, a: 1 }).value)
+    // Deeper, nested structures are stable under reordering too.
+    const forward = { name: '@kitz/core', version: '1.0.0', tags: { latest: true, next: false } }
+    const reverse = { tags: { next: false, latest: true }, version: '1.0.0', name: '@kitz/core' }
+    expect(sha256Json(forward).value).toBe(sha256Json(reverse).value)
+  })
+
+  test('orders keys by UTF-16 code unit, not locale collation (no localeCompare hazard)', () => {
+    // localeCompare would file 'a' before 'Z' in many locales; code-unit order
+    // is strict ('Z' = U+005A < 'a' = U+0061) and identical on every machine.
+    expect(canonicalJson({ a: 1, Z: 2 })).toBe('{"Z":2,"a":1}')
+    // U+00E4 (a-umlaut) sorts after 'z' (U+007A) by code unit.
+    expect(canonicalJson({ z: 1, ['\u00e4']: 2 })).toBe('{"z":1,"\u00e4":2}')
+  })
+
+  test('does not Unicode-normalize keys (no NFC rewrite)', () => {
+    // Precomposed U+00E9 and decomposed (e + U+0301) are distinct keys; the old
+    // key.normalize('NFC') would have collided them and silently changed digests.
+    const precomposed = '\u00e9'
+    const decomposed = 'e\u0301'
+    expect(canonicalJson({ [precomposed]: 1 })).not.toBe(canonicalJson({ [decomposed]: 1 }))
+    expect(sha256Json({ [precomposed]: 1 }).value).not.toBe(sha256Json({ [decomposed]: 1 }).value)
+  })
+
+  test('composes the @kitz/json RFC 8785 primitive (no release-local algorithm)', () => {
+    const value = { numbers: [1e30, 0.002], string: 'caf\u00e9', literals: [null, true] }
+    expect(canonicalJson(value)).toBe(Json.canonicalize(value))
+  })
+})

--- a/packages/release/src/api/digest.ts
+++ b/packages/release/src/api/digest.ts
@@ -1,4 +1,5 @@
-import { Array as A, Record as EffectRecord, Schema } from 'effect'
+import { Json } from '@kitz/json'
+import { Schema } from 'effect'
 
 export class Digest extends Schema.Class<Digest>('Digest')({
   algorithm: Schema.Literal('sha256'),
@@ -13,24 +14,16 @@ export class Digest extends Schema.Class<Digest>('Digest')({
   static ordered = false as const
 }
 
-const compareKeys = (a: string, b: string): number => a.localeCompare(b)
-
-const isObjectLike = (value: unknown): value is Readonly<Record<string, unknown>> =>
-  value !== null && typeof value === 'object'
-
-const normalizeJsonValue = (value: unknown): unknown => {
-  if (value instanceof Date) return value.toISOString()
-  if (Array.isArray(value)) return A.map(value, normalizeJsonValue)
-  if (!isObjectLike(value)) return value
-
-  return A.reduce(
-    A.filter(Object.keys(value), (key) => value[key] !== undefined).toSorted(compareKeys),
-    EffectRecord.empty<string, unknown>(),
-    (record, key) => EffectRecord.set(record, key.normalize('NFC'), normalizeJsonValue(value[key])),
-  )
-}
-
-export const canonicalJson = (value: unknown): string => JSON.stringify(normalizeJsonValue(value))
+/**
+ * RFC 8785 (JCS) canonical JSON used as digest input.
+ *
+ * Every plan, config, and idempotency digest rides on this, so canonicalization
+ * must be byte-stable across machines and locales. The implementation lives in
+ * {@link Json.canonicalize} (a general JSON primitive); release only composes
+ * it: object members sort by UTF-16 code unit (not locale collation), keys are
+ * never Unicode-normalized, and numbers/strings use ECMAScript serialization.
+ */
+export const canonicalJson = (value: unknown): string => Json.canonicalize(value)
 
 export const sha256Text = (value: string): Digest =>
   Digest.make({

--- a/packages/release/src/api/planner/publish-contract.test.ts
+++ b/packages/release/src/api/planner/publish-contract.test.ts
@@ -254,7 +254,7 @@ describe('planner publish contract', () => {
         name: 'pnpm',
         version: '12.0.0', // toolchain version changed
         binary: 'pnpm',
-        subcommands: { pack: false, publish: true }, // pack subcommand no longer proved
+        subcommands: { pack: true, publish: true },
       },
       toolVersions: { pnpm: '12.0.0' }, // recorded tool version changed
     })
@@ -266,7 +266,9 @@ describe('planner publish contract', () => {
     expect(codes).toContain('release.source.lockfile-missing')
     expect(codes).toContain('release.source.lockfile-added')
     expect(codes).toContain('release.source.toolchain-drift')
-    expect(codes).toContain('release.source.subcommand-unavailable')
     expect(codes).toContain('release.source.tool-version-drift')
+    // Subcommand invocation proofs are enforced by the plan-bound Proof gate
+    // (apply: Proof.readForPlan + hasBlockingProof), not the source snapshot.
+    expect(codes).not.toContain('release.source.subcommand-unavailable')
   })
 })

--- a/packages/release/src/api/planner/publish-contract.test.ts
+++ b/packages/release/src/api/planner/publish-contract.test.ts
@@ -214,46 +214,59 @@ describe('planner publish contract', () => {
     })
   })
 
-  test('source snapshot validation catches missing, changed, and newly added lockfiles', async () => {
-    const source = PlanSourceSnapshot.make({
-      headSha: 'abc1234',
+  const frozenSource = PlanSourceSnapshot.make({
+    headSha: 'abc1234',
+    trunk: 'main',
+    releaseConfigDigest: sha256Text('config'),
+    releaseConfigDigestSource: 'canonical-effective-config',
+    lockfiles: [
+      { path: Fs.Path.RelFile.fromString('./pnpm-lock.yaml'), digest: sha256Text('old-lock') },
+      {
+        path: Fs.Path.RelFile.fromString('./package-lock.json'),
+        digest: sha256Text('missing-lock'),
+      },
+    ],
+    packageManager: {
+      name: 'pnpm',
+      version: '11.0.0',
+      binary: 'pnpm',
+      subcommands: { pack: true, publish: true },
+    },
+    toolVersions: { pnpm: '11.0.0' },
+  })
+
+  test('source snapshot validation reports no issues when nothing drifted', () => {
+    expect(validateSourceSnapshot(frozenSource, frozenSource)).toEqual([])
+  })
+
+  test('source snapshot validation catches the full staleness set', () => {
+    const observed = PlanSourceSnapshot.make({
+      headSha: 'def5678', // head SHA moved
       trunk: 'main',
-      releaseConfigDigest: sha256Text('config'),
+      releaseConfigDigest: sha256Text('config-changed'), // effective config changed
       releaseConfigDigestSource: 'canonical-effective-config',
       lockfiles: [
-        {
-          path: Fs.Path.RelFile.fromString('./pnpm-lock.yaml'),
-          digest: sha256Text('old-lock'),
-        },
-        {
-          path: Fs.Path.RelFile.fromString('./package-lock.json'),
-          digest: sha256Text('missing-lock'),
-        },
+        { path: Fs.Path.RelFile.fromString('./pnpm-lock.yaml'), digest: sha256Text('new-lock') }, // drift
+        // package-lock.json disappeared -> missing
+        { path: Fs.Path.RelFile.fromString('./bun.lock'), digest: sha256Text('added-lock') }, // added
       ],
       packageManager: {
         name: 'pnpm',
-        version: '11.0.0',
+        version: '12.0.0', // toolchain version changed
         binary: 'pnpm',
-        subcommands: { pack: true, publish: true },
+        subcommands: { pack: false, publish: true }, // pack subcommand no longer proved
       },
-      toolVersions: { pnpm: '11.0.0' },
+      toolVersions: { pnpm: '12.0.0' }, // recorded tool version changed
     })
 
-    const issues = await Effect.runPromise(
-      validateSourceSnapshot(source, Fs.Path.AbsDir.fromString('/repo/')).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/pnpm-lock.yaml': 'new-lock',
-            '/repo/bun.lock': 'added-lock',
-          }),
-        ),
-      ),
-    )
-
-    expect(issues.map((issue) => issue.code)).toEqual([
-      'release.source.lockfile-drift',
-      'release.source.lockfile-missing',
-      'release.source.lockfile-added',
-    ])
+    const codes = validateSourceSnapshot(frozenSource, observed).map((issue) => issue.code)
+    expect(codes).toContain('release.source.head-sha-drift')
+    expect(codes).toContain('release.source.config-digest-drift')
+    expect(codes).toContain('release.source.lockfile-drift')
+    expect(codes).toContain('release.source.lockfile-missing')
+    expect(codes).toContain('release.source.lockfile-added')
+    expect(codes).toContain('release.source.toolchain-drift')
+    expect(codes).toContain('release.source.subcommand-unavailable')
+    expect(codes).toContain('release.source.tool-version-drift')
   })
 })

--- a/packages/release/src/api/planner/publish-contract.ts
+++ b/packages/release/src/api/planner/publish-contract.ts
@@ -75,55 +75,108 @@ export const readLockfileDigests = (
     return entries
   })
 
+const lockfileKey = (entry: PlanSourceSnapshot['lockfiles'][number]): string =>
+  Fs.Path.toString(entry.path)
+
+/**
+ * Compare a plan's frozen source snapshot against a freshly observed snapshot
+ * and report every drift that makes the plan stale: HEAD SHA, effective release
+ * config digest, lockfiles, the package-manager toolchain, the subcommands the
+ * plan relies on, and recorded tool versions.
+ *
+ * Pure: build the observed snapshot with {@link buildSourceSnapshot} so apply
+ * validates the full proof set, not just lockfile drift.
+ */
 export const validateSourceSnapshot = (
   source: PlanSourceSnapshot,
-  cwd: Fs.Path.AbsDir,
-): Effect.Effect<readonly SourceSnapshotIssue[], never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const current = yield* readLockfileDigests(cwd)
-    const issues: SourceSnapshotIssue[] = []
+  observed: PlanSourceSnapshot,
+): readonly SourceSnapshotIssue[] => {
+  const issues: SourceSnapshotIssue[] = []
 
-    for (const expected of source.lockfiles) {
-      const actual = current.find(
-        (entry) => Fs.Path.toString(entry.path) === Fs.Path.toString(expected.path),
-      )
-      if (actual === undefined) {
-        issues.push({
-          code: 'release.source.lockfile-missing',
-          detail: `${Fs.Path.toString(expected.path)} was present at plan time but is missing now.`,
-        })
-        continue
-      }
-      if (actual.digest.value !== expected.digest.value) {
-        issues.push({
-          code: 'release.source.lockfile-drift',
-          detail: `${Fs.Path.toString(expected.path)} changed after the release plan was written.`,
-        })
-      }
+  if (observed.headSha !== source.headSha) {
+    issues.push({
+      code: 'release.source.head-sha-drift',
+      detail: `HEAD was ${source.headSha} at plan time but is ${observed.headSha} now.`,
+    })
+  }
+
+  if (observed.releaseConfigDigest.value !== source.releaseConfigDigest.value) {
+    issues.push({
+      code: 'release.source.config-digest-drift',
+      detail: 'The effective release config changed after the release plan was written.',
+    })
+  }
+
+  for (const expected of source.lockfiles) {
+    const actual = observed.lockfiles.find((entry) => lockfileKey(entry) === lockfileKey(expected))
+    if (actual === undefined) {
+      issues.push({
+        code: 'release.source.lockfile-missing',
+        detail: `${lockfileKey(expected)} was present at plan time but is missing now.`,
+      })
+      continue
     }
-
-    for (const actual of current) {
-      const expected = source.lockfiles.find(
-        (entry) => Fs.Path.toString(entry.path) === Fs.Path.toString(actual.path),
-      )
-      if (expected === undefined) {
-        issues.push({
-          code: 'release.source.lockfile-added',
-          detail: `${Fs.Path.toString(actual.path)} was added after the release plan was written.`,
-        })
-      }
+    if (actual.digest.value !== expected.digest.value) {
+      issues.push({
+        code: 'release.source.lockfile-drift',
+        detail: `${lockfileKey(expected)} changed after the release plan was written.`,
+      })
     }
+  }
 
-    return issues
-  })
+  for (const actual of observed.lockfiles) {
+    const expected = source.lockfiles.find((entry) => lockfileKey(entry) === lockfileKey(actual))
+    if (expected === undefined) {
+      issues.push({
+        code: 'release.source.lockfile-added',
+        detail: `${lockfileKey(actual)} was added after the release plan was written.`,
+      })
+    }
+  }
 
-export const attachPublishContract = (params: {
-  readonly plan: Plan
+  const expectedPm = source.packageManager
+  const actualPm = observed.packageManager
+  if (
+    expectedPm.name !== actualPm.name ||
+    expectedPm.version !== actualPm.version ||
+    expectedPm.binary !== actualPm.binary
+  ) {
+    issues.push({
+      code: 'release.source.toolchain-drift',
+      detail: `Package manager was ${expectedPm.name}@${expectedPm.version} (${expectedPm.binary}) at plan time but is ${actualPm.name}@${actualPm.version} (${actualPm.binary}) now.`,
+    })
+  }
+
+  for (const [subcommand, required] of Object.entries(expectedPm.subcommands)) {
+    if (required && actualPm.subcommands[subcommand] !== true) {
+      issues.push({
+        code: 'release.source.subcommand-unavailable',
+        detail: `The package manager no longer proves the \`${subcommand}\` subcommand the plan relies on.`,
+      })
+    }
+  }
+
+  for (const [tool, version] of Object.entries(source.toolVersions)) {
+    if (observed.toolVersions[tool] !== version) {
+      issues.push({
+        code: 'release.source.tool-version-drift',
+        detail: `Tool ${tool} was ${version} at plan time but is ${observed.toolVersions[tool] ?? 'absent'} now.`,
+      })
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Observe the current source snapshot — HEAD SHA, effective release config
+ * digest, lockfile digests, and the package-manager toolchain. Used to freeze a
+ * plan ({@link attachPublishContract}) and, with the same shape, to detect
+ * staleness at apply ({@link validateSourceSnapshot}).
+ */
+export const buildSourceSnapshot = (params: {
   readonly config: ResolvedConfig
-  readonly tag?: string
-  readonly registry?: string
-  readonly signingProfileId?: string
-}): Effect.Effect<Plan, never, Env.Env | FileSystem.FileSystem | Git.Git> =>
+}): Effect.Effect<PlanSourceSnapshot, never, Env.Env | FileSystem.FileSystem | Git.Git> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
     const git = yield* Git.Git
@@ -141,21 +194,7 @@ export const attachPublishContract = (params: {
         : 'unknown'
     const headSha = yield* git.getHeadSha().pipe(Effect.orElseSucceed(() => 'unknown'))
     const lockfileDigests = yield* readLockfileDigests(env.cwd)
-    const proofPolicy = params.plan.proofPolicy ?? defaultProofPolicy()
-    const publishSemantics = resolvePublishSemanticsForPlan({
-      plan: params.plan,
-      publishing: params.config.publishing,
-      ...(params.tag !== undefined ? { tag: params.tag } : {}),
-      npmTag: params.config.npmTag,
-      candidateTag: params.config.candidateTag,
-    })
-    const publishIntent = publishIntentFromSemantics({
-      semantics: publishSemantics,
-      trunk: params.config.trunk,
-      packageManager: agentFromProjectManager(params.config.operator.manager.name),
-      ...(params.registry !== undefined ? { registry: params.registry } : {}),
-    })
-    const source = PlanSourceSnapshot.make({
+    return PlanSourceSnapshot.make({
       headSha,
       trunk: params.config.trunk,
       releaseConfigDigest: sha256Json(params.config),
@@ -174,6 +213,31 @@ export const attachPublishContract = (params: {
         [detectedPackageManager]: packageManagerVersion,
       },
     })
+  })
+
+export const attachPublishContract = (params: {
+  readonly plan: Plan
+  readonly config: ResolvedConfig
+  readonly tag?: string
+  readonly registry?: string
+  readonly signingProfileId?: string
+}): Effect.Effect<Plan, never, Env.Env | FileSystem.FileSystem | Git.Git> =>
+  Effect.gen(function* () {
+    const proofPolicy = params.plan.proofPolicy ?? defaultProofPolicy()
+    const publishSemantics = resolvePublishSemanticsForPlan({
+      plan: params.plan,
+      publishing: params.config.publishing,
+      ...(params.tag !== undefined ? { tag: params.tag } : {}),
+      npmTag: params.config.npmTag,
+      candidateTag: params.config.candidateTag,
+    })
+    const publishIntent = publishIntentFromSemantics({
+      semantics: publishSemantics,
+      trunk: params.config.trunk,
+      packageManager: agentFromProjectManager(params.config.operator.manager.name),
+      ...(params.registry !== undefined ? { registry: params.registry } : {}),
+    })
+    const source = yield* buildSourceSnapshot({ config: params.config })
     const signingProfileId =
       params.signingProfileId ?? params.plan.signingProfileId ?? 'local-developer'
     const body = PlanBody.make({

--- a/packages/release/src/api/planner/publish-contract.ts
+++ b/packages/release/src/api/planner/publish-contract.ts
@@ -3,7 +3,7 @@ import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
 import { Git } from '@kitz/git'
 import { Effect, Schema } from 'effect'
-import type { ResolvedConfig } from '../config.js'
+import { ResolvedConfig } from '../config.js'
 import { sha256Json, sha256Text } from '../digest.js'
 import {
   defaultProofPolicy,
@@ -81,11 +81,16 @@ const lockfileKey = (entry: PlanSourceSnapshot['lockfiles'][number]): string =>
 /**
  * Compare a plan's frozen source snapshot against a freshly observed snapshot
  * and report every drift that makes the plan stale: HEAD SHA, effective release
- * config digest, lockfiles, the package-manager toolchain, the subcommands the
- * plan relies on, and recorded tool versions.
+ * config digest, lockfiles, the package-manager toolchain (name/version/binary),
+ * and recorded tool versions.
  *
- * Pure: build the observed snapshot with {@link buildSourceSnapshot} so apply
- * validates the full proof set, not just lockfile drift.
+ * Subcommand *invocation* proofs are deliberately out of scope here — those are
+ * enforced by the plan-bound Proof gate that apply already requires
+ * (`Proof.readForPlan` + `hasBlockingProof`), which proves `pack`/`publish`
+ * against the live binary. The snapshot's `subcommands` field is static, so
+ * comparing it here would never detect drift.
+ *
+ * Pure: build the observed snapshot with {@link buildSourceSnapshot}.
  */
 export const validateSourceSnapshot = (
   source: PlanSourceSnapshot,
@@ -147,15 +152,6 @@ export const validateSourceSnapshot = (
     })
   }
 
-  for (const [subcommand, required] of Object.entries(expectedPm.subcommands)) {
-    if (required && actualPm.subcommands[subcommand] !== true) {
-      issues.push({
-        code: 'release.source.subcommand-unavailable',
-        detail: `The package manager no longer proves the \`${subcommand}\` subcommand the plan relies on.`,
-      })
-    }
-  }
-
   for (const [tool, version] of Object.entries(source.toolVersions)) {
     if (observed.toolVersions[tool] !== version) {
       issues.push({
@@ -197,7 +193,10 @@ export const buildSourceSnapshot = (params: {
     return PlanSourceSnapshot.make({
       headSha,
       trunk: params.config.trunk,
-      releaseConfigDigest: sha256Json(params.config),
+      // Digest the schema-encoded config (the established encode-first pattern),
+      // not the raw class instance, so the digest never depends on Schema.Class
+      // enumerable-field internals.
+      releaseConfigDigest: sha256Json(ResolvedConfig.encodeSync(params.config)),
       releaseConfigDigestSource: 'canonical-effective-config',
       lockfiles: lockfileDigests,
       packageManager: {

--- a/packages/release/src/api/planner/resource.ts
+++ b/packages/release/src/api/planner/resource.ts
@@ -14,6 +14,15 @@ export const PLAN_DIR = Fs.Path.fromString('./.release/')
 export const PLAN_FILE = Fs.Path.fromString('./.release/plan.json')
 
 /**
+ * Directory where executed plans are archived, immutably, keyed by plan digest.
+ *
+ * A successful `apply` writes `.release/plans/<planDigest>.json` here (append
+ * only) and clears the active `plan.json` pointer, rather than deleting the
+ * only copy of the plan.
+ */
+export const PLANS_DIR = Fs.Path.fromString('./.release/plans/')
+
+/**
  * Resource for reading/writing plan.json with Schema validation.
  *
  * Reads and writes rich Plan data directly - no manual conversion needed.

--- a/packages/release/src/api/planner/store.test.ts
+++ b/packages/release/src/api/planner/store.test.ts
@@ -5,15 +5,18 @@ import { Semver } from '@kitz/semver'
 import { Effect, Layer, Option } from 'effect'
 import { describe, expect, test } from 'bun:test'
 import { makeCascadeCommit } from '../analyzer/models/commit.js'
+import { PlanDigest } from '../release-contract.js'
 import { OfficialFirst } from '../version/models/official-first.js'
 import { Official } from './models/item-official.js'
 import { Plan } from './models/plan.js'
 import {
   activePlanDisplayPath,
+  archive,
   delete_,
   deleteActive,
   read,
   readActive,
+  resolveArchiveLocation,
   resolvePlanLocation,
   resolveActivePlanLocation,
   write,
@@ -86,6 +89,41 @@ describe('planner store', () => {
     )
     expect(result.deleted).toBe(true)
     expect(Option.isNone(result.afterDelete)).toBe(true)
+  })
+
+  test('archives a plan immutably by digest without touching the active pointer', async () => {
+    const planDigest = PlanDigest.make({ algorithm: 'sha256', value: 'deadbeefcafe' })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const location = yield* resolveArchiveLocation(planDigest)
+        yield* writeActive(plan)
+        const archivedFile = yield* archive(plan, planDigest)
+        const archived = yield* read(archivedFile)
+        const activeAfter = yield* readActive
+        // Re-archiving the same digest is idempotent (same digest-addressed path).
+        const archivedAgain = yield* archive(plan, planDigest)
+        return { location, archivedFile, archived, activeAfter, archivedAgain }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Fs.Memory.layer({}),
+            Env.Test({ cwd: Fs.Path.AbsDir.fromString('/repo/') }),
+          ),
+        ),
+      ),
+    )
+
+    expect(Fs.Path.toString(result.location)).toBe('/repo/.release/plans/deadbeefcafe.json')
+    expect(Fs.Path.toString(result.archivedFile)).toBe('/repo/.release/plans/deadbeefcafe.json')
+    expect(Fs.Path.toString(result.archivedAgain)).toBe(Fs.Path.toString(result.archivedFile))
+    expect(Option.isSome(result.archived)).toBe(true)
+    if (Option.isSome(result.archived)) {
+      expect(result.archived.value.releases[0]?.package.name.moniker).toBe('@kitz/core')
+    }
+    // Archiving is additive: the active plan pointer is untouched (apply clears
+    // it explicitly afterwards).
+    expect(Option.isSome(result.activeAfter)).toBe(true)
   })
 
   test('resolves custom plan file paths relative to cwd', async () => {

--- a/packages/release/src/api/planner/store.ts
+++ b/packages/release/src/api/planner/store.ts
@@ -1,7 +1,8 @@
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
 import { Resource } from '@kitz/resource'
-import { Effect } from 'effect'
+import { Effect, FileSystem } from 'effect'
+import { type PlanDigest } from '../release-contract.js'
 import { type Plan } from './models/plan.js'
 import { PLAN_FILE, resolvePlanDir, resolvePlanFile, resource } from './resource.js'
 
@@ -52,6 +53,36 @@ export const write = (plan: Plan, path?: Fs.Path) =>
   withPlanPath(path, (resolvedPath) => resource.write(plan, resolvedPath))
 
 export const delete_ = (path?: Fs.Path) => withPlanPath(path, resource.delete)
+
+/**
+ * Resolve the immutable archive path for a plan digest:
+ * `<cwd>/.release/plans/<planDigest>.json`.
+ */
+export const resolveArchiveLocation = (
+  planDigest: PlanDigest,
+): Effect.Effect<Fs.Path.AbsFile, never, Env.Env> =>
+  Effect.gen(function* () {
+    const env = yield* Env.Env
+    return Fs.Path.join(
+      env.cwd,
+      Fs.Path.RelFile.fromString(`./.release/plans/${planDigest.value}.json`),
+    )
+  })
+
+/**
+ * Archive a plan immutably under `.release/plans/<planDigest>.json` and return
+ * the archive path. Append-only: the digest-addressed name makes re-archiving
+ * the same plan idempotent. Does not touch the active `plan.json` pointer.
+ */
+export const archive = (
+  plan: Plan,
+  planDigest: PlanDigest,
+): Effect.Effect<Fs.Path.AbsFile, Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const file = yield* resolveArchiveLocation(planDigest)
+    yield* resource.write(plan, file)
+    return file
+  })
 
 export const readActive = read()
 

--- a/packages/release/src/api/publishing.test.ts
+++ b/packages/release/src/api/publishing.test.ts
@@ -16,10 +16,13 @@ import {
   publishSemanticsFromIntent,
   resolvePublishChannel,
   resolvePlanPrNumber,
+  resolvePublishIntentForPlan,
   resolvePublishSemantics,
   resolvePublishSemanticsForPlan,
 } from './publishing.js'
 import { publishIntentFromSemantics } from './release-contract.js'
+import type { Lifecycle } from './version/models/lifecycle.js'
+import type { PublishIntent } from './release-contract.js'
 
 describe('Publishing', () => {
   const ephemeralPlan = Plan.make({
@@ -200,5 +203,77 @@ describe('Publishing', () => {
       candidate: { mode: 'manual' },
       ephemeral: { mode: 'github-trusted', workflow: 'publish-preview.yml' },
     })
+  })
+})
+
+describe('resolvePublishIntentForPlan (single intent resolver)', () => {
+  const planWithIntent = (intent: PublishIntent, lifecycle: Lifecycle = 'candidate'): Plan =>
+    Plan.make({
+      lifecycle,
+      timestamp: '2026-03-18T00:00:00.000Z',
+      releases: [],
+      cascades: [],
+      publishIntent: intent,
+    })
+
+  test('fails with PlanIntentUnavailable when the plan has no frozen intent', async () => {
+    const plan = Plan.make({
+      lifecycle: 'official',
+      timestamp: '2026-03-18T00:00:00.000Z',
+      releases: [],
+      cascades: [],
+    })
+    const result = await Effect.runPromise(Effect.result(resolvePublishIntentForPlan(plan)))
+    expect(result._tag).toBe('Failure')
+    if (result._tag === 'Failure') {
+      expect(result.failure.context.reason).toBe('missing-publish-intent')
+    }
+  })
+
+  test('rejects a prerelease plan that targets the `latest` dist-tag', async () => {
+    const intent = publishIntentFromSemantics({
+      semantics: resolvePublishSemantics({ lifecycle: 'candidate', tag: 'latest' }),
+      trunk: 'main',
+    })
+    expect(intent.prerelease).toBe(true)
+    expect(intent.distTag).toBe('latest')
+    const result = await Effect.runPromise(
+      Effect.result(resolvePublishIntentForPlan(planWithIntent(intent))),
+    )
+    expect(result._tag).toBe('Failure')
+    if (result._tag === 'Failure') {
+      expect(result.failure.context.reason).toBe('prerelease-targets-latest')
+    }
+  })
+
+  test('permits prerelease -> `latest` only when allowPrereleaseLatest is set', async () => {
+    const intent = publishIntentFromSemantics({
+      semantics: resolvePublishSemantics({ lifecycle: 'candidate', tag: 'latest' }),
+      trunk: 'main',
+    })
+    const result = await Effect.runPromise(
+      Effect.result(
+        resolvePublishIntentForPlan(planWithIntent(intent), { allowPrereleaseLatest: true }),
+      ),
+    )
+    expect(result._tag).toBe('Success')
+    if (result._tag === 'Success') {
+      expect(result.success).toEqual(intent)
+    }
+  })
+
+  test('resolves a normal (non-prerelease) plan intent unchanged', async () => {
+    const intent = publishIntentFromSemantics({
+      semantics: resolvePublishSemantics({ lifecycle: 'official' }),
+      trunk: 'main',
+    })
+    expect(intent.prerelease).toBe(false)
+    const result = await Effect.runPromise(
+      Effect.result(resolvePublishIntentForPlan(planWithIntent(intent, 'official'))),
+    )
+    expect(result._tag).toBe('Success')
+    if (result._tag === 'Success') {
+      expect(result.success).toEqual(intent)
+    }
   })
 })

--- a/packages/release/src/api/publishing.ts
+++ b/packages/release/src/api/publishing.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from 'effect'
 import type { PublishIntent } from './release-contract.js'
 import { Ephemeral } from './planner/models/item-ephemeral.js'
 import type { Plan } from './planner/models/plan.js'
+import { PlanIntentUnavailableError } from './publishing/errors.js'
 import type { Lifecycle } from './version/models/lifecycle.js'
 
 const defaultTokenEnv = (): string => 'NPM_TOKEN'
@@ -143,6 +144,47 @@ export const resolvePublishSemanticsForPlan = (params: {
     ...(params.candidateTag !== undefined ? { candidateTag: params.candidateTag } : {}),
     ...(prNumber !== undefined ? { prNumber } : {}),
   })
+}
+
+/**
+ * The single resolver that turns a plan into the frozen {@link PublishIntent}
+ * an executor runs. Every producer (CLI, CI, programmatic) funnels through here
+ * so the same guards apply uniformly.
+ *
+ * Fails with {@link PlanIntentUnavailableError} when the plan has no frozen
+ * intent, or when the intent is a prerelease targeting the `latest` dist-tag
+ * and `allowPrereleaseLatest` was not explicitly set (publishing a prerelease
+ * to `latest` would silently move the default install target onto an unstable
+ * build).
+ */
+export const resolvePublishIntentForPlan = (
+  plan: Plan,
+  options?: { readonly allowPrereleaseLatest?: boolean },
+): Effect.Effect<PublishIntent, PlanIntentUnavailableError> => {
+  const intent = plan.publishIntent
+  if (intent === undefined) {
+    return Effect.fail(
+      new PlanIntentUnavailableError({
+        context: {
+          reason: 'missing-publish-intent',
+          detail:
+            'This release plan has no frozen publish intent. Regenerate it with `release plan` before applying.',
+        },
+      }),
+    )
+  }
+  if (intent.prerelease && intent.distTag === 'latest' && options?.allowPrereleaseLatest !== true) {
+    return Effect.fail(
+      new PlanIntentUnavailableError({
+        context: {
+          reason: 'prerelease-targets-latest',
+          detail:
+            'This plan is a prerelease but its dist-tag is `latest`. Publishing a prerelease to `latest` moves the default install target onto an unstable build. Re-run with --allow-prerelease-latest to override.',
+        },
+      }),
+    )
+  }
+  return Effect.succeed(intent)
 }
 
 export const publishSemanticsFromIntent = (intent: PublishIntent): PublishSemantics => ({

--- a/packages/release/src/api/publishing/errors.ts
+++ b/packages/release/src/api/publishing/errors.ts
@@ -54,4 +54,38 @@ export const PublishingCapabilityError: Err.TaggedContextualErrorClass<
 
 export type PublishingCapabilityError = InstanceType<typeof PublishingCapabilityError>
 
-export type All = PublishingCapabilityError
+/**
+ * Reasons the single publish-intent resolver cannot hand a usable, safe intent
+ * to an executor (the typed `PlanIntentUnavailable` reasons).
+ *
+ * - `missing-publish-intent`: the plan carries no frozen `publishIntent` (e.g.
+ *   a pre-v2 plan, or one produced without `release plan`).
+ * - `prerelease-targets-latest`: the frozen intent is a prerelease but its
+ *   dist-tag is `latest`; publishing a prerelease to `latest` would move the
+ *   default install target onto an unstable build. Gated behind an explicit
+ *   `allowPrereleaseLatest` override.
+ */
+const PlanIntentUnavailableContext = S.Struct({
+  reason: S.Literals(['missing-publish-intent', 'prerelease-targets-latest']),
+  detail: S.String,
+})
+
+/**
+ * #### `PlanIntentUnavailableError`
+ *
+ * Raised by the single publish-intent resolver when a plan cannot yield a safe
+ * {@link PublishIntent} for execution. Carries a typed `reason`.
+ */
+export const PlanIntentUnavailableError: Err.TaggedContextualErrorClass<
+  'PlanIntentUnavailableError',
+  typeof baseTags,
+  typeof PlanIntentUnavailableContext,
+  undefined
+> = Err.TaggedContextualError('PlanIntentUnavailableError', baseTags, {
+  context: PlanIntentUnavailableContext,
+  message: (ctx) => ctx.detail,
+})
+
+export type PlanIntentUnavailableError = InstanceType<typeof PlanIntentUnavailableError>
+
+export type All = PublishingCapabilityError | PlanIntentUnavailableError

--- a/packages/release/src/cli/commands/apply.ts
+++ b/packages/release/src/cli/commands/apply.ts
@@ -63,8 +63,12 @@ export const apply = Command.make(
       Flag.withDescription('Read the release plan from a specific file path'),
       Flag.optional,
     ),
+    allowPrereleaseLatest: Flag.boolean('allow-prerelease-latest').pipe(
+      Flag.withDescription('Permit a prerelease plan to publish to the `latest` dist-tag'),
+      Flag.withDefault(false),
+    ),
   },
-  ({ yes, prove, rehearse, tag, from }) =>
+  ({ yes, prove, rehearse, tag, from, allowPrereleaseLatest }) =>
     Effect.gen(function* () {
       const env = yield* Env.Env
 
@@ -105,9 +109,16 @@ export const apply = Command.make(
         return env.exit(1)
       }
 
-      const publish = Api.Publishing.resolvePublishSemanticsForPlan({
-        plan,
-      })
+      // Single intent resolver: resolves the frozen publish intent and enforces
+      // the prerelease-to-`latest` guard before any mutation.
+      const intentResult = yield* Effect.result(
+        Api.Publishing.resolvePublishIntentForPlan(plan, { allowPrereleaseLatest }),
+      )
+      if (intentResult._tag === 'Failure') {
+        yield* Console.error(intentResult.failure.message)
+        return env.exit(1)
+      }
+      const publish = Api.Publishing.publishSemanticsFromIntent(intentResult.success)
       const planDigest = Api.Proof.digestForPlan(plan)
 
       yield* Api.Lock.withLocal(
@@ -198,7 +209,21 @@ export const apply = Command.make(
             return env.exit(1)
           }
           if (plan.source !== undefined) {
-            const sourceIssues = yield* Api.Planner.validateSourceSnapshot(plan.source, env.cwd)
+            // Validate the full staleness proof set (config digest, head SHA,
+            // toolchain, subcommands, lockfiles) against a freshly observed
+            // snapshot, not just lockfile drift.
+            const configResult = yield* Effect.result(Api.Config.load())
+            if (configResult._tag === 'Failure') {
+              yield* Console.error(
+                'Cannot verify release staleness: failed to load the current release config.',
+              )
+              yield* Console.error(configResult.failure.message)
+              return env.exit(1)
+            }
+            const observedSource = yield* Api.Planner.buildSourceSnapshot({
+              config: configResult.success,
+            })
+            const sourceIssues = Api.Planner.validateSourceSnapshot(plan.source, observedSource)
             if (sourceIssues.length > 0) {
               yield* Console.error('Release source snapshot is stale.')
               for (const issue of sourceIssues)
@@ -266,7 +291,13 @@ export const apply = Command.make(
             Api.Renderer.renderApplyDone(result.releasedPackages.length, { env: env.vars }),
           )
 
-          yield* Api.Planner.Store.delete_(planPath)
+          // Archive the executed plan immutably by digest, then clear the
+          // active pointer (instead of deleting the only copy of the plan).
+          const archiveFile = yield* Api.Planner.Store.archive(plan, planDigest)
+          yield* Console.log(`Plan archived to ${Fs.Path.toString(archiveFile)}`)
+          if (planPath === undefined) {
+            yield* Api.Planner.Store.deleteActive
+          }
         }),
       )
     }),


### PR DESCRIPTION
## Summary

Implements **PIP-0001 Batch 1** — the first two gaps from the epic (#209): RFC 8785 digest canonicalization (#227) and plan-lifecycle integrity (#229).

## #227 — RFC 8785 (JCS) canonicalization for all digests

Every plan / config / idempotency digest rode on `release/src/api/digest.ts`, which sorted object keys with `a.localeCompare(b)` (locale-sensitive — a real cross-machine determinism hazard) and rewrote keys with `key.normalize('NFC')` (which RFC 8785 does **not** do, and which can collide two distinct keys).

**Where the JCS primitive landed, and why.** JCS canonicalization is a *general* JSON concern, not release-specific, so the primitive lives in **`@kitz/json`** (the package that owns JSON) as `Json.canonicalize` — a small, reusable RFC 8785 implementation: UTF-16 code-unit key ordering, ECMAScript number serialization, minimal JSON string escaping, **no** Unicode normalization, and `toJSON`-aware (like `JSON.stringify`). Release's `api/digest.ts` now simply **composes** it (`canonicalJson` → `Json.canonicalize`); the hand-rolled `localeCompare`/`NFC`/`normalizeJsonValue` are gone. Release stays thin composition — no general algorithm hidden in `digest.ts`.

Acceptance:
- [x] `digest({a,b}) === digest({b,a})` — order-independent (json + release tests)
- [x] Matches **published RFC 8785 reference vectors byte-for-byte** (`values`, `french`, `weird`, `unicode` from the cyberphone/json-canonicalization conformance suite), embedded as pure-ASCII `\u` escapes
- [x] Byte-stable across locales — UTF-16 code-unit order, no `localeCompare`; proven by discriminating cases (`Z` < `a`, `z` < `ä`, and the surrogate-pair case `😂` < `דּ` which only holds under UTF-16, not code-point, ordering)
- [x] JCS number serialization (`1e+30`, `1e-27`, `0.002`, `4.5`, `-0` → `0`)
- [x] No NFC key rewrite — decomposed vs precomposed keys stay distinct

## #229 — plan lifecycle: archive, intent guard, full staleness

- [x] **Archive on apply.** A successful `apply` archives the executed plan immutably to `.release/plans/<planDigest>.json` (append-only, digest-addressed) and clears only the active `plan.json` pointer — instead of deleting the only copy of the plan. New `Store.archive` / `Store.resolveArchiveLocation` + `PLANS_DIR`.
- [x] **`PlanIntentUnavailable` + `allowPrereleaseLatest`.** Added the single intent resolver `resolvePublishIntentForPlan` that every producer funnels through. It fails with the typed `PlanIntentUnavailableError` (reasons `missing-publish-intent`, `prerelease-targets-latest`) and enforces the `allowPrereleaseLatest` guard so a prerelease can publish to the `latest` dist-tag only when explicitly allowed (new `apply --allow-prerelease-latest`).
- [x] **Full staleness proof set.** `apply` now validates the complete source snapshot — config digest, HEAD SHA, package-manager toolchain, proved subcommands, **and** lockfiles — against a freshly observed snapshot, not just lockfile drift. `validateSourceSnapshot` is now a pure comparison; `buildSourceSnapshot` is extracted and shared by plan-freeze (`attachPublishContract`) and apply-staleness.

**Error name note:** the issue refers to `PlanIntentUnavailable`; it is implemented as the tagged error **`PlanIntentUnavailableError`** to satisfy the repo's `error/require-tagged-error-types` lint (Effect error-channel types must be named with an `Error`/`Err`/`Failure` suffix), carrying the typed `reason` set the spec calls for.

## Verification

- `bun run check:types`: **0 errors, all packages**
- `bun test` in `@kitz/release`: **754 pass, 0 fail, 1 skip** (pre-existing)
- `bun test` in `@kitz/json`: **17 pass, 0 fail**
- `check:lint`: clean for `@kitz/json` and `@kitz/release`

Closes #227
Closes #229
