### PR TITLE
fix(release): smooth dry-run command guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "platform:verify": "bun run check:platform",
     "pre-commit": "bun tools/pre-commit.ts",
     "release:plan:ephemeral": "bun run release plan --lifecycle ephemeral",
-    "release:apply:ephemeral": "bun run release apply --yes --tag pr",
+    "release:apply:ephemeral": "bun run release apply --yes",
     "_:build": "tsgo -p tsconfig.build.json",
     "_:dev": "tsgo -p tsconfig.build.json --watch",
     "_:check:types": "bun run --workspaces check:types",

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -315,7 +315,7 @@ export default defineConfig({
 
 Programmatic callers can override file config per-field via `Config.load(options)` without modifying `release.config.ts`.
 
-Use `release apply --dry-run` when you want to preview a release without publishing packages or mutating git and GitHub state.
+Use `release preview` to inspect the frozen plan, `release prove` to refresh plan-bound environment proof, and `release rehearse` to build the exact artifacts before running `release apply`.
 
 Use `release plan --out <file>` when you want to persist a plan somewhere other than `.release/plan.json`, and pair it with `release apply --from <file>` to execute that exact snapshot without moving the active plan file.
 

--- a/packages/release/src/_.test.ts
+++ b/packages/release/src/_.test.ts
@@ -12,7 +12,7 @@ import { Test } from '@kitz/test'
 import { Effect, Layer, Option, Schema } from 'effect'
 import { describe, expect, test } from 'bun:test'
 import * as ReleaseConfig from './api/config.js'
-import { Analyzer, Planner } from './__.js'
+import { Analyzer, Planner, Publishing, ReleaseContract } from './__.js'
 
 // ─── Test Helpers ───────────────────────────────────────────────────
 
@@ -266,6 +266,68 @@ describe('release package scripts', () => {
       expect(output).toContain('real release test runs')
       expect(output).not.toContain('mirrored worktree test should not run')
       expect(output).not.toContain('.claude/worktrees')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('release status cli', () => {
+  test('reports not-started for a custom plan before .release exists', () => {
+    const projectDir = mkdtempSync(path.join(os.tmpdir(), 'kitz-release-status-'))
+
+    try {
+      writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'fixture', private: true, type: 'module' }, null, 2),
+      )
+
+      const plan = Planner.Plan.make({
+        lifecycle: 'official',
+        timestamp: '2026-06-09T00:00:00.000Z',
+        releases: [],
+        cascades: [],
+        planDigest: ReleaseContract.PlanDigest.make({
+          algorithm: 'sha256',
+          value: 'a'.repeat(64),
+        }),
+        publishIntent: ReleaseContract.publishIntentFromSemantics({
+          semantics: Publishing.resolvePublishSemantics({ lifecycle: 'official' }),
+          trunk: 'main',
+        }),
+      })
+      writeFileSync(
+        path.join(projectDir, 'release-plan.json'),
+        `${JSON.stringify(Schema.encodeSync(Planner.Plan)(plan), null, 2)}\n`,
+      )
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          fileURLToPath(new URL('./cli/cli.ts', import.meta.url)),
+          'status',
+          '--from',
+          'release-plan.json',
+          '--format',
+          'json',
+        ],
+        {
+          cwd: projectDir,
+          encoding: 'utf8',
+          env: process.env,
+        },
+      )
+
+      if (result.error) {
+        throw result.error
+      }
+
+      expect(result.stderr).toBe('')
+      expect(result.status).toBe(0)
+      expect(decodeJsonRecordSync(result.stdout)).toMatchObject({
+        state: 'not-started',
+        plannedPackages: [],
+      })
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/packages/release/src/api/renderer/plan.test.ts
+++ b/packages/release/src/api/renderer/plan.test.ts
@@ -194,7 +194,9 @@ describe('renderApplyConfirmation', () => {
     expect(output).toContain('npm')
     expect(output).toContain('GitHub releases')
     expect(output).toContain('@kitz/core v1.1.0')
-    expect(output).toContain('--dry-run')
+    expect(output).toContain('release preview')
+    expect(output).toContain('release prove')
+    expect(output).toContain('release rehearse')
   })
 
   test('pluralizes for multiple packages', () => {
@@ -222,6 +224,22 @@ describe('renderApplyConfirmation', () => {
 
     expect(output).toContain('\u001b[')
     expect(Str.Visual.strip(output)).toContain('npm dist-tag: `latest`')
+  })
+
+  test('uses the resolved release command for command guidance', () => {
+    const plan = Plan.make({
+      lifecycle: 'official',
+      timestamp: '2026-01-01T00:00:00Z',
+      releases: [makeRelease('@kitz/core', 'core', '1.0.0', '1.1.0', 'minor')],
+      cascades: [],
+    })
+    const output = renderApplyConfirmation(plan, officialSemantics, {
+      releaseCommand: 'bun run ship',
+    })
+
+    expect(output).toContain('bun run ship preview')
+    expect(output).toContain('bun run ship prove')
+    expect(output).toContain('bun run ship rehearse')
   })
 
   test('renders cascade entries in confirmation output', () => {

--- a/packages/release/src/api/renderer/plan.ts
+++ b/packages/release/src/api/renderer/plan.ts
@@ -40,11 +40,12 @@ export const renderPlan = (plan: Plan): string => {
 export const renderApplyConfirmation = (
   plan: Plan,
   semantics: PublishSemantics,
-  options?: Cli.Terminal.TerminalFormatOptions,
+  options?: Cli.Terminal.TerminalFormatOptions & { readonly releaseCommand?: string },
 ): string => {
   const totalReleases = plan.releases.length + plan.cascades.length
   const output = Str.Builder()
   const theme = Cli.Terminal.createTerminalTheme(options)
+  const releaseCommand = options?.releaseCommand ?? 'release'
 
   output(
     `${theme.badge('accent', 'APPLY')} ${theme.heading(`${formatLifecycle(plan.lifecycle)} release plan`)}`,
@@ -68,7 +69,7 @@ export const renderApplyConfirmation = (
   output`  5. Create GitHub releases`
   output``
   output(
-    `Use ${theme.code('--dry-run')} to preview without side effects, or ${theme.code('--yes')} to skip this prompt.`,
+    `Use ${theme.code(`${releaseCommand} preview`)}, ${theme.code(`${releaseCommand} prove`)}, and ${theme.code(`${releaseCommand} rehearse`)} before apply, or ${theme.code('--yes')} to skip this prompt.`,
   )
   return output.render()
 }

--- a/packages/release/src/cli/commands/apply.ts
+++ b/packages/release/src/cli/commands/apply.ts
@@ -164,8 +164,15 @@ export const apply = Command.make(
 
           // Confirmation prompt (unless --yes)
           if (!yes) {
+            const releaseCommand = yield* Api.Config.load().pipe(
+              Effect.map((config) => config.operator.releaseCommand),
+              Effect.catch(() => Effect.succeed('release')),
+            )
             yield* Console.log(
-              Api.Renderer.renderApplyConfirmation(plan, publish, { env: env.vars }),
+              Api.Renderer.renderApplyConfirmation(plan, publish, {
+                env: env.vars,
+                releaseCommand,
+              }),
             )
             const approved = yield* confirm('Proceed with release? [y/N] ')
             if (!approved) {

--- a/packages/release/src/cli/commands/status.ts
+++ b/packages/release/src/cli/commands/status.ts
@@ -8,7 +8,7 @@
  */
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
-import { Console, Effect, Layer, Option } from 'effect'
+import { Console, Effect, FileSystem, Layer, Option } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { FileSystemLayer } from '../../platform.js'
@@ -75,6 +75,13 @@ export const status = Command.make(
         return env.exit(1)
       }
       const publishing = Api.Publishing.publishingFromIntent(plan.publishIntent)
+      const fs = yield* FileSystem.FileSystem
+      yield* fs.makeDirectory(
+        Fs.Path.toString(Fs.Path.join(env.cwd, Fs.Path.RelDir.fromString('./.release/'))),
+        {
+          recursive: true,
+        },
+      )
 
       const workflowStatus = yield* Api.Executor.status(plan, {
         tag: plan.publishIntent.distTag,


### PR DESCRIPTION
## Summary

- Stop the ephemeral apply script from passing the rejected `release apply --tag pr` flag.
- Replace stale `release apply --dry-run` guidance with the current `preview` / `prove` / `rehearse` flow.
- Ensure `release status --from <plan>` creates `.release/` before opening the SQLite workflow store, so first-run status reports `not-started` instead of crashing.

## Review Follow-up

- Apply confirmation guidance now uses the resolved operator command, so custom scripts like `bun run ship` render correctly.
- Added a real CLI subprocess regression for first-run `release status --from release-plan.json --format json` with no pre-existing `.release/` directory.

## Stack

This is stacked on #254, which is stacked on #253.

## QA

- `bun run --cwd packages/release test src/api/renderer/plan.test.ts src/_.test.ts`
- `bun run --cwd packages/release check:types`
- `git diff --check`
