### PR TITLE
feat(git, npm-registry, test): service mock driver + per-tag test services

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,12 +188,12 @@
         "@kitz/core": "workspace:*",
         "@kitz/fs": "workspace:*",
         "@kitz/resource": "workspace:*",
+        "@kitz/test": "workspace:*",
         "effect": "catalog:",
         "simple-git": "^3.36.0",
       },
       "devDependencies": {
         "@kitz/platform": "workspace:*",
-        "@kitz/test": "workspace:*",
       },
     },
     "packages/github": {
@@ -339,6 +339,7 @@
         "@kitz/fs": "workspace:*",
         "@kitz/pkg": "workspace:*",
         "@kitz/semver": "workspace:*",
+        "@kitz/test": "workspace:*",
         "effect": "catalog:",
       },
     },

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -14,7 +14,8 @@
   },
   "exports": {
     ".": "./src/_.ts",
-    "./__": "./src/__.ts"
+    "./__": "./src/__.ts",
+    "./test": "./src/test.ts"
   },
   "files": [
     "build",
@@ -34,11 +35,11 @@
     "@kitz/core": "workspace:*",
     "@kitz/fs": "workspace:*",
     "@kitz/resource": "workspace:*",
+    "@kitz/test": "workspace:*",
     "effect": "catalog:",
     "simple-git": "^3.36.0"
   },
   "devDependencies": {
-    "@kitz/platform": "workspace:*",
-    "@kitz/test": "workspace:*"
+    "@kitz/platform": "workspace:*"
   }
 }

--- a/packages/git/src/test.test.ts
+++ b/packages/git/src/test.test.ts
@@ -8,7 +8,7 @@ const { GitError } = Git
 const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect as Effect.Effect<A>)
 const runExit = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect)
 
-describe('Git.Test — happy-path defaults', () => {
+describe('Git test service — happy-path defaults', () => {
   test('make() provides a driver with all methods scripted to succeed', async () => {
     const git = GitTest.make()
 
@@ -62,7 +62,7 @@ describe('Git.Test — happy-path defaults', () => {
   })
 })
 
-describe('Git.Test — failure injection without re-stubbing', () => {
+describe('Git test service — failure injection without re-stubbing', () => {
   test('inject a createTag failure on the happy-path driver', async () => {
     const git = GitTest.make()
     git.createTag.everyFail(
@@ -101,7 +101,7 @@ describe('Git.Test — failure injection without re-stubbing', () => {
   })
 })
 
-describe('Git.Test — call inspection', () => {
+describe('Git test service — call inspection', () => {
   test('records calls to driven methods', async () => {
     const git = GitTest.make()
 

--- a/packages/git/src/test.test.ts
+++ b/packages/git/src/test.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test'
+import { Effect } from 'effect'
+import { Git } from './_.js'
+import * as GitTest from './test.js'
+
+const { GitError } = Git
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect as Effect.Effect<A>)
+const runExit = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect)
+
+describe('Git.Test — happy-path defaults', () => {
+  test('make() provides a driver with all methods scripted to succeed', async () => {
+    const git = GitTest.make()
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Git.Git
+      const branch = yield* svc.getCurrentBranch()
+      const clean = yield* svc.isClean()
+      const root = yield* svc.getRoot()
+      const remote = yield* svc.getRemoteUrl()
+      const tags = yield* svc.getTags()
+      return { branch, clean, root, remote, tags }
+    })
+
+    const result = await run(program.pipe(Effect.provide(git.$test.layer())))
+    expect(result.branch).toBe('main')
+    expect(result.clean).toBe(true)
+    expect(result.root).toBe('/repo')
+    expect(result.remote).toBe('git@github.com:example/repo.git')
+    expect(result.tags).toEqual([])
+  })
+
+  test('config overrides the happy-path defaults', async () => {
+    const git = GitTest.make({ branch: 'develop', tags: ['v1.0.0'], isClean: false })
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Git.Git
+      return {
+        branch: yield* svc.getCurrentBranch(),
+        tags: yield* svc.getTags(),
+        clean: yield* svc.isClean(),
+      }
+    })
+
+    const result = await run(program.pipe(Effect.provide(git.$test.layer())))
+    expect(result.branch).toBe('develop')
+    expect(result.tags).toEqual(['v1.0.0'])
+    expect(result.clean).toBe(false)
+  })
+
+  test('void methods (createTag, pushTag) succeed by default', async () => {
+    const git = GitTest.make()
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Git.Git
+      yield* svc.createTag('v2.0.0', 'release')
+      yield* svc.pushTag('v2.0.0')
+    })
+
+    const exit = await runExit(program.pipe(Effect.provide(git.$test.layer())))
+    expect(exit._tag).toBe('Success')
+  })
+})
+
+describe('Git.Test — failure injection without re-stubbing', () => {
+  test('inject a createTag failure on the happy-path driver', async () => {
+    const git = GitTest.make()
+    git.createTag.everyFail(
+      new GitError({
+        context: { operation: 'createTag', detail: 'remote rejected' },
+        cause: new Error('remote rejected'),
+      }),
+    )
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Git.Git
+      yield* svc.createTag('v3.0.0')
+    })
+
+    const exit = await runExit(program.pipe(Effect.provide(git.$test.layer())))
+    expect(exit._tag).toBe('Failure')
+  })
+
+  test('other methods still succeed after one is set to fail', async () => {
+    const git = GitTest.make()
+    git.pushTagsAtomic.everyFail(
+      new GitError({
+        context: { operation: 'pushTagsAtomic' },
+        cause: new Error('push failed'),
+      }),
+    )
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Git.Git
+      const branch = yield* svc.getCurrentBranch()
+      return branch
+    })
+
+    const result = await run(program.pipe(Effect.provide(git.$test.layer())))
+    expect(result).toBe('main')
+  })
+})
+
+describe('Git.Test — call inspection', () => {
+  test('records calls to driven methods', async () => {
+    const git = GitTest.make()
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Git.Git
+      yield* svc.createTag('v1.0.0', 'first')
+      yield* svc.createTag('v2.0.0')
+    })
+
+    await run(program.pipe(Effect.provide(git.$test.layer())))
+
+    // normalizeArgs: 2 args -> tuple; 1 arg (omitted optional) -> scalar.
+    expect(git.createTag.calls).toEqual([[['v1.0.0', 'first']], ['v2.0.0']])
+  })
+})

--- a/packages/git/src/test.ts
+++ b/packages/git/src/test.ts
@@ -1,7 +1,7 @@
 /**
  * Tag-owned test double for the {@link Git} service.
  *
- * `Test.make(config?)` returns a {@link Test.Mock} driver whose every method is
+ * `make(config?)` returns a {@link Test.Mock} driver whose every method is
  * pre-scripted to succeed with happy-path defaults (mirroring
  * {@link Memory.make}). Callers wire it in with `driver.$test.layer()`, inspect
  * calls via `driver.<method>.calls`, and inject failures on any method without
@@ -9,9 +9,10 @@
  *
  * @example
  * ```ts
+ * import { make as makeGitTest } from '@kitz/git/test'
  * import { Git } from '@kitz/git'
  *
- * const git = Git.Test.make({ branch: 'develop' })
+ * const git = makeGitTest({ branch: 'develop' })
  * git.createTag.everyFail(new Git.GitError({ context: { operation: 'createTag' }, cause: new Error('x') }))
  * const layer = git.$test.layer()
  * ```

--- a/packages/git/src/test.ts
+++ b/packages/git/src/test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tag-owned test double for the {@link Git} service.
+ *
+ * `Test.make(config?)` returns a {@link Test.Mock} driver whose every method is
+ * pre-scripted to succeed with happy-path defaults (mirroring
+ * {@link Memory.make}). Callers wire it in with `driver.$test.layer()`, inspect
+ * calls via `driver.<method>.calls`, and inject failures on any method without
+ * re-stubbing the whole interface — e.g. `driver.createTag.everyFail(error)`.
+ *
+ * @example
+ * ```ts
+ * import { Git } from '@kitz/git'
+ *
+ * const git = Git.Test.make({ branch: 'develop' })
+ * git.createTag.everyFail(new Git.GitError({ context: { operation: 'createTag' }, cause: new Error('x') }))
+ * const layer = git.$test.layer()
+ * ```
+ *
+ * @category Testing
+ */
+
+import { Test } from '@kitz/test'
+import type { GitPushDryRunResult } from './service.js'
+import { Git } from './service.js'
+import * as Sha from './sha.js'
+
+/**
+ * Happy-path defaults for the Git test double.
+ *
+ * Mirrors the defaults of {@link Memory.make}: `main` branch, clean tree,
+ * `/repo` root, the example remote, and empty tag/commit lists.
+ *
+ * @category Testing
+ */
+export interface GitTestConfig {
+  /** Tags reported by `getTags` (default `[]`). */
+  readonly tags?: ReadonlyArray<string>
+  /** Current branch reported by `getCurrentBranch` (default `'main'`). */
+  readonly branch?: string
+  /** Working-tree clean status reported by `isClean` (default `true`). */
+  readonly isClean?: boolean
+  /** Repository root reported by `getRoot` (default `'/repo'`). */
+  readonly root?: string
+  /** Hooks directory reported by `getHooksDir` (default `'<root>/.git/hooks'`). */
+  readonly hooksDir?: string
+  /** Short HEAD SHA reported by `getHeadSha` (default `'abc1234'`). */
+  readonly headSha?: Sha.Sha
+  /** Remote URL reported by `getRemoteUrl` (default the example remote). */
+  readonly remoteUrl?: string
+  /** Dry-run stdout reported by the push dry-run methods (default `'dry-run ok'`). */
+  readonly dryRunStdout?: string
+}
+
+/**
+ * Build a happy-path Git test driver.
+ *
+ * @category Testing
+ */
+export const make = (config: GitTestConfig = {}): Test.Mock.Driver<typeof Git> => {
+  const root = config.root ?? '/repo'
+  const dryRun: GitPushDryRunResult = { stdout: config.dryRunStdout ?? 'dry-run ok' }
+
+  const git = Test.Mock.make(Git)
+
+  git.getTags.everySuccess([...(config.tags ?? [])])
+  git.getCurrentBranch.everySuccess(config.branch ?? 'main')
+  git.getCommitsSince.everySuccess([])
+  git.isClean.everySuccess(config.isClean ?? true)
+  git.createTag.everySuccess(undefined)
+  git.pushTags.everySuccess(undefined)
+  git.pushTagsAtomic.everySuccess(undefined)
+  git.pushTagDryRun.everySuccess(dryRun)
+  git.pushTagsAtomicDryRun.everySuccess(dryRun)
+  git.getRoot.everySuccess(root)
+  git.getHooksDir.everySuccess(config.hooksDir ?? `${root}/.git/hooks`)
+  git.getHeadSha.everySuccess(config.headSha ?? Sha.make('abc1234'))
+  git.getTagSha.everySuccess(config.headSha ?? Sha.make('abc1234'))
+  git.isAncestor.everySuccess(true)
+  git.createTagAt.everySuccess(undefined)
+  git.deleteTag.everySuccess(undefined)
+  git.commitExists.everySuccess(true)
+  git.pushTag.everySuccess(undefined)
+  git.deleteRemoteTag.everySuccess(undefined)
+  git.getRemoteUrl.everySuccess(config.remoteUrl ?? 'git@github.com:example/repo.git')
+
+  return git
+}

--- a/packages/npm-registry/package.json
+++ b/packages/npm-registry/package.json
@@ -14,7 +14,8 @@
   },
   "exports": {
     ".": "./src/_.ts",
-    "./__": "./src/__.ts"
+    "./__": "./src/__.ts",
+    "./test": "./src/test.ts"
   },
   "files": [
     "build",
@@ -35,6 +36,7 @@
     "@kitz/fs": "workspace:*",
     "@kitz/pkg": "workspace:*",
     "@kitz/semver": "workspace:*",
+    "@kitz/test": "workspace:*",
     "effect": "catalog:"
   }
 }

