### PR TITLE
fix(pkg, release): unblock artifact staging

### DIFF
--- a/packages/pkg/src/manifest/publish.test.ts
+++ b/packages/pkg/src/manifest/publish.test.ts
@@ -1,6 +1,11 @@
 import { Semver } from '@kitz/semver'
 import { describe, expect, test } from 'bun:test'
-import { findLocalDependencyNames, findPackHooks, rewriteManifestForPack } from './publish.js'
+import {
+  findLocalDependencyNames,
+  findPackHooks,
+  findPublishOrderDependencyNames,
+  rewriteManifestForPack,
+} from './publish.js'
 
 describe('Pkg.Manifest publish rewrite', () => {
   test('rewrites version, runtime targets, and workspace protocol dependencies for pack', () => {
@@ -21,11 +26,15 @@ describe('Pkg.Manifest publish rewrite', () => {
         dependencies: {
           '@kitz/core': 'workspace:*',
           '@kitz/fs': 'workspace:^',
+          ansis: 'catalog:',
           effect: '^3.19.13',
         },
         peerDependencies: {
           '@kitz/env': 'workspace:~',
           '@kitz/git': 'workspace:^1.0.0',
+        },
+        devDependencies: {
+          '@kitz/platform': 'workspace:*',
         },
       },
       {
@@ -35,6 +44,9 @@ describe('Pkg.Manifest publish rewrite', () => {
           '@kitz/fs': Semver.fromString('2.0.0'),
           '@kitz/env': Semver.fromString('3.0.0'),
           '@kitz/git': Semver.fromString('4.0.0'),
+        },
+        catalogVersions: {
+          ansis: '^4.3.1',
         },
       },
     )
@@ -53,12 +65,14 @@ describe('Pkg.Manifest publish rewrite', () => {
     expect(result['dependencies']).toEqual({
       '@kitz/core': '1.0.0',
       '@kitz/fs': '^2.0.0',
+      ansis: '^4.3.1',
       effect: '^3.19.13',
     })
     expect(result['peerDependencies']).toEqual({
       '@kitz/env': '~3.0.0',
       '@kitz/git': '^1.0.0',
     })
+    expect(result).not.toHaveProperty('devDependencies')
   })
 
   test.each([
@@ -97,5 +111,41 @@ describe('Pkg.Manifest publish rewrite', () => {
         ['@kitz/core', '@kitz/fs', '@kitz/git'],
       ),
     ).toEqual(['@kitz/core', '@kitz/fs'])
+  })
+
+  test('findPublishOrderDependencyNames ignores local dev and peer dependency cycles', () => {
+    const manifestWithNonRuntimeDeps = {
+      dependencies: {},
+      optionalDependencies: {},
+      devDependencies: {
+        '@kitz/assert': 'workspace:*',
+      },
+      peerDependencies: {
+        '@kitz/fs': 'workspace:*',
+      },
+    }
+
+    expect(
+      findPublishOrderDependencyNames(
+        {
+          dependencies: {
+            '@kitz/core': 'workspace:*',
+          },
+          optionalDependencies: {
+            '@kitz/git': 'workspace:*',
+          },
+        },
+        ['@kitz/assert', '@kitz/core', '@kitz/fs', '@kitz/git'],
+      ),
+    ).toEqual(['@kitz/core', '@kitz/git'])
+
+    expect(
+      findPublishOrderDependencyNames(manifestWithNonRuntimeDeps, [
+        '@kitz/assert',
+        '@kitz/core',
+        '@kitz/fs',
+        '@kitz/git',
+      ]),
+    ).toEqual([])
   })
 })

--- a/packages/pkg/src/manifest/publish.ts
+++ b/packages/pkg/src/manifest/publish.ts
@@ -8,12 +8,15 @@ const dependencyFieldNames = [
   'peerDependencies',
   'optionalDependencies',
 ] as const
+const publishOrderDependencyFieldNames = ['dependencies', 'optionalDependencies'] as const
 
 type DependencyFieldName = (typeof dependencyFieldNames)[number]
+type PublishOrderDependencyFieldName = (typeof publishOrderDependencyFieldNames)[number]
 type JsonRecord = Record<string, unknown>
 
 interface RewriteDependencyOptions {
   readonly workspaceVersions: Readonly<Record<string, Semver.Semver>>
+  readonly catalogVersions?: Readonly<Record<string, string>>
 }
 
 export interface RewriteManifestForPackOptions extends RewriteDependencyOptions {
@@ -28,7 +31,15 @@ const rewriteDependencyField = (field: unknown, options: RewriteDependencyOption
 
   return Object.fromEntries(
     Object.entries(field).map(([dependencyName, specifier]) => {
-      if (typeof specifier !== 'string' || !specifier.startsWith('workspace:')) {
+      if (typeof specifier !== 'string') {
+        return [dependencyName, specifier]
+      }
+
+      if (specifier === 'catalog:') {
+        return [dependencyName, options.catalogVersions?.[dependencyName] ?? specifier]
+      }
+
+      if (!specifier.startsWith('workspace:')) {
         return [dependencyName, specifier]
       }
 
@@ -73,6 +84,7 @@ export const rewriteManifestForPack = (
   for (const fieldName of dependencyFieldNames) {
     nextManifest[fieldName] = rewriteDependencyField(manifest[fieldName], options)
   }
+  delete nextManifest['devDependencies']
 
   return nextManifest
 }
@@ -115,4 +127,34 @@ export const findLocalDependencyNames = (
   return names
 }
 
+/**
+ * Find local package dependencies that affect publish ordering.
+ *
+ * Dev and peer dependencies do not need a registry publish to happen first, so
+ * they must not create release workflow cycles.
+ */
+export const findPublishOrderDependencyNames = (
+  manifest: {
+    readonly dependencies?: Readonly<Record<string, string>> | undefined
+    readonly optionalDependencies?: Readonly<Record<string, string>> | undefined
+  },
+  localPackageNames: readonly string[],
+): readonly string[] => {
+  const names: string[] = []
+
+  for (const fieldName of publishOrderDependencyFieldNames) {
+    const field = manifest[fieldName]
+    if (field === undefined) continue
+
+    for (const dependencyName of Object.keys(field)) {
+      if (localPackageNames.includes(dependencyName) && !names.includes(dependencyName)) {
+        names.push(dependencyName)
+      }
+    }
+  }
+
+  return names
+}
+
 export type DependencyField = DependencyFieldName
+export type PublishOrderDependencyField = PublishOrderDependencyFieldName

--- a/packages/release/src/api/artifact.test.ts
+++ b/packages/release/src/api/artifact.test.ts
@@ -310,6 +310,41 @@ describe('artifact manifest', () => {
     expect(result.error).toBeInstanceOf(PublishError)
   })
 
+  test('rehearsal rejects unresolved catalog dependencies before pack', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness({
+          git: {
+            tags: [tag(Pkg.Moniker.parse('@kitz/core'), '1.0.0')],
+            commits: [Git.Memory.commit('feat(core): new API')],
+            isClean: true,
+          },
+          diskLayout: {
+            '/repo/package.json': JSON.stringify({ name: 'repo', catalog: {} }),
+            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
+              dependencies: {
+                ansis: 'catalog:',
+              },
+            }),
+          },
+        })
+        const releasePlan = yield* planOfficial([pkg]).pipe(Effect.provide(harness.planLayer))
+        const error = yield* rehearse(releasePlan).pipe(
+          Effect.flip,
+          Effect.provide(harness.workflowLayer),
+        )
+        const packCalls = yield* Ref.get(harness.packCalls)
+        return { error, packCalls }
+      }),
+    )
+
+    expect(result.packCalls).toEqual([])
+    if (!(result.error instanceof PublishError)) {
+      throw new Error('expected PublishError')
+    }
+    expect(result.error.message).toContain('ansis')
+  })
+
   test('rehearsal gives pack child processes only the plan-approved environment', async () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/release/src/api/executor/execute.test.ts
+++ b/packages/release/src/api/executor/execute.test.ts
@@ -103,6 +103,12 @@ describe('executor execute helpers', () => {
             '/repo/packages/core/package.json': JSON.stringify({
               name: '@kitz/core',
               version: '1.0.0',
+              peerDependencies: {
+                '@kitz/cli': 'workspace:*',
+              },
+              devDependencies: {
+                '@kitz/cli': 'workspace:*',
+              },
             }),
             '/repo/packages/cli/package.json': JSON.stringify({
               name: '@kitz/cli',
@@ -120,6 +126,7 @@ describe('executor execute helpers', () => {
       '@kitz/core',
       '@kitz/cli',
     ])
+    expect(payload.releases[0]!.dependsOn).toEqual([])
     expect(payload.releases[1]!.dependsOn).toEqual(['@kitz/core'])
     expect(payload.releases[0]!.currentVersion).toEqual(Option.some('1.0.0'))
     expect(payload.options).toEqual({

--- a/packages/release/src/api/executor/execute.ts
+++ b/packages/release/src/api/executor/execute.ts
@@ -509,7 +509,7 @@ export const toPayload = (
             commits: item.commits.map((commit) =>
               toReleasePayloadCommitEntry(commit, item.package.scope),
             ),
-            dependsOn: Pkg.Manifest.findLocalDependencyNames(manifest, localPackageNames),
+            dependsOn: Pkg.Manifest.findPublishOrderDependencyNames(manifest, localPackageNames),
           }
         }),
       ),

--- a/packages/release/src/api/executor/publish.ts
+++ b/packages/release/src/api/executor/publish.ts
@@ -87,6 +87,29 @@ export interface PublishOptions {
 const formatUnknownError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
+const isStringRecord = (value: unknown): value is Record<string, string> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.values(value).every((entry) => typeof entry === 'string')
+
+const catalogVersionsFrom = (manifest: Record<string, unknown>): Record<string, string> => {
+  const catalog = manifest['catalog']
+  return isStringRecord(catalog) ? catalog : {}
+}
+
+const packedDependencyFieldNames = ['dependencies', 'peerDependencies', 'optionalDependencies']
+
+const unresolvedCatalogDependenciesIn = (manifest: Record<string, unknown>): readonly string[] =>
+  A.flatMap(packedDependencyFieldNames, (fieldName) => {
+    const field = manifest[fieldName]
+    if (!isStringRecord(field)) return []
+
+    return Object.entries(field)
+      .filter(([, specifier]) => specifier === 'catalog:')
+      .map(([dependencyName]) => dependencyName)
+  })
+
 const decodeJsonRecordOrFail = (pkgDir: Fs.Path.AbsDir, json: string) =>
   decodeJsonRecord(json).pipe(
     Effect.mapError(
@@ -225,6 +248,7 @@ export const preparePackageArtifact = (
       release.package.path,
       Fs.Path.RelFile.fromString('./package.json'),
     )
+    const rootPackageJsonPath = Fs.Path.join(env.cwd, Fs.Path.RelFile.fromString('./package.json'))
     const packageJsonPathString = Fs.Path.toString(packageJsonPath)
     const artifactDir = artifactDirectoryFor(env.cwd, options)
     const artifactPath = artifactPathFor(env.cwd, release, options)
@@ -236,12 +260,29 @@ export const preparePackageArtifact = (
 
     const originalJson = yield* fs.readFileString(packageJsonPathString)
     const originalManifest = yield* decodeJsonRecordOrFail(release.package.path, originalJson)
+    const catalogVersions = yield* fs.readFileString(Fs.Path.toString(rootPackageJsonPath)).pipe(
+      Effect.flatMap((rootJson) => decodeJsonRecordOrFail(env.cwd, rootJson)),
+      Effect.map(catalogVersionsFrom),
+      Effect.orElseSucceed(() => ({})),
+    )
     const typedManifest = yield* Pkg.Manifest.resource.readOrEmpty(release.package.path)
     const packHooks = Pkg.Manifest.findPackHooks(typedManifest.scripts)
     const rewrittenManifest = Pkg.Manifest.rewriteManifestForPack(originalManifest, {
       version: release.nextVersion,
       workspaceVersions: workspaceVersionsFor(releases),
+      catalogVersions,
     })
+    const unresolvedCatalogDependencies = unresolvedCatalogDependenciesIn(rewrittenManifest)
+    if (unresolvedCatalogDependencies.length > 0) {
+      return yield* Effect.fail(
+        new PublishError({
+          context: {
+            package: release.package.path,
+            detail: `Unresolved catalog dependencies in staged manifest: ${unresolvedCatalogDependencies.join(', ')}`,
+          },
+        }),
+      )
+    }
 
     yield* fs
       .remove(Fs.Path.toString(stagedPackageDir), { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- Order release execution from runtime publish dependencies only, so local dev/peer dependency cycles do not block the publish DAG.
- Strip devDependencies from staged package manifests before `bun pm pack`.
- Resolve root `catalog:` specs while staging package artifacts so packed manifests are registry-safe.

## Review Follow-up

- Added a regression that rejects any remaining `catalog:` spec in packed dependency fields before pack/staging can proceed.
- Added payload-level coverage that dev/peer cycles do not leak into publish execution ordering.

## QA

- `bun run --cwd packages/pkg test src/manifest/publish.test.ts`
- `bun run --cwd packages/release test src/api/artifact.test.ts --test-name-pattern "catalog|malformed|rehearsal proves"`
- `bun run --cwd packages/release test src/api/executor/execute.test.ts`
- `bun run --cwd packages/pkg check:types`
- `bun run --cwd packages/release check:types`
- `git diff --check`
