### PR TITLE
fix(release): include runtime dependency closure

### DIFF
--- a/packages/pkg/src/manifest/publish.test.ts
+++ b/packages/pkg/src/manifest/publish.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   findLocalDependencyNames,
   findPackHooks,
+  findPublishedManifestWorkspaceDependencyNames,
   findPublishOrderDependencyNames,
   rewriteManifestForPack,
 } from './publish.js'
@@ -147,5 +148,28 @@ describe('Pkg.Manifest publish rewrite', () => {
         '@kitz/git',
       ]),
     ).toEqual([])
+  })
+
+  test('findPublishedManifestWorkspaceDependencyNames only reports packed workspace protocols', () => {
+    expect(
+      findPublishedManifestWorkspaceDependencyNames(
+        {
+          dependencies: {
+            '@kitz/core': '^1.0.0',
+            '@kitz/fs': 'workspace:*',
+          },
+          peerDependencies: {
+            '@kitz/git': 'workspace:^',
+          },
+          optionalDependencies: {
+            '@kitz/env': 'workspace:~',
+          },
+          devDependencies: {
+            '@kitz/assert': 'workspace:*',
+          },
+        },
+        ['@kitz/assert', '@kitz/core', '@kitz/env', '@kitz/fs', '@kitz/git'],
+      ),
+    ).toEqual(['@kitz/fs', '@kitz/git', '@kitz/env'])
   })
 })

--- a/packages/pkg/src/manifest/publish.ts
+++ b/packages/pkg/src/manifest/publish.ts
@@ -9,9 +9,16 @@ const dependencyFieldNames = [
   'optionalDependencies',
 ] as const
 const publishOrderDependencyFieldNames = ['dependencies', 'optionalDependencies'] as const