--- a/packages/npm-registry/src/test.test.ts
+++ b/packages/npm-registry/src/test.test.ts
@@ -1,0 +1,121 @@
+import { Fs } from '@kitz/fs'
+import { describe, expect, test } from 'bun:test'
+import { Effect } from 'effect'
+import { NpmRegistry } from './_.js'
+import * as NpmCliTest from './test.js'
+
+const { NpmCli, NpmCliError } = NpmRegistry
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect as Effect.Effect<A>)
+const runExit = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect)
+
+describe('NpmCli test service — happy-path defaults', () => {
+  test('make() provides a driver with all methods scripted to succeed', async () => {
+    const npm = NpmCliTest.make()
+
+    const program = Effect.gen(function* () {
+      const cli = yield* NpmCli
+      const user = yield* cli.whoami()
+      const exists = yield* cli.hasVersion('@kitz/git', '1.0.0')
+      const status = yield* cli.getAccessStatus('@kitz/git')
+      return { user, exists, status }
+    })
+
+    const result = await run(program.pipe(Effect.provide(npm.$test.layer())))
+    expect(result.user).toBe('dry-run-user')
+    expect(result.exists).toBe(true)
+    expect(result.status).toBe('public')
+  })
+
+  test('config overrides whoami default', async () => {
+    const npm = NpmCliTest.make({ whoamiUser: 'alice' })
+
+    const program = Effect.gen(function* () {
+      const cli = yield* NpmCli
+      return yield* cli.whoami()
+    })
+
+    expect(await run(program.pipe(Effect.provide(npm.$test.layer())))).toBe('alice')
+  })
+
+  test('pack returns a usable PackResult, publish succeeds', async () => {
+    const npm = NpmCliTest.make()
+
+    const program = Effect.gen(function* () {
+      const cli = yield* NpmCli
+      const packed = yield* cli.pack({
+        cwd: Fs.Path.AbsDir.fromString('/repo/packages/git/'),
+        packDestination: Fs.Path.AbsDir.fromString('/repo/.artifacts/'),
+      })
+      yield* cli.publish({ tarball: packed.tarball, access: 'public' })
+      return packed.filename
+    })
+
+    const exit = await runExit(program.pipe(Effect.provide(npm.$test.layer())))
+    expect(exit._tag).toBe('Success')
+  })
+})
+
+describe('NpmCli test service — failure injection without re-stubbing', () => {
+  test('inject a whoami failure on the happy-path driver', async () => {
+    const npm = NpmCliTest.make()
+    npm.whoami.everyFail(
+      new NpmCliError({
+        context: { operation: 'whoami', detail: 'not logged in' },
+        cause: new Error('not logged in'),
+      }),
+    )
+
+    const program = Effect.gen(function* () {
+      const cli = yield* NpmCli
+      return yield* cli.whoami()
+    })
+
+    const exit = await runExit(program.pipe(Effect.provide(npm.$test.layer())))
+    expect(exit._tag).toBe('Failure')
+  })
+
+  test('other methods still succeed after whoami is set to fail', async () => {
+    const npm = NpmCliTest.make()
+    npm.whoami.everyFail(
+      new NpmCliError({ context: { operation: 'whoami' }, cause: new Error('x') }),
+    )
+
+    const program = Effect.gen(function* () {
+      const cli = yield* NpmCli
+      return yield* cli.hasVersion('@kitz/git', '1.0.0')
+    })
+
+    expect(await run(program.pipe(Effect.provide(npm.$test.layer())))).toBe(true)
+  })
+
+  test('inject a per-version hasVersion result with when()', async () => {
+    const npm = NpmCliTest.make()
+    npm.hasVersion.when(['@kitz/git', '9.9.9']).everySuccess(false)
+
+    const program = (name: string, version: string) =>
+      Effect.gen(function* () {
+        const cli = yield* NpmCli
+        return yield* cli.hasVersion(name, version)
+      }).pipe(Effect.provide(npm.$test.layer()))
+
+    expect(await run(program('@kitz/git', '9.9.9'))).toBe(false)
+    expect(await run(program('@kitz/git', '1.0.0'))).toBe(true)
+  })
+})
+
+describe('NpmCli test service — call inspection', () => {
+  test('records publish calls', async () => {
+    const npm = NpmCliTest.make()
+    const tarball = Fs.Path.AbsFile.fromString('/repo/.artifacts/pkg-1.0.0.tgz')
+
+    const program = Effect.gen(function* () {
+      const cli = yield* NpmCli
+      yield* cli.publish({ tarball, access: 'public' })
+    })
+
+    await run(program.pipe(Effect.provide(npm.$test.layer())))
+
+    expect(npm.publish.calls).toEqual([[{ tarball, access: 'public' }]])
+  })
+})

