### PR TITLE
fix(git): treat explicit cwd as work tree

### DIFF
--- a/packages/git/src/_.test.ts
+++ b/packages/git/src/_.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Test } from '@kitz/test'
@@ -607,6 +607,44 @@ describe('GitLive', () => {
       )
 
       expect(result).toBe('main')
+    } finally {
+      process.chdir(originalCwd)
+      repo.cleanup()
+    }
+  })
+
+  test('GitLive treats a cwd under bare git config as the work tree', async () => {
+    const repo = makeTempGitRepo()
+    const originalCwd = process.cwd()
+
+    try {
+      runGit(repo.root, ['config', 'core.bare', 'true'])
+      const nested = join(repo.root, 'packages', 'git')
+      mkdirSync(nested, { recursive: true })
+
+      const probe = async (cwd: string) => {
+        process.chdir(cwd)
+        return await Effect.runPromise(
+          Effect.gen(function* () {
+            const git = yield* Git.Git
+            return {
+              branch: yield* git.getCurrentBranch(),
+              clean: yield* git.isClean(),
+              root: yield* git.getRoot(),
+            }
+          }).pipe(Effect.provide(Git.GitLive)),
+        )
+      }
+
+      const rootResult = await probe(repo.root)
+      const nestedResult = await probe(nested)
+
+      expect(rootResult.branch).toBe('main')
+      expect(rootResult.clean).toBe(true)
+      expect(realpathSync(rootResult.root)).toBe(realpathSync(repo.root))
+      expect(nestedResult.branch).toBe('main')
+      expect(nestedResult.clean).toBe(true)
+      expect(realpathSync(nestedResult.root)).toBe(realpathSync(repo.root))
     } finally {
       process.chdir(originalCwd)
       repo.cleanup()

--- a/packages/git/src/live.ts
+++ b/packages/git/src/live.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs'
 import { Err } from '@kitz/core'
+import { Fs } from '@kitz/fs'
 import { Effect, Layer } from 'effect'
 import { type SimpleGit, simpleGit } from 'simple-git'
 import { Author } from './author.js'
@@ -22,9 +24,28 @@ const sanitizeGitEnv = (): NodeJS.ProcessEnv => {
   return nextEnv
 }
 
+const gitDirPath = (dir: Fs.Path.AbsDir): Fs.Path.AbsFile =>
+  Fs.Path.join(dir, Fs.Path.RelFile.fromString('./.git'))
+
+const findWorkTreeRoot = (start: Fs.Path.AbsDir): Fs.Path.AbsDir | undefined => {
+  if (existsSync(Fs.Path.toString(gitDirPath(start)))) return start
+
+  const parent = Fs.Path.up(start)
+  return Fs.Path.toString(parent) === Fs.Path.toString(start) ? undefined : findWorkTreeRoot(parent)
+}
+
 const createGit = (cwd?: string): SimpleGit => {
-  const git = cwd ? simpleGit(cwd) : simpleGit()
-  return git.env(sanitizeGitEnv())
+  const baseDir = cwd ?? process.cwd()
+  const git = simpleGit(baseDir)
+  const gitEnv = sanitizeGitEnv()
+  const workTreeRoot = findWorkTreeRoot(Fs.Path.AbsDir.fromString(baseDir))
+
+  if (workTreeRoot !== undefined) {
+    gitEnv['GIT_DIR'] = Fs.Path.toString(gitDirPath(workTreeRoot))
+    gitEnv['GIT_WORK_TREE'] = Fs.Path.toString(workTreeRoot)
+  }
+
+  return git.env(gitEnv)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Make `GitLive`/`makeGitLive` treat an explicit cwd inside a worktree as the intended work tree, even when the discovered `.git/config` has `core.bare = true`.
- Walk upward from nested package directories to find the worktree root, then set absolute `GIT_DIR` and `GIT_WORK_TREE` after sanitizing inherited Git env.
- Fixes release CLI commands from this repo's root checkout shape and package subdirectories.

## Review Follow-up

- Added nested-cwd coverage for `packages/git` under a bare-config worktree, matching the subdirectory release CLI failure mode.

## Red Test

- `GitLive > GitLive treats a cwd under bare git config as the work tree`

## QA

- `bun run --cwd packages/git test src/_.test.ts --test-name-pattern "GitLive"`
- `bun run --cwd packages/git check:types`
- `bun /Users/jasonkuhrt/.codex/worktrees/kitz-release-rehearse-artifacts-only/packages/release/src/cli/cli.ts forecast --format json` from `/Users/jasonkuhrt/projects/jasonkuhrt/kitz/packages/git`
- `git diff --check`