+const publishedManifestWorkspaceDependencyFieldNames = [
+  'dependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const
 
 type DependencyFieldName = (typeof dependencyFieldNames)[number]
 type PublishOrderDependencyFieldName = (typeof publishOrderDependencyFieldNames)[number]
+type PublishedManifestWorkspaceDependencyFieldName =
+  (typeof publishedManifestWorkspaceDependencyFieldNames)[number]
 type JsonRecord = Record<string, unknown>
 
 interface RewriteDependencyOptions {
@@ -156,5 +163,43 @@ export const findPublishOrderDependencyNames = (
   return names
 }
 
+/**
+ * Find local workspace-protocol dependencies that remain in published manifests
+ * unless the release plan includes a version for them.
+ *
+ * Dev dependencies are removed from packed manifests, while peer dependencies
+ * remain and must also have their workspace protocol rewritten.
+ */
+export const findPublishedManifestWorkspaceDependencyNames = (
+  manifest: {
+    readonly dependencies?: Readonly<Record<string, string>> | undefined
+    readonly devDependencies?: Readonly<Record<string, string>> | undefined
+    readonly peerDependencies?: Readonly<Record<string, string>> | undefined
+    readonly optionalDependencies?: Readonly<Record<string, string>> | undefined
+  },
+  localPackageNames: readonly string[],
+): readonly string[] => {
+  const names: string[] = []
+
+  for (const fieldName of publishedManifestWorkspaceDependencyFieldNames) {
+    const field = manifest[fieldName]
+    if (field === undefined) continue
+
+    for (const [dependencyName, specifier] of Object.entries(field)) {
+      if (
+        specifier.startsWith('workspace:') &&
+        localPackageNames.includes(dependencyName) &&
+        !names.includes(dependencyName)
+      ) {
+        names.push(dependencyName)
+      }
+    }
+  }
+
+  return names
+}
+
 export type DependencyField = DependencyFieldName
 export type PublishOrderDependencyField = PublishOrderDependencyFieldName
+export type PublishedManifestWorkspaceDependencyField =
+  PublishedManifestWorkspaceDependencyFieldName

--- a/packages/release/src/api/planner/candidate.ts
+++ b/packages/release/src/api/planner/candidate.ts
@@ -7,9 +7,22 @@ import * as Version from '../version/__.js'
 import { calculateNextVersion } from '../version/calculate.js'
 import { mapOfficialCascades, planLifecycle } from './core.js'
 import { Candidate } from './models/item-candidate.js'
+import type { Official } from './models/item-official.js'
 import type { PlanOf } from './models/plan.js'
 import type { Context } from './official.js'
 import { type Options } from './options.js'
+
+const toCandidateRelease = (release: Official, tags: readonly string[]): Candidate => {
+  const baseVersion = release.nextVersion
+  const candidateNumber = findLatestCandidateNumber(release.package.name, baseVersion, [...tags])
+
+  return Candidate.make({
+    package: release.package,
+    baseVersion,
+    prerelease: Version.Candidate.make({ iteration: candidateNumber + 1 }),
+    commits: release.commits,
+  })
+}
 
 /**
  * Detect cascades for candidate releases with candidate version format.
@@ -25,17 +38,7 @@ const detectCascadesForCandidate = (
     primaryReleases,
     dependencyGraph,
     tags,
-    map: (cascade) => {
-      const baseVersion = cascade.nextVersion
-      const candidateNumber = findLatestCandidateNumber(cascade.package.name, baseVersion, tags)
-
-      return Candidate.make({
-        package: cascade.package,
-        baseVersion,
-        prerelease: Version.Candidate.make({ iteration: candidateNumber + 1 }),
-        commits: cascade.commits,
-      })
-    },
+    map: (cascade) => toCandidateRelease(cascade, tags),
   })
 }
 
@@ -75,6 +78,7 @@ export const candidate = (
         commits: impact.commits,
       })
     },
+    toSecondaryRelease: (release) => toCandidateRelease(release, analysis.tags),
     toCascades: ({ packages, primaryReleases, dependencyGraph, tags }) =>
       detectCascadesForCandidate(packages, primaryReleases, dependencyGraph, [...tags]),
   })

--- a/packages/release/src/api/planner/cascade.ts
+++ b/packages/release/src/api/planner/cascade.ts
@@ -1,4 +1,5 @@
 import { FileSystem } from 'effect'
+import { Pkg } from '@kitz/pkg'
 import { Resource } from '@kitz/resource'
 import { Effect, HashMap, MutableHashSet, Option } from 'effect'
 import { buildDependencyGraph, type DependencyGraph } from '../analyzer/cascade.js'
@@ -174,3 +175,70 @@ export const detect = (
 
   return cascades
 }
+
+const makePatchRelease = (pkg: Package, tags: readonly string[], commits: ReleaseCommit[]) => {
+  const currentVersion = findLatestTagVersion(pkg.name, [...tags])
+  const nextVersion = calculateNextVersion(currentVersion, 'patch')
+  const version: OfficialFirst | OfficialIncrement = Option.isSome(currentVersion)
+    ? OfficialIncrement.make({ from: currentVersion.value, to: nextVersion, bump: 'patch' })
+    : OfficialFirst.make({ version: nextVersion, bump: 'patch' })
+
+  return Official.make({
+    package: pkg,
+    version,
+    commits,
+  })
+}
+
+/**
+ * Find runtime workspace dependencies that must be part of a publish plan.
+ *
+ * Artifact staging rewrites workspace dependency specifiers from the planned
+ * version map. If a planned package has a runtime workspace dependency outside
+ * the plan, its staged manifest still contains `workspace:*` and cannot pack.
+ */
+export const detectPublishDependencyClosure = (
+  packages: readonly Package[],
+  plannedItems: readonly Item[],
+  tags: readonly string[],
+): Effect.Effect<readonly Official[], Resource.ResourceError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const localPackageNames = packages.map((pkg) => pkg.name.moniker)
+    const packageByName = HashMap.fromIterable(
+      packages.map((pkg): [string, Package] => [pkg.name.moniker, pkg]),
+    )
+    const plannedNames = MutableHashSet.fromIterable(
+      plannedItems.map((item) => item.package.name.moniker),
+    )
+    const queue = plannedItems.map((item) => item.package.name.moniker)
+    const closureReleases: Official[] = []
+
+    while (queue.length > 0) {
+      const packageName = queue.shift()!
+      const pkg = Option.getOrUndefined(HashMap.get(packageByName, packageName))
+      if (pkg === undefined) continue
+
+      const manifestOption = yield* Pkg.Manifest.resource.read(pkg.path)
+      if (Option.isNone(manifestOption)) continue
+
+      for (const dependencyName of Pkg.Manifest.findPublishedManifestWorkspaceDependencyNames(
+        manifestOption.value,
+        localPackageNames,
+      )) {
+        if (MutableHashSet.has(plannedNames, dependencyName)) continue
+
+        const dependencyPackage = Option.getOrUndefined(HashMap.get(packageByName, dependencyName))
+        if (dependencyPackage === undefined) continue
+
+        MutableHashSet.add(plannedNames, dependencyName)
+        queue.push(dependencyName)
+        closureReleases.push(
+          makePatchRelease(dependencyPackage, tags, [
+            makeCascadeCommit(dependencyPackage.scope, `Runtime dependency of ${packageName}`),
+          ]),
+        )
+      }
+    }
+
+    return closureReleases
+  })