--- a/packages/npm-registry/src/test.ts
+++ b/packages/npm-registry/src/test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tag-owned test double for the {@link NpmCli} service.
+ *
+ * `Test.make(config?)` returns a {@link Test.Mock} driver whose every method is
+ * pre-scripted to succeed with happy-path defaults (mirroring
+ * {@link NpmCliDryRun}). Callers wire it in with `driver.$test.layer()`,
+ * inspect calls via `driver.<method>.calls`, and inject failures on any method
+ * without re-stubbing the whole interface — e.g. `driver.whoami.everyFail(error)`.
+ *
+ * @example
+ * ```ts
+ * import { make as makeNpmCliTest } from '@kitz/npm-registry/test'
+ * import { NpmRegistry } from '@kitz/npm-registry'
+ *
+ * const npm = makeNpmCliTest({ whoamiUser: 'alice' })
+ * npm.whoami.everyFail(
+ *   new NpmRegistry.NpmCliError({ context: { operation: 'whoami' }, cause: new Error('x') }),
+ * )
+ * const layer = npm.$test.layer()
+ * ```
+ *
+ * @category Testing
+ */
+
+import { Fs } from '@kitz/fs'
+import { Test } from '@kitz/test'
+import type { AccessStatus, PackResult, RegistryVersionObservation } from './cli.js'
+import { NpmCli } from './service.js'
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/'
+
+/**
+ * Happy-path defaults for the NpmCli test double.
+ *
+ * Mirrors the canned values of {@link NpmCliDryRun}: `'dry-run-user'`, a fixed
+ * tarball, `hasVersion → true`, `getAccessStatus → 'public'`, and empty access
+ * listings.
+ *
+ * @category Testing
+ */
+export interface NpmCliTestConfig {
+  /** Username reported by `whoami` (default `'dry-run-user'`). */
+  readonly whoamiUser?: string
+  /** Result reported by `pack` (default a fixed dry-run tarball). */
+  readonly packResult?: PackResult
+  /** Result reported by `hasVersion` (default `true`). */
+  readonly hasVersion?: boolean
+  /** Access status reported by `getAccessStatus` (default `'public'`). */
+  readonly accessStatus?: AccessStatus
+  /** Package listing reported by `listAccessPackages` (default `{}`). */
+  readonly accessPackages?: Readonly<Record<string, string>>
+  /** Collaborator listing reported by `listAccessCollaborators` (default `{}`). */
+  readonly accessCollaborators?: Readonly<Record<string, string>>
+  /** Observation reported by `observeVersion` (default a fixed observation). */
+  readonly observation?: RegistryVersionObservation
+}
+
+const defaultPackResult = (): PackResult => ({
+  filename: 'dry-run-package-0.0.0.tgz',
+  tarball: Fs.Path.AbsFile.fromString('/dry-run/dry-run-package-0.0.0.tgz'),
+})
+
+const defaultObservation = (): RegistryVersionObservation => ({
+  versionMetadata: {
+    name: 'dry-run-package',
+    version: '0.0.0',
+    dist: { tarball: `${DEFAULT_REGISTRY}dry-run-package/-/0.0.0.tgz` },
+  },
+  distTags: { latest: '0.0.0' },
+  tarballUrl: `${DEFAULT_REGISTRY}dry-run-package/-/0.0.0.tgz`,
+})
+
+/**
+ * Build a happy-path NpmCli test driver.
+ *
+ * @category Testing
+ */
+export const make = (config: NpmCliTestConfig = {}): Test.Mock.Driver<typeof NpmCli> => {
+  const npm = Test.Mock.make(NpmCli)
+
+  npm.whoami.everySuccess(config.whoamiUser ?? 'dry-run-user')
+  npm.pack.everySuccess(config.packResult ?? defaultPackResult())
+  npm.publish.everySuccess(undefined)
+  npm.hasVersion.everySuccess(config.hasVersion ?? true)
+  npm.observeVersion.everySuccess(config.observation ?? defaultObservation())
+  npm.listAccessPackages.everySuccess(config.accessPackages ?? {})
+  npm.listAccessCollaborators.everySuccess(config.accessCollaborators ?? {})
+  npm.getAccessStatus.everySuccess(config.accessStatus ?? 'public')
+
+  return npm
+}

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -29,7 +29,9 @@
     "check:types": "tsgo --noEmit",
     "check:lint": "bun ../../tools/run-lint.ts src/",
     "check:package": "publint && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm internal-resolution-error",
-    "test": "bun test"
+    "test": "bun test",
+    "test:coverage": "bun test --coverage",
+    "check:cov": "bun run test:coverage"
   },
   "files": [
     "build",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -28,7 +28,8 @@
     "dev": "tsgo -p tsconfig.build.json --watch",
     "check:types": "tsgo --noEmit",
     "check:lint": "bun ../../tools/run-lint.ts src/",
-    "check:package": "publint && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm internal-resolution-error"
+    "check:package": "publint && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm internal-resolution-error",
+    "test": "bun test"
   },
   "files": [
     "build",

--- a/packages/test/src/__.ts
+++ b/packages/test/src/__.ts
@@ -6,5 +6,13 @@
 export { Matchers } from './matchers/_.js'
 
 export * from './effect.js'
+
+/**
+ * Generic Effect-service mock driver.
+ *
+ * @category Mocking
+ */
+export * as Mock from './mock.js'
+
 export * from './property.js'
 export * from './table/__.js'

--- a/packages/test/src/mock.test.ts
+++ b/packages/test/src/mock.test.ts
@@ -16,6 +16,8 @@ interface SampleService {
   readonly ping: () => Effect.Effect<'pong', SampleError>
   readonly find: (id: string) => Effect.Effect<Option.Option<string>, SampleError>
   readonly label: string
+  /** Nested synchronous config object — exercises nested `override` proxying. */
+  readonly meta: { readonly version: string; readonly nested: { readonly deep: number } }
 }
 
 class SampleError {
@@ -238,6 +240,89 @@ describe('Mock.make — missing-mock behavior', () => {
     const sample = Mock.make(Sample)
     const exit = await runExit(sample.greet('x'))
     expect(exit._tag).toBe('Failure')
+  })
+})
+
+// ─── Proxy reflection invariants ─────────────────────────────────────────────
+//
+// Test frameworks, assertion libraries (`expect().toEqual`), serializers, and
+// snapshot tools enumerate or spread objects. The driver and its method
+// controllers are callable Proxies; their `ownKeys`/`getOwnPropertyDescriptor`
+// traps must satisfy the Proxy invariants or every such operation throws.
+
+describe('Mock.make — proxy reflection invariants', () => {
+  test('the root driver enumerates and spreads without throwing', () => {
+    const sample = Mock.make(Sample)
+    expect(() => Object.keys(sample)).not.toThrow()
+    expect(() => Object.getOwnPropertyNames(sample)).not.toThrow()
+    expect(() => Reflect.ownKeys(sample)).not.toThrow()
+    expect(() => ({ ...sample })).not.toThrow()
+    // `$test` is reported as a (non-enumerable) own property.
+    expect(Object.getOwnPropertyNames(sample)).toContain('$test')
+  })
+
+  test('a method controller enumerates without throwing', () => {
+    const sample = Mock.make(Sample)
+    expect(() => Object.getOwnPropertyNames(sample.greet)).not.toThrow()
+    expect(() => ({ ...sample.greet })).not.toThrow()
+    const keys = Object.getOwnPropertyNames(sample.greet)
+    expect(keys).toContain('calls')
+    expect(keys).toContain('nextSuccess')
+    expect(keys).toContain('when')
+  })
+
+  test('the controller surface answers `in` checks', () => {
+    const sample = Mock.make(Sample)
+    expect('calls' in sample.greet).toBe(true)
+    expect('nextSuccess' in sample.greet).toBe(true)
+    expect('$test' in sample).toBe(true)
+  })
+})
+
+// ─── Override surface ─────────────────────────────────────────────────────────
+
+describe('Mock.make — override', () => {
+  test('override pins a nested object and deep-merges partial updates', () => {
+    const sample = Mock.make(Sample)
+    // `label` is the only declared sync field; exercise nested override on a
+    // structurally-typed read to cover the override-proxy path.
+    sample.$test.override({ label: 'first' })
+    expect(sample.label).toBe('first')
+
+    sample.$test.override({ label: 'second' })
+    expect(sample.label).toBe('second')
+  })
+
+  test('reset() drops overrides', () => {
+    const sample = Mock.make(Sample)
+    sample.$test.override({ label: 'pinned' })
+    expect(sample.label).toBe('pinned')
+
+    sample.$test.reset()
+    // After reset the override is gone; the field is no longer the pinned value.
+    expect(sample.label).not.toBe('pinned')
+  })
+
+  test('override pins a nested object and deep-merges a partial update', () => {
+    const sample = Mock.make(Sample)
+    sample.$test.override({ meta: { version: '1.0.0', nested: { deep: 7 } } })
+    expect(sample.meta.version).toBe('1.0.0')
+    expect(sample.meta.nested.deep).toBe(7)
+
+    // A partial update to a sibling key must preserve the unrelated nested branch.
+    sample.$test.override({ meta: { version: '2.0.0' } })
+    expect(sample.meta.version).toBe('2.0.0')
+    expect(sample.meta.nested.deep).toBe(7)
+  })
+
+  test('the override proxy enumerates and answers `in` without throwing', () => {
+    const sample = Mock.make(Sample)
+    sample.$test.override({ meta: { version: '1.0.0', nested: { deep: 1 } } })
+    const meta = sample.meta
+    expect(() => Object.keys(meta)).not.toThrow()
+    expect(Object.keys(meta)).toContain('version')
+    expect('version' in meta).toBe(true)
+    expect(() => Object.getOwnPropertyDescriptor(meta, 'version')).not.toThrow()
   })
 })
 

--- a/packages/test/src/mock.test.ts
+++ b/packages/test/src/mock.test.ts
@@ -264,6 +264,7 @@ describe('Mock.make — proxy reflection invariants', () => {
   test('a method controller enumerates without throwing', () => {
     const sample = Mock.make(Sample)
     expect(() => Object.getOwnPropertyNames(sample.greet)).not.toThrow()
+    // oxlint-disable-next-line typescript/no-misused-spread -- regression: a callable mock-method proxy must spread without throwing (the ownKeys invariant)
     expect(() => ({ ...sample.greet })).not.toThrow()
     const keys = Object.getOwnPropertyNames(sample.greet)
     expect(keys).toContain('calls')

--- a/packages/test/src/mock.test.ts
+++ b/packages/test/src/mock.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from 'bun:test'
+import { Context, Effect, type Layer, Option } from 'effect'
+import * as Mock from './mock.js'
+
+// ─── Sample flat Context.Service under test ────────────────────────────────
+//
+// Mirrors the flat services the driver must support (Git, NpmCli): every
+// method lives directly on the service and returns an Effect. One method
+// returns an Effect<Option<_>> to exercise the Option helpers; one takes
+// multiple args to exercise tuple normalization; one takes zero args; one is a
+// synchronous (non-Effect) field to exercise `override`.
+
+interface SampleService {
+  readonly greet: (name: string) => Effect.Effect<string, SampleError>
+  readonly add: (a: number, b: number) => Effect.Effect<number, SampleError>
+  readonly ping: () => Effect.Effect<'pong', SampleError>
+  readonly find: (id: string) => Effect.Effect<Option.Option<string>, SampleError>
+  readonly label: string
+}
+
+class SampleError {
+  readonly _tag = 'SampleError'
+  constructor(readonly reason: string) {}
+}
+
+class Sample extends Context.Service<Sample, SampleService>()('Sample') {}
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect as Effect.Effect<A>)
+const runExit = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect)
+
+describe('Mock.make — per-method controls', () => {
+  test('nextSuccess queues a single FIFO success', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.nextSuccess('hello alice')
+
+    expect(await run(sample.greet('alice'))).toBe('hello alice')
+  })
+
+  test('next queues a raw implementation receiving normalized args', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.next((name) => Effect.succeed(`hi ${name}`))
+
+    expect(await run(sample.greet('bob'))).toBe('hi bob')
+  })
+
+  test('next FIFO drains in order, then falls through to every', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.nextSuccess('first')
+    sample.greet.nextSuccess('second')
+    sample.greet.everySuccess('sticky')
+
+    expect(await run(sample.greet('x'))).toBe('first')
+    expect(await run(sample.greet('x'))).toBe('second')
+    expect(await run(sample.greet('x'))).toBe('sticky')
+    expect(await run(sample.greet('x'))).toBe('sticky')
+  })
+
+  test('everySuccess is sticky across all calls', async () => {
+    const sample = Mock.make(Sample)
+    sample.add.everySuccess(42)
+
+    expect(await run(sample.add(1, 2))).toBe(42)
+    expect(await run(sample.add(3, 4))).toBe(42)
+  })
+
+  test('nextFail / everyFail inject typed failures', async () => {
+    const sample = Mock.make(Sample)
+    const error = new SampleError('boom')
+    sample.greet.nextFail(error)
+
+    const exit = await runExit(sample.greet('x'))
+    expect(exit._tag).toBe('Failure')
+
+    sample.greet.everyFail(new SampleError('always'))
+    const exit2 = await runExit(sample.greet('y'))
+    expect(exit2._tag).toBe('Failure')
+  })
+
+  test('every receives normalized args', async () => {
+    const sample = Mock.make(Sample)
+    sample.add.every(([a, b]) => Effect.succeed(a + b))
+
+    expect(await run(sample.add(2, 3))).toBe(5)
+    expect(await run(sample.add(10, 20))).toBe(30)
+  })
+
+  test('zero-arg methods normalize args to undefined', async () => {
+    const sample = Mock.make(Sample)
+    sample.ping.everySuccess('pong')
+
+    expect(await run(sample.ping())).toBe('pong')
+    expect(sample.ping.calls).toEqual([[undefined]])
+  })
+})
+
+describe('Mock.make — Option helpers', () => {
+  test('nextSome / everySome wrap in Option.some', async () => {
+    const sample = Mock.make(Sample)
+    sample.find.nextSome('found-it')
+
+    const result = await run(sample.find('id-1'))
+    expect(Option.isSome(result)).toBe(true)
+    expect(Option.getOrNull(result)).toBe('found-it')
+  })
+
+  test('nextNone / everyNone wrap in Option.none', async () => {
+    const sample = Mock.make(Sample)
+    sample.find.everyNone()
+
+    const result = await run(sample.find('missing'))
+    expect(Option.isNone(result)).toBe(true)
+  })
+})
+
+describe('Mock.make — call inspection', () => {
+  test('records calls with normalized single arg', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.everySuccess('ok')
+
+    await run(sample.greet('alice'))
+    await run(sample.greet('bob'))
+
+    expect(sample.greet.calls).toEqual([['alice'], ['bob']])
+  })
+
+  test('records calls with normalized arg tuples', async () => {
+    const sample = Mock.make(Sample)
+    sample.add.everySuccess(0)
+
+    await run(sample.add(1, 2))
+
+    expect(sample.add.calls).toEqual([[[1, 2]]])
+  })
+
+  test('clear() drops recorded calls but keeps queued impls', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.everySuccess('ok')
+
+    await run(sample.greet('a'))
+    sample.greet.clear()
+    expect(sample.greet.calls).toEqual([])
+
+    // every impl survived clear()
+    expect(await run(sample.greet('b'))).toBe('ok')
+    expect(sample.greet.calls).toEqual([['b']])
+  })
+
+  test('reset() drops calls and queued impls', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.nextSuccess('one')
+    await run(sample.greet('a'))
+    sample.greet.reset()
+
+    expect(sample.greet.calls).toEqual([])
+    const exit = await runExit(sample.greet('b'))
+    expect(exit._tag).toBe('Failure') // no impl after reset -> die
+  })
+})
+
+describe('Mock.make — when() branch matching', () => {
+  test('when() branch wins over global next', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.nextSuccess('global')
+    sample.greet.when('vip').nextSuccess('special')
+
+    expect(await run(sample.greet('vip'))).toBe('special')
+    expect(await run(sample.greet('other'))).toBe('global')
+  })
+
+  test('when() deep-partial object matching', async () => {
+    const sample = Mock.make(Sample)
+    sample.add.when([1, 2]).everySuccess(999)
+    sample.add.everySuccess(0)
+
+    expect(await run(sample.add(1, 2))).toBe(999)
+    expect(await run(sample.add(5, 6))).toBe(0)
+  })
+
+  test('branch next() FIFO drains before branch every()', async () => {
+    const sample = Mock.make(Sample)
+    const branch = sample.greet.when('a')
+    branch.nextSuccess('once')
+    branch.everySuccess('thereafter')
+
+    expect(await run(sample.greet('a'))).toBe('once')
+    expect(await run(sample.greet('a'))).toBe('thereafter')
+  })
+})
+
+describe('Mock.make — $test controls', () => {
+  test('layer() wires the mock as the service', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.everySuccess('from layer')
+
+    const program = Effect.gen(function* () {
+      const svc = yield* Sample
+      return yield* svc.greet('x')
+    })
+
+    const result = await run(program.pipe(Effect.provide(sample.$test.layer())))
+    expect(result).toBe('from layer')
+  })
+
+  test('clearCalls() clears every controller', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.everySuccess('ok')
+    sample.ping.everySuccess('pong')
+
+    await run(sample.greet('a'))
+    await run(sample.ping())
+
+    sample.$test.clearCalls()
+    expect(sample.greet.calls).toEqual([])
+    expect(sample.ping.calls).toEqual([])
+  })
+
+  test('reset() clears calls and impls across controllers', async () => {
+    const sample = Mock.make(Sample)
+    sample.greet.nextSuccess('x')
+    await run(sample.greet('a'))
+
+    sample.$test.reset()
+    expect(sample.greet.calls).toEqual([])
+    const exit = await runExit(sample.greet('b'))
+    expect(exit._tag).toBe('Failure')
+  })
+
+  test('override() pins a synchronous field', () => {
+    const sample = Mock.make(Sample)
+    sample.$test.override({ label: 'overridden' })
+
+    expect(sample.label).toBe('overridden')
+  })
+})
+
+describe('Mock.make — missing-mock behavior', () => {
+  test('calling a method with no impl dies with an unimplemented error', async () => {
+    const sample = Mock.make(Sample)
+    const exit = await runExit(sample.greet('x'))
+    expect(exit._tag).toBe('Failure')
+  })
+})
+
+// ─── Type-level contract proofs (enforced by `tsgo --noEmit`) ───────────────
+
+describe('Mock.make — type contract', () => {
+  test('public type surface holds', () => {
+    const sample = Mock.make(Sample)
+
+    // The driver method is still callable as the service method and returns
+    // the service's Effect.
+    const greetReturn: Effect.Effect<string, SampleError> = sample.greet('x')
+    expect(greetReturn).toBeDefined()
+
+    // nextSuccess accepts exactly the success type.
+    sample.greet.nextSuccess('a string')
+    // @ts-expect-error -- success channel is string, not number
+    sample.greet.nextSuccess(123)
+
+    // nextFail accepts exactly the error type.
+    sample.greet.nextFail(new SampleError('x'))
+    // @ts-expect-error -- error channel is SampleError, not a bare string
+    sample.greet.nextFail('not an error')
+
+    // Option helpers exist on an Option-returning method...
+    sample.find.nextSome('value')
+    sample.find.everyNone()
+
+    // ...and are absent on a non-Option method.
+    // @ts-expect-error -- greet's success is string, not Option, so no nextSome
+    sample.greet.nextSome('value')
+    // @ts-expect-error -- add's success is number, not Option, so no everyNone
+    sample.add.everyNone()
+
+    // calls is read-only inspection typed by normalized input.
+    const greetCalls: ReadonlyArray<readonly [string]> = sample.greet.calls
+    const addCalls: ReadonlyArray<readonly [readonly [number, number]]> = sample.add.calls
+    const pingCalls: ReadonlyArray<readonly [undefined]> = sample.ping.calls
+    expect(greetCalls).toBeDefined()
+    expect(addCalls).toBeDefined()
+    expect(pingCalls).toBeDefined()
+
+    // $test.layer() is typed to the service identifier.
+    const layer: Layer.Layer<Sample> = sample.$test.layer()
+    expect(layer).toBeDefined()
+
+    // override accepts synchronous fields and rejects method positions.
+    sample.$test.override({ label: 'ok' })
+    // @ts-expect-error -- greet is a method, not an overridable synchronous field
+    sample.$test.override({ greet: 'nope' })
+  })
+})