--- a/packages/release/src/api/planner/core.test.ts
+++ b/packages/release/src/api/planner/core.test.ts
@@ -14,6 +14,7 @@ import { Candidate } from './models/item-candidate.js'
 import { Ephemeral } from './models/item-ephemeral.js'
 import { ephemeral } from './ephemeral.js'
 import { planLifecycle } from './core.js'
+import { official } from './official.js'
 
 const packages: readonly Package[] = [
   {
@@ -27,6 +28,18 @@ const packages: readonly Package[] = [
     path: Fs.Path.AbsDir.fromString('/repo/packages/cli/'),
   },
 ]
+
+const platformPackage: Package = {
+  scope: 'platform',
+  name: Pkg.Moniker.parse('@kitz/platform'),
+  path: Fs.Path.AbsDir.fromString('/repo/packages/platform/'),
+}
+
+const assertPackage: Package = {
+  scope: 'assert',
+  name: Pkg.Moniker.parse('@kitz/assert'),
+  path: Fs.Path.AbsDir.fromString('/repo/packages/assert/'),
+}
 
 const analysis = Analysis.make({
   impacts: [
@@ -96,6 +109,7 @@ describe('planner core', () => {
             commits: impact.commits,
           })
         },
+        toSecondaryRelease: (release) => release,
         toCascades: ({ primaryReleases, dependencyGraph, tags }) => {
           expect(primaryReleases.map((release) => release.package.name.moniker)).toEqual([
             '@kitz/core',
@@ -113,6 +127,68 @@ describe('planner core', () => {
     expect(result.lifecycle).toBe('official')
     expect(result.releases).toHaveLength(1)
     expect(result.cascades).toHaveLength(0)
+  })
+
+  test('adds runtime workspace dependencies needed to pack planned packages', async () => {
+    const cliPackage = packages[1]!
+    const result = await Effect.runPromise(
+      official(
+        Analysis.make({
+          impacts: [
+            Impact.make({
+              package: cliPackage,
+              bump: 'patch',
+              commits: [makeCascadeCommit('cli', 'fix')],
+              currentVersion: Option.some(Semver.fromString('2.0.0')),
+            }),
+          ],
+          cascades: [],
+          unchanged: [packages[0]!, platformPackage],
+          tags: ['@kitz/cli@2.0.0', '@kitz/core@1.0.0'],
+        }),
+        { packages: [...packages, assertPackage, platformPackage] },
+      ).pipe(
+        Effect.provide(
+          Fs.Memory.layer({
+            '/repo/packages/core/package.json': JSON.stringify({
+              name: '@kitz/core',
+              version: '1.0.0',
+            }),
+            '/repo/packages/cli/package.json': JSON.stringify({
+              name: '@kitz/cli',
+              version: '2.0.0',
+              dependencies: {
+                '@kitz/platform': 'workspace:*',
+                '@kitz/core': '^1.0.0',
+              },
+              peerDependencies: {
+                '@kitz/assert': 'workspace:^',
+              },
+              devDependencies: {
+                '@kitz/core': 'workspace:*',
+              },
+            }),
+            '/repo/packages/platform/package.json': JSON.stringify({
+              name: '@kitz/platform',
+              version: '0.0.0-kitz-release',
+            }),
+            '/repo/packages/assert/package.json': JSON.stringify({
+              name: '@kitz/assert',
+              version: '0.0.0-kitz-release',
+            }),
+          }),
+        ),
+      ),
+    )
+
+    expect(result.releases.map((release) => release.package.name.moniker)).toEqual(['@kitz/cli'])
+    expect(result.cascades.map((release) => release.package.name.moniker).toSorted()).toEqual([
+      '@kitz/assert',
+      '@kitz/platform',
+    ])
+    expect(result.cascades.every((release) => release.nextVersion.toString() === '0.0.1')).toBe(
+      true,
+    )
   })
 
   test('candidate planning preserves candidate typing and remaps cascade iterations', async () => {

--- a/packages/release/src/api/planner/core.ts
+++ b/packages/release/src/api/planner/core.ts
@@ -5,7 +5,7 @@ import { buildDependencyGraph, type DependencyGraph } from '../analyzer/cascade.
 import type { Analysis, Impact } from '../analyzer/models/__.js'
 import type { Package } from '../analyzer/workspace.js'
 import type { Lifecycle } from '../version/models/lifecycle.js'
-import { detect as detectOfficialCascades } from './cascade.js'
+import { detect as detectOfficialCascades, detectPublishDependencyClosure } from './cascade.js'
 import type { Official } from './models/item-official.js'
 import { make, type PlanOf, type PlannedItem } from './models/plan.js'
 import { passesFilter } from './options.js'
@@ -33,6 +33,7 @@ export interface PlanLifecycleParams<
   readonly lifecycle: $lifecycle
   readonly options?: $options
   readonly toPrimaryRelease: (impact: Impact) => PlannedItem<$lifecycle>
+  readonly toSecondaryRelease: (release: Official) => PlannedItem<$lifecycle>
   readonly toCascades: (params: CascadeParams<$lifecycle>) => readonly PlannedItem<$lifecycle>[]
 }
 
@@ -74,6 +75,14 @@ export const planLifecycle = <
       dependencyGraph,
       tags: [...params.analysis.tags],
     })
+    const dependencyReleases = yield* detectPublishDependencyClosure(
+      [...params.packages],
+      [...releases, ...cascades],
+      [...params.analysis.tags],
+    )
 
-    return make(params.lifecycle, releases, [...cascades])
+    return make(params.lifecycle, releases, [
+      ...cascades,
+      ...dependencyReleases.map(params.toSecondaryRelease),
+    ])
   })

--- a/packages/release/src/api/planner/ephemeral.ts
+++ b/packages/release/src/api/planner/ephemeral.ts
@@ -12,9 +12,25 @@ import * as Version from '../version/__.js'
 import { mapOfficialCascades, planLifecycle } from './core.js'
 import { ReleaseError } from './errors.js'
 import { Ephemeral } from './models/item-ephemeral.js'
+import type { Official } from './models/item-official.js'
 import type { PlanOf } from './models/plan.js'
 import type { Context } from './official.js'
 import { type EphemeralOptions } from './options.js'
+
+const toEphemeralRelease = (
+  release: Official,
+  tags: readonly string[],
+  prNumber: number,
+  sha: Git.Sha.Sha,
+): Ephemeral => {
+  const prReleaseNumber = findLatestEphemeralNumber(release.package.name, prNumber, [...tags])
+
+  return Ephemeral.make({
+    package: release.package,
+    prerelease: Version.Ephemeral.make({ prNumber, iteration: prReleaseNumber + 1, sha }),
+    commits: release.commits,
+  })
+}
 
 /**
  * Detect cascades for ephemeral releases with ephemeral version format.
@@ -32,15 +48,7 @@ const detectCascadesForEphemeral = (
     primaryReleases,
     dependencyGraph,
     tags,
-    map: (cascade) => {
-      const prReleaseNumber = findLatestEphemeralNumber(cascade.package.name, prNumber, tags)
-
-      return Ephemeral.make({
-        package: cascade.package,
-        prerelease: Version.Ephemeral.make({ prNumber, iteration: prReleaseNumber + 1, sha }),
-        commits: cascade.commits,
-      })
-    },
+    map: (cascade) => toEphemeralRelease(cascade, tags, prNumber, sha),
   })
 }
 
@@ -116,6 +124,7 @@ export const ephemeral = (
           commits: impact.commits,
         })
       },
+      toSecondaryRelease: (release) => toEphemeralRelease(release, analysis.tags, prNumber, sha),
       toCascades: ({ packages, primaryReleases, dependencyGraph, tags }) =>
         detectCascadesForEphemeral(
           packages,

--- a/packages/release/src/api/planner/official.ts
+++ b/packages/release/src/api/planner/official.ts
@@ -56,6 +56,7 @@ export const official = (
         commits: impact.commits,
       })
     },
+    toSecondaryRelease: (release) => release,
     toCascades: ({ packages, primaryReleases, dependencyGraph, tags }) =>
       detectCascades(packages, [...primaryReleases], dependencyGraph, [...tags]),
   })


### PR DESCRIPTION
## Summary

- Adds a publish-dependency closure pass after normal cascade planning.
- Includes runtime workspace dependencies in the plan when a planned package needs them for manifest rewriting and packing.
- Maps those synthetic secondary releases through official, candidate, and ephemeral lifecycle versioning.

## Review Follow-up

- Closure detection now includes packed `peerDependencies` and `optionalDependencies` that still use `workspace:`.
- Closure detection ignores dev-only workspace deps and local package names whose packed specifier is already registry-safe semver.

## Stack

This is stacked on #253 (`codex/release-execution-dry-run-fixes`).

## QA

- `bun run --cwd packages/pkg test src/manifest/publish.test.ts`
- `bun run --cwd packages/release test src/api/planner/core.test.ts`
- `bun run --cwd packages/pkg check:types`
- `bun run --cwd packages/release check:types`
- `git diff --check`