--- a/packages/test/src/mock.ts
+++ b/packages/test/src/mock.ts
@@ -14,10 +14,13 @@
  * → that branch's `every` → the global `next` FIFO → the global `every`
  * fallback → otherwise the call dies with an unimplemented-mock error.
  *
- * The driver is the generic core of the Prisma test driver with the
- * Prisma-specific delegate taxonomy removed; it works on flat services (every
- * method directly on the service) and nested services (methods grouped under
- * sub-objects) alike.
+ * The driver works on flat services (every method directly on the service) and
+ * nested services (methods grouped under sub-objects) alike.
+ *
+ * Synchronous (non-`Effect`) fields have no control surface; they must be
+ * pinned with `$test.override(...)` before being read. Reading an
+ * un-overridden synchronous field returns a callable mock-method proxy, not the
+ * field's value or `undefined`.
  *
  * @example
  * ```ts
@@ -120,6 +123,13 @@ type MockImplementation<TArgs extends ReadonlyArray<any>, TReturn extends AnyEff
 ) => TReturn
 
 type MockInspection<TArgs extends ReadonlyArray<any>> = {
+  /**
+   * Recorded calls, one normalized argument shape per call. Args are
+   * normalized the same way the controls observe them: `[]` and `[undefined]`
+   * both record as `[undefined]`, so for a method with an optional leading
+   * param a zero-arg call and an explicit-`undefined` call are
+   * indistinguishable here.
+   */
   readonly calls: ReadonlyArray<MockCall<TArgs>>
   clear(): void
   reset(): void

--- a/packages/test/src/mock.ts
+++ b/packages/test/src/mock.ts
@@ -54,11 +54,6 @@ export type DeepPartial<TValue> = TValue extends (...args: ReadonlyArray<any>) =
       ? { readonly [TKey in keyof TValue]?: DeepPartial<TValue[TKey]> }
       : TValue
 
-/**
- * Normalize a method's parameter tuple to the shape the controls observe:
- * zero params → `undefined`, one param → that param, multiple params → the
- * tuple.
- */
 /** Distribute a head prepend over a union of tuple tails. */
 type Prepend<THead, TTail extends ReadonlyArray<any>> = TTail extends TTail
   ? readonly [THead, ...TTail]

--- a/packages/test/src/mock.ts
+++ b/packages/test/src/mock.ts
@@ -611,8 +611,12 @@ function createDriverProxy(state: RuntimeState, path: ReadonlyArray<string>): un
     return cached
   }
 
-  // oxlint-disable-next-line eslint/prefer-arrow-callback -- named function expression supplies proxy.name (callable Proxy target) used in error messages and runtime identification
-  const proxy = new Proxy(function mockServiceMethod() {}, {
+  // Arrow function target: callable (for the `apply` trap) but — unlike a
+  // `function` expression — carries no own `prototype` property. A `function`
+  // target's `prototype` is non-configurable, so an `ownKeys` trap that omits
+  // it violates the Proxy invariant and makes `Object.keys`/spread/`Reflect
+  // .ownKeys` on the driver throw. The arrow target has no such key.
+  const proxy = new Proxy(() => {}, {
     get(_target, prop) {
       if (prop === 'then') {
         return undefined

--- a/packages/test/src/mock.ts
+++ b/packages/test/src/mock.ts
@@ -1,0 +1,781 @@
+/**
+ * Generic Effect-service mock driver.
+ *
+ * `Mock.make(tag)` builds a mutable test double for any `Context.Service` whose
+ * methods return `Effect`s. The returned driver mirrors the service's method
+ * tree; each method is callable (acting as the mocked service method) and also
+ * carries a per-method control + inspection surface (`next`, `every`,
+ * `nextSuccess`, `everySuccess`, `nextFail`, `everyFail`, `when`, `calls`,
+ * `clear`, `reset`). The `$test` property exposes driver-wide controls:
+ * `layer()` to wire the mock into an Effect program, plus `clearCalls()`,
+ * `reset()`, and `override()`.
+ *
+ * Resolution precedence per call: a matching `when(...)` branch's queued `next`
+ * → that branch's `every` → the global `next` FIFO → the global `every`
+ * fallback → otherwise the call dies with an unimplemented-mock error.
+ *
+ * The driver is the generic core of the Prisma test driver with the
+ * Prisma-specific delegate taxonomy removed; it works on flat services (every
+ * method directly on the service) and nested services (methods grouped under
+ * sub-objects) alike.
+ *
+ * @example
+ * ```ts
+ * const git = Mock.make(Git)
+ * git.getTags.nextSuccess(['v1.0.0'])
+ * const layer = git.$test.layer()
+ * ```
+ *
+ * @category Mocking
+ */
+
+import { Context, Effect, Layer, Match, Option } from 'effect'
+
+type AnyEffect = Effect.Effect<any, any, any>
+type AnyEffectMethod = (...args: ReadonlyArray<any>) => AnyEffect
+
+// ─── Public type surface ────────────────────────────────────────────────────
+
+/**
+ * Recursive partial used for `when(...)` argument matching.
+ *
+ * @example
+ * ```ts
+ * type Match = Mock.DeepPartial<{ where: { id: string } }>
+ * ```
+ *
+ * @category Mocking
+ */
+export type DeepPartial<TValue> = TValue extends (...args: ReadonlyArray<any>) => any
+  ? TValue
+  : TValue extends ReadonlyArray<infer TItem>
+    ? ReadonlyArray<DeepPartial<TItem>>
+    : TValue extends object
+      ? { readonly [TKey in keyof TValue]?: DeepPartial<TValue[TKey]> }
+      : TValue
+
+/**
+ * Normalize a method's parameter tuple to the shape the controls observe:
+ * zero params → `undefined`, one param → that param, multiple params → the
+ * tuple.
+ */
+/** Distribute a head prepend over a union of tuple tails. */
+type Prepend<THead, TTail extends ReadonlyArray<any>> = TTail extends TTail
+  ? readonly [THead, ...TTail]
+  : never
+
+/** Drop the leading element of a tuple, preserving the tail's optionality. */
+type Tail<TArgs extends ReadonlyArray<any>> = TArgs extends readonly [any?, ...infer TRest]
+  ? TRest
+  : []
+
+/**
+ * Enumerate every concrete argument array a parameter tuple can be called
+ * with — one tuple per optional prefix from the required arity up to the full
+ * arity. `[a, b?]` yields `[a] | [a, b]`.
+ */
+type ValidCalls<TArgs extends ReadonlyArray<any>> =
+  Required<TArgs> extends readonly [infer THead, ...any[]]
+    ?
+        | ([] extends TArgs ? readonly [] : never)
+        | (Required<Tail<TArgs>> extends readonly [any, ...any[]]
+            ? Prepend<THead, ValidCalls<Tail<TArgs>>>
+            : readonly [THead])
+    : readonly []
+
+/**
+ * Map one concrete argument arity to the shape `normalizeArgs` records: `[]` →
+ * `undefined`, `[a]` → `a`, `[a, b, ...]` → the tuple.
+ */
+type NormalizeArity<TArgs extends ReadonlyArray<any>> = TArgs extends readonly []
+  ? undefined
+  : TArgs extends readonly [any]
+    ? TArgs[0]
+    : TArgs
+
+/**
+ * Normalize a method's parameter tuple to the union of shapes the controls
+ * observe across every callable arity. A variadic tuple keeps its full shape.
+ */
+type NormalizeInput<TArgs extends ReadonlyArray<any>> = number extends TArgs['length']
+  ? TArgs
+  : ValidCalls<TArgs> extends infer TCall
+    ? TCall extends ReadonlyArray<any>
+      ? NormalizeArity<TCall>
+      : never
+    : never
+
+type HasEffectCallableDescendant<TValue> =
+  TValue extends ReadonlyArray<any>
+    ? false
+    : TValue extends AnyEffectMethod
+      ? true
+      : TValue extends object
+        ? true extends {
+            readonly [TKey in keyof TValue]: HasEffectCallableDescendant<TValue[TKey]>
+          }[keyof TValue]
+          ? true
+          : false
+        : false
+
+type MockCall<TArgs extends ReadonlyArray<any>> = readonly [NormalizeInput<TArgs>]
+
+type MockImplementation<TArgs extends ReadonlyArray<any>, TReturn extends AnyEffect> = (
+  args: NormalizeInput<TArgs>,
+) => TReturn
+
+type MockInspection<TArgs extends ReadonlyArray<any>> = {
+  readonly calls: ReadonlyArray<MockCall<TArgs>>
+  clear(): void
+  reset(): void
+}
+
+/**
+ * Option-shaped controls, present only when the method's success channel is an
+ * `Option`. Lets callers script the some/none cases without re-wrapping.
+ */
+type OptionHelpers<TSuccess> =
+  TSuccess extends Option.Option<infer TSome>
+    ? {
+        nextSome(value: TSome): void
+        everySome(value: TSome): void
+        nextNone(): void
+        everyNone(): void
+      }
+    : {}
+
+type BaseMockConfigurer<TArgs extends ReadonlyArray<any>, TReturn extends AnyEffect, TSuccess> = {
+  next(fn: MockImplementation<TArgs, TReturn>): void
+  every(fn: MockImplementation<TArgs, TReturn>): void
+  nextSuccess(value: TSuccess): void
+  everySuccess(value: TSuccess): void
+  nextFail(error: Effect.Error<TReturn>): void
+  everyFail(error: Effect.Error<TReturn>): void
+} & OptionHelpers<TSuccess>
+
+type MockConfigurer<
+  TArgs extends ReadonlyArray<any>,
+  TReturn extends AnyEffect,
+> = BaseMockConfigurer<TArgs, TReturn, Effect.Success<TReturn>> & {
+  when(partialArgs: DeepPartial<NormalizeInput<TArgs>>): MockConfigurer<TArgs, TReturn>
+}
+
+/**
+ * Controls and inspection surface attached to one mocked Effect-returning
+ * method.
+ *
+ * @example
+ * ```ts
+ * git.getTags.nextSuccess(['v1.0.0'])
+ * git.getTags.calls // ReadonlyArray<[undefined]>
+ * ```
+ *
+ * @category Mocking
+ */
+export type MockOp<
+  TArgs extends ReadonlyArray<any>,
+  TReturn extends AnyEffect,
+> = MockInspection<TArgs> & MockConfigurer<TArgs, TReturn>
+
+type MockMethod<TMethod extends AnyEffectMethod> = TMethod &
+  MockOp<Extract<Parameters<TMethod>, ReadonlyArray<any>>, ReturnType<TMethod>>
+
+type DriverValue<TValue> = TValue extends AnyEffectMethod
+  ? MockMethod<Extract<TValue, AnyEffectMethod>>
+  : TValue extends ReadonlyArray<any>
+    ? TValue
+    : TValue extends object
+      ? HasEffectCallableDescendant<TValue> extends true
+        ? DriverObject<TValue>
+        : TValue
+      : TValue
+
+type DriverObject<TObject extends object> = {
+  readonly [TKey in keyof TObject]: DriverValue<TObject[TKey]>
+}
+
+/**
+ * Deep mock facade matching a caller-owned context service.
+ *
+ * @example
+ * ```ts
+ * const git = Mock.make(Git)
+ * ```
+ *
+ * @category Mocking
+ */
+export type Driver<TService extends Context.Service.Any> = DriverObject<
+  Context.Service.Shape<TService>
+> & {
+  readonly $test: Controls<TService>
+}
+
+/**
+ * Partial service override shape accepted by `driver.$test.override(...)`.
+ *
+ * Synchronous (non-Effect) fields can be pinned; method positions are dropped
+ * from the accepted shape because methods are controlled via `next`/`every`.
+ *
+ * @category Mocking
+ */
+export type Override<TValue> = TValue extends (...args: ReadonlyArray<any>) => any
+  ? never
+  : TValue extends ReadonlyArray<infer TItem>
+    ? ReadonlyArray<Override<TItem>>
+    : TValue extends object
+      ? { readonly [TKey in keyof TValue]?: Override<TValue[TKey]> }
+      : TValue
+
+/**
+ * Driver-wide mutable test controls for one `Mock.make(service)` driver.
+ *
+ * @category Mocking
+ */
+export type Controls<TService extends Context.Service.Any> = {
+  /**
+   * Build the `Layer` that provides this mock as the service for `TService`.
+   * Call at the edge of the test (`Effect.provide(driver.$test.layer())`); each
+   * `Mock.make(service)` owns its own layer instance.
+   */
+  layer(): Layer.Layer<Context.Service.Identifier<TService>>
+  /**
+   * Clear the recorded call log on every method controller without discarding
+   * queued implementations or overrides.
+   */
+  clearCalls(): void
+  /**
+   * Drop all queued implementations, recorded calls, branches, and overrides,
+   * returning the driver to its freshly-made state.
+   */
+  reset(): void
+  /**
+   * Merge a partial service shape on top of the mock's resolution chain so
+   * subsequent property reads return the overridden synchronous values.
+   */
+  override(partial: Override<Context.Service.Shape<TService>>): void
+}
+
+// ─── Runtime state ──────────────────────────────────────────────────────────
+
+type RuntimeImplementation = (args: unknown) => AnyEffect
+type RuntimeBranch = {
+  readonly matcher: (args: unknown) => boolean
+  readonly queue: Array<RuntimeImplementation>
+  every: RuntimeImplementation | undefined
+}
+type RuntimeController = {
+  readonly calls: Array<readonly [unknown]>
+  readonly queue: Array<RuntimeImplementation>
+  every: RuntimeImplementation | undefined
+  readonly branches: Array<RuntimeBranch>
+}
+type RuntimeState = {
+  readonly serviceKey: Context.Service.Any
+  readonly controllers: Map<string, RuntimeController>
+  readonly proxyCache: Map<string, unknown>
+  service: unknown
+  controls: Controls<Context.Service.Any>
+  overrides: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isHiddenStringProperty(prop: string, isRoot: boolean): boolean {
+  if (isRoot && prop === '$test') {
+    return false
+  }
+  return prop.startsWith('$') || prop.startsWith('_')
+}
+
+function createController(): RuntimeController {
+  return { calls: [], queue: [], every: undefined, branches: [] }
+}
+
+function getController(state: RuntimeState, path: string): RuntimeController {
+  const existing = state.controllers.get(path)
+  if (existing !== undefined) {
+    return existing
+  }
+  const controller = createController()
+  state.controllers.set(path, controller)
+  return controller
+}
+
+function normalizeArgs(args: ReadonlyArray<unknown>): unknown {
+  return Match.value(args.length).pipe(
+    Match.when(0, () => undefined),
+    Match.when(1, () => args[0]),
+    Match.orElse(() => args),
+  )
+}
+
+function makeUnimplementedError(message: string): Error {
+  const error = new Error(message)
+  error.name = 'UnimplementedError'
+  return error
+}
+
+function missingMock(path: string): AnyEffect {
+  return Effect.die(makeUnimplementedError(`Missing Mock implementation for ${path}`))
+}
+
+function isPlainObjectForMerge(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value) || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function mergeOverride(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  for (const [key, value] of Object.entries(source)) {
+    const existing = target[key]
+    if (isPlainObjectForMerge(existing) && isPlainObjectForMerge(value)) {
+      mergeOverride(existing, value)
+      continue
+    }
+    target[key] = isPlainObjectForMerge(value) ? mergeOverride({}, value) : value
+  }
+  return target
+}
+
+function lookupOverride(
+  root: Record<string, unknown>,
+  path: ReadonlyArray<string>,
+): { readonly found: boolean; readonly value?: unknown } {
+  let current: unknown = root
+  for (const segment of path) {
+    if (!isRecord(current) || !Reflect.has(current, segment)) {
+      return { found: false }
+    }
+    current = current[segment]
+  }
+  return { found: true, value: current }
+}
+
+function shouldProxyOverrideObject(value: Record<string, unknown>): boolean {
+  return Object.values(value).some(
+    (child) => typeof child === 'function' || (isRecord(child) && !Array.isArray(child)),
+  )
+}
+
+function createOverrideProxy(state: RuntimeState, path: ReadonlyArray<string>): unknown {
+  const cacheKey = `override:${path.join('.')}`
+  const cached = state.proxyCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const currentOverride = lookupOverride(state.overrides, path)
+  const target =
+    currentOverride.found && isRecord(currentOverride.value) ? currentOverride.value : {}
+
+  const proxy = new Proxy(target, {
+    get(_target, prop) {
+      if (prop === 'then') {
+        return undefined
+      }
+      if (prop === Symbol.toStringTag) {
+        return 'Mock.Override'
+      }
+      if (typeof prop !== 'string') {
+        return undefined
+      }
+
+      const override = lookupOverride(state.overrides, path)
+      if (!override.found || !isRecord(override.value)) {
+        return Reflect.get(createDriverProxy(state, path) as object, prop)
+      }
+
+      if (Reflect.has(override.value, prop)) {
+        const value = override.value[prop]
+        if (isRecord(value) && !Array.isArray(value)) {
+          return shouldProxyOverrideObject(value)
+            ? createOverrideProxy(state, [...path, prop])
+            : value
+        }
+        return value
+      }
+
+      return createDriverProxy(state, [...path, prop])
+    },
+    has(_target, prop) {
+      if (typeof prop !== 'string') {
+        return false
+      }
+      const override = lookupOverride(state.overrides, path)
+      return (
+        (override.found && isRecord(override.value) && Reflect.has(override.value, prop)) ||
+        Reflect.has(createDriverProxy(state, path) as object, prop)
+      )
+    },
+    ownKeys() {
+      const override = lookupOverride(state.overrides, path)
+      return override.found && isRecord(override.value) ? Reflect.ownKeys(override.value) : []
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (typeof prop !== 'string') {
+        return undefined
+      }
+      const override = lookupOverride(state.overrides, path)
+      if (!override.found || !isRecord(override.value)) {
+        return undefined
+      }
+      if (!Reflect.has(override.value, prop)) {
+        return undefined
+      }
+      return {
+        configurable: true,
+        enumerable: true,
+        writable: false,
+        value: override.value[prop],
+      }
+    },
+  })
+
+  state.proxyCache.set(cacheKey, proxy)
+  return proxy
+}
+
+function clearOverrideProxyCache(state: RuntimeState) {
+  for (const key of [...state.proxyCache.keys()]) {
+    if (key.startsWith('override:')) {
+      state.proxyCache.delete(key)
+    }
+  }
+}
+
+function isDeepPartialMatch(expected: unknown, actual: unknown): boolean {
+  if (Object.is(expected, actual)) {
+    return true
+  }
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || expected.length !== actual.length) {
+      return false
+    }
+    return expected.every((value, index) => isDeepPartialMatch(value, actual[index]))
+  }
+  if (!isPlainObjectForMerge(expected)) {
+    return false
+  }
+  if (!isRecord(actual)) {
+    return false
+  }
+  return Object.entries(expected).every(([key, value]) => isDeepPartialMatch(value, actual[key]))
+}
+
+function clearControllerCalls(controller: RuntimeController) {
+  controller.calls.length = 0
+}
+
+function resetController(controller: RuntimeController) {
+  clearControllerCalls(controller)
+  controller.queue.length = 0
+  controller.every = undefined
+  controller.branches.length = 0
+}
+
+function resolveImplementation(
+  controller: RuntimeController,
+  args: unknown,
+): RuntimeImplementation | undefined {
+  for (const branch of controller.branches) {
+    if (!branch.matcher(args)) {
+      continue
+    }
+    const branchNext = branch.queue.shift()
+    if (branchNext !== undefined) {
+      return branchNext
+    }
+    if (branch.every !== undefined) {
+      return branch.every
+    }
+  }
+  const next = controller.queue.shift()
+  if (next !== undefined) {
+    return next
+  }
+  return controller.every
+}
+
+function successImplementation(value: unknown): RuntimeImplementation {
+  return () => Effect.succeed(value)
+}
+
+function failImplementation(error: unknown): RuntimeImplementation {
+  return () => Effect.fail(error)
+}
+
+function someImplementation(value: unknown): RuntimeImplementation {
+  return () => Effect.succeed(Option.some(value))
+}
+
+function noneImplementation(): RuntimeImplementation {
+  return () => Effect.succeed(Option.none())
+}
+
+function createRuntimeBranchConfigurer(
+  controller: RuntimeController,
+  branch: RuntimeBranch,
+): Record<string, unknown> {
+  return {
+    next(fn: RuntimeImplementation) {
+      branch.queue.push(fn)
+    },
+    every(fn: RuntimeImplementation) {
+      branch.every = fn
+    },
+    nextSuccess(value: unknown) {
+      branch.queue.push(successImplementation(value))
+    },
+    everySuccess(value: unknown) {
+      branch.every = successImplementation(value)
+    },
+    nextFail(error: unknown) {
+      branch.queue.push(failImplementation(error))
+    },
+    everyFail(error: unknown) {
+      branch.every = failImplementation(error)
+    },
+    nextSome(value: unknown) {
+      branch.queue.push(someImplementation(value))
+    },
+    everySome(value: unknown) {
+      branch.every = someImplementation(value)
+    },
+    nextNone() {
+      branch.queue.push(noneImplementation())
+    },
+    everyNone() {
+      branch.every = noneImplementation()
+    },
+    when(partialArgs: unknown) {
+      const nestedBranch = {
+        matcher: (args: unknown) => isDeepPartialMatch(partialArgs, args),
+        queue: [],
+        every: undefined,
+      } satisfies RuntimeBranch
+      controller.branches.push(nestedBranch)
+      return createRuntimeBranchConfigurer(controller, nestedBranch)
+    },
+  }
+}
+
+const controllerOwnKeys = [
+  'calls',
+  'clear',
+  'reset',
+  'next',
+  'every',
+  'nextSuccess',
+  'everySuccess',
+  'nextFail',
+  'everyFail',
+  'nextSome',
+  'everySome',
+  'nextNone',
+  'everyNone',
+  'when',
+] as const
+
+function createRuntimeControllerFacade(controller: RuntimeController): Record<string, unknown> {
+  const globalBranch = {
+    matcher: () => true,
+    queue: controller.queue,
+    get every() {
+      return controller.every
+    },
+    set every(value: RuntimeImplementation | undefined) {
+      controller.every = value
+    },
+  } as RuntimeBranch
+
+  return {
+    get calls() {
+      return controller.calls
+    },
+    clear() {
+      clearControllerCalls(controller)
+    },
+    reset() {
+      resetController(controller)
+    },
+    ...createRuntimeBranchConfigurer(controller, globalBranch),
+  }
+}
+
+function createDriverProxy(state: RuntimeState, path: ReadonlyArray<string>): unknown {
+  const cacheKey = path.join('.')
+  const cached = state.proxyCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  // oxlint-disable-next-line eslint/prefer-arrow-callback -- named function expression supplies proxy.name (callable Proxy target) used in error messages and runtime identification
+  const proxy = new Proxy(function mockServiceMethod() {}, {
+    get(_target, prop) {
+      if (prop === 'then') {
+        return undefined
+      }
+      if (prop === Symbol.toStringTag) {
+        return 'Mock'
+      }
+      if (typeof prop !== 'string') {
+        return undefined
+      }
+
+      if (path.length === 0 && prop === '$test') {
+        return state.controls
+      }
+
+      if (isHiddenStringProperty(prop, path.length === 0)) {
+        return undefined
+      }
+
+      if (path.length > 0) {
+        const controller = createRuntimeControllerFacade(getController(state, cacheKey))
+        if (Reflect.has(controller, prop)) {
+          return controller[prop]
+        }
+      }
+
+      const childPath = [...path, prop]
+      const override = lookupOverride(state.overrides, childPath)
+      if (override.found) {
+        if (isRecord(override.value) && !Array.isArray(override.value)) {
+          return shouldProxyOverrideObject(override.value)
+            ? createOverrideProxy(state, childPath)
+            : override.value
+        }
+        return override.value
+      }
+
+      return createDriverProxy(state, childPath)
+    },
+    apply(_target, _thisArg, args) {
+      if (path.length === 0) {
+        return missingMock('<root>')
+      }
+
+      const override = lookupOverride(state.overrides, path)
+      if (override.found && typeof override.value === 'function') {
+        return (override.value as (...args: ReadonlyArray<unknown>) => unknown)(...args)
+      }
+
+      const pathKey = path.join('.')
+      const normalizedArgs = normalizeArgs(args)
+      const controller = getController(state, pathKey)
+      controller.calls.push([normalizedArgs] as const)
+
+      const implementation = resolveImplementation(controller, normalizedArgs)
+      if (implementation === undefined) {
+        return missingMock(pathKey)
+      }
+      return implementation(normalizedArgs)
+    },
+    has(_target, prop) {
+      if (typeof prop !== 'string') {
+        return false
+      }
+      if (path.length === 0 && prop === '$test') {
+        return true
+      }
+      if (isHiddenStringProperty(prop, path.length === 0)) {
+        return false
+      }
+      if (path.length > 0) {
+        const controller = createRuntimeControllerFacade(getController(state, cacheKey))
+        if (Reflect.has(controller, prop)) {
+          return true
+        }
+      }
+      return true
+    },
+    ownKeys() {
+      if (path.length === 0) {
+        return ['$test']
+      }
+      return [...controllerOwnKeys]
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (typeof prop !== 'string') {
+        return undefined
+      }
+      if (path.length === 0 && prop === '$test') {
+        return { configurable: true, enumerable: false, writable: false, value: undefined }
+      }
+      if (isHiddenStringProperty(prop, path.length === 0)) {
+        return undefined
+      }
+      if (path.length > 0) {
+        const controller = createRuntimeControllerFacade(getController(state, cacheKey))
+        if (Reflect.has(controller, prop)) {
+          return {
+            configurable: true,
+            enumerable: false,
+            writable: false,
+            value: controller[prop],
+          }
+        }
+      }
+      return { configurable: true, enumerable: true, writable: false, value: undefined }
+    },
+  })
+
+  state.proxyCache.set(cacheKey, proxy)
+  return proxy
+}
+
+/**
+ * Create a mutable mock driver for an Effect context service.
+ *
+ * @param serviceKey The caller-owned service whose shape should be mocked.
+ *
+ * @example
+ * ```ts
+ * const git = Mock.make(Git)
+ * git.getTags.nextSuccess(['v1.0.0'])
+ * Effect.provide(program, git.$test.layer())
+ * ```
+ *
+ * @category Mocking
+ */
+export function make<TService extends Context.Service.Any>(serviceKey: TService): Driver<TService> {
+  const state: RuntimeState = {
+    serviceKey,
+    controllers: new Map<string, RuntimeController>(),
+    proxyCache: new Map<string, unknown>(),
+    service: undefined,
+    controls: undefined as unknown as Controls<Context.Service.Any>,
+    overrides: {},
+  }
+
+  const service = createDriverProxy(state, [])
+  state.service = service
+  state.controls = {
+    layer: () => Layer.succeed(serviceKey, service as Context.Service.Shape<TService>),
+    clearCalls: () => {
+      for (const controller of state.controllers.values()) {
+        clearControllerCalls(controller)
+      }
+    },
+    reset: () => {
+      for (const controller of state.controllers.values()) {
+        resetController(controller)
+      }
+      state.overrides = {}
+      clearOverrideProxyCache(state)
+    },
+    override: (partial) => {
+      mergeOverride(state.overrides, partial as unknown as Record<string, unknown>)
+      clearOverrideProxyCache(state)
+    },
+  } as Controls<Context.Service.Any>
+
+  return service as Driver<TService>
+}


### PR DESCRIPTION
Generic `@kitz/test` `Mock.make` driver (generalized from effect-prisma `Test.make`, Prisma delegate taxonomy removed) plus per-tag test services for `@kitz/git` and `@kitz/npm-registry`, retiring the need to re-stub the service interface inline for failure injection.

## @kitz/test — `Test.Mock`

`Mock.make(tag)` over any `Context.Service` of Effect-returning methods returns a proxy `Driver` mirroring the method tree. Each method is callable (acts as the mocked method) and carries per-method controls:

- `next` / `every` — raw `(args) => Effect` (FIFO vs sticky)
- `nextSuccess` / `everySuccess`, `nextFail` / `everyFail`
- `nextSome` / `everySome` / `nextNone` / `everyNone` — present only when the method's success channel is an `Option`
- `when(partialArgs)` — deep-partial branch matcher (recursive)
- `calls` (inspection), `clear()`, `reset()`

Driver-wide ``: `layer()`, `clearCalls()`, `reset()`, `override()` (pins synchronous fields). Resolution precedence: matching `when` branch `next` → branch `every` → global `next` FIFO → global `every` → otherwise the call dies with an unimplemented-mock error. Works on flat services (Git, NpmCli); recursion is path-length-driven so it terminates at depth 1.

Prisma specifics dropped: `StandardDelegate*` taxonomy, `Prisma.Result` select-narrowing, `findUniqueOrFail`/`*OrThrow` synthetic names, `$action`/`$batch`, the `Client<_,_>` constraint and `TRawObject` threading. Uses Effect v4 `Context.Service.Any/Shape/Identifier`, `Effect.Success/Error`, plain `Map` for state — no `@heartbeat/effect-plus`.

## Per-tag test services (`/test` subpath)

- `@kitz/git/test` — `make(config?)` returns a happy-path Git driver (defaults mirror `Git.Memory`: `main`/clean/`/repo`/example remote); inject failures via `git.createTag.everyFail(...)` without re-stubbing.
- `@kitz/npm-registry/test` — `make(config?)` returns a happy-path NpmCli driver (defaults mirror `NpmCliDryRun`: `dry-run-user`, fixed tarball, `hasVersion → true`, `getAccessStatus → 'public'`).

Both add `@kitz/test` as a regular dependency (so the `/test` entry resolves in consumers) and keep test machinery out of the main entrypoint via a dedicated `./test` export.