### PR TITLE
fix(release): harden dry-run release flow

### DIFF
--- a/packages/release/src/_.test.ts
+++ b/packages/release/src/_.test.ts
@@ -14,8 +14,6 @@ import { describe, expect, test } from 'bun:test'
 import * as ReleaseConfig from './api/config.js'
 import { Analyzer, Planner, Publishing, ReleaseContract } from './__.js'
 
-// ─── Test Helpers ───────────────────────────────────────────────────
-
 const mockPackages: Analyzer.Workspace.Package[] = [
   {
     name: Pkg.Moniker.parse('@kitz/core'),
@@ -62,21 +60,22 @@ const makePackageJson = (
     2,
   )
 
-/** Type-safe version assertion */
 const expectVersion = (actual: Semver.Semver | undefined, expected: string) => {
   expect(actual).toBeDefined()
   expect(Semver.equivalence(actual!, Semver.fromString(expected))).toBe(true)
 }
 
-const JsonRecordFromStringSchema = Schema.fromJsonString(
-  Schema.Record(Schema.String, Schema.Unknown),
-)
-const decodeJsonRecordSync = Schema.decodeUnknownSync(JsonRecordFromStringSchema)
+const pkgJson = (
+  scope: string,
+  options?: Parameters<typeof makePackageJson>[2],
+): readonly [string, string] => [
+  `/repo/packages/${scope}/package.json`,
+  makePackageJson(`@kitz/${scope}`, '1.0.0', options),
+]
 
-/**
- * Pipeline helper: analyze → plan official.
- * Mirrors the two-step pipeline CLI commands use.
- */
+const packageJsons = (...entries: readonly (readonly [string, string])[]) =>
+  Object.fromEntries(entries)
+
 const analyzeAndPlanOfficial = (
   packages: readonly Analyzer.Workspace.Package[],
   options?: Planner.Options,
@@ -91,6 +90,42 @@ const analyzeAndPlanOfficial = (
     })
     return yield* Planner.official(analysis, { packages }, options)
   })
+
+const analyzeWorkspace = ({
+  git,
+  diskLayout,
+  until,
+}: {
+  readonly git: Parameters<typeof Git.Memory.make>[0]
+  readonly diskLayout?: Fs.Memory.DiskLayout
+  readonly until?: string
+}) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const gitService = yield* Git.Git
+      return yield* Analyzer.analyze({
+        packages: mockPackages,
+        tags: yield* gitService.getTags(),
+        ...(until === undefined ? {} : { until }),
+        resolvedConventionalCommitTypes: ReleaseConfig.resolveConventionalCommitTypes({}),
+      })
+    }).pipe(Effect.provide(makeTestLayer(git, diskLayout))),
+  )
+
+const runOfficial = ({
+  git,
+  diskLayout,
+  options,
+}: {
+  readonly git: Parameters<typeof Git.Memory.make>[0]
+  readonly diskLayout?: Fs.Memory.DiskLayout
+  readonly options?: Planner.Options
+}) =>
+  Effect.runPromise(
+    analyzeAndPlanOfficial(mockPackages, options).pipe(
+      Effect.provide(makeTestLayer(git, diskLayout)),
+    ),
+  )
 
 describe('release status cli', () => {
   test('reports not-started for a custom plan before .release exists', () => {
@@ -117,7 +152,7 @@ describe('release status cli', () => {
         }),
       })
       writeFileSync(
-        path.join(projectDir, 'release-plan.json'),
+        path.join(projectDir, 'release plan.json'),
         `${JSON.stringify(Schema.encodeSync(Planner.Plan)(plan), null, 2)}\n`,
       )
 
@@ -127,9 +162,7 @@ describe('release status cli', () => {
           fileURLToPath(new URL('./cli/cli.ts', import.meta.url)),
           'status',
           '--from',
-          'release-plan.json',
-          '--format',
-          'json',
+          'release plan.json',
         ],
         {
           cwd: projectDir,
@@ -144,66 +177,56 @@ describe('release status cli', () => {
 
       expect(result.stderr).toBe('')
       expect(result.status).toBe(0)
-      expect(decodeJsonRecordSync(result.stdout)).toMatchObject({
-        state: 'not-started',
-        plannedPackages: [],
-      })
+      expect(result.stdout).toContain('Release workflow status: [NOT-STARTED]')
+      expect(result.stdout).toContain("Run `release apply --from 'release plan.json'`")
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
   })
 })
 
-// ─── Planner.official ────────────────────────────────────────────────
-
 describe('Planner.official', () => {
   test('no releases when no commits since last tag', async () => {
-    const layer = makeTestLayer({
-      tags: ['@kitz/core@1.0.0'],
-      commits: [],
+    const result = await runOfficial({
+      git: {
+        tags: ['@kitz/core@1.0.0'],
+        commits: [],
+      },
     })
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
 
     expect(result.releases).toHaveLength(0)
     expect(result.cascades).toHaveLength(0)
   })
 
   test('uses the most recent package tag in git history as analysis baseline', async () => {
-    const layer = makeTestLayer({
-      tags: ['@kitz/core@9.0.0', '@kitz/cli@1.0.0'],
-      commits: [
-        Git.Memory.commit('chore: housekeeping'),
-        Git.Memory.commit('feat(cli): 1.0.0 release'),
-        Git.Memory.commit('chore: bridge'),
-        Git.Memory.commit('feat(core): 9.0.0 release'),
-      ],
+    const result = await runOfficial({
+      git: {
+        tags: ['@kitz/core@9.0.0', '@kitz/cli@1.0.0'],
+        commits: [
+          Git.Memory.commit('chore: housekeeping'),
+          Git.Memory.commit('feat(cli): 1.0.0 release'),
+          Git.Memory.commit('chore: bridge'),
+          Git.Memory.commit('feat(core): 9.0.0 release'),
+        ],
+      },
     })
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
 
     expect(result.releases).toHaveLength(0)
     expect(result.cascades).toHaveLength(0)
   })
 
   test('keeps unreleased package commits even when another package was released more recently', async () => {
-    const layer = makeTestLayer({
-      tags: ['@kitz/core@9.0.0', '@kitz/cli@1.0.0'],
-      commits: [
-        Git.Memory.commit('feat(cli): 1.0.0 release'),
-        Git.Memory.commit('fix(core): patch after the core release'),
-        Git.Memory.commit('feat(core): feature after the core release'),
-        Git.Memory.commit('feat(core): 9.0.0 release'),
-      ],
+    const result = await runOfficial({
+      git: {
+        tags: ['@kitz/core@9.0.0', '@kitz/cli@1.0.0'],
+        commits: [
+          Git.Memory.commit('feat(cli): 1.0.0 release'),
+          Git.Memory.commit('fix(core): patch after the core release'),
+          Git.Memory.commit('feat(core): feature after the core release'),
+          Git.Memory.commit('feat(core): 9.0.0 release'),
+        ],
+      },
     })
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
 
     expect(result.releases).toHaveLength(1)
     expect(result.releases[0]!.package.name.moniker).toBe('@kitz/core')
@@ -238,14 +261,9 @@ describe('Planner.official', () => {
       },
     )
     .test(async ({ input, output }) => {
-      const layer = makeTestLayer({
-        tags: input.tags,
-        commits: [Git.Memory.commit(input.commit)],
+      const result = await runOfficial({
+        git: { tags: input.tags, commits: [Git.Memory.commit(input.commit)] },
       })
-
-      const result = await Effect.runPromise(
-        Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-      )
 
       expect(result.releases).toHaveLength(1)
       expect(result.releases[0]!.bumpType).toBe(output.bump)
@@ -253,18 +271,16 @@ describe('Planner.official', () => {
     })
 
   test('aggregates multiple commits to highest bump', async () => {
-    const layer = makeTestLayer({
-      tags: ['@kitz/core@1.0.0'],
-      commits: [
-        Git.Memory.commit('fix(core): bug fix 1'),
-        Git.Memory.commit('feat(core): new feature'),
-        Git.Memory.commit('fix(core): bug fix 2'),
-      ],
+    const result = await runOfficial({
+      git: {
+        tags: ['@kitz/core@1.0.0'],
+        commits: [
+          Git.Memory.commit('fix(core): bug fix 1'),
+          Git.Memory.commit('feat(core): new feature'),
+          Git.Memory.commit('fix(core): bug fix 2'),
+        ],
+      },
     })
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
 
     expect(result.releases).toHaveLength(1)
     expect(result.releases[0]!.bumpType).toBe('minor')
@@ -272,17 +288,15 @@ describe('Planner.official', () => {
   })
 
   test('handles multiple packages', async () => {
-    const layer = makeTestLayer({
-      tags: ['@kitz/core@1.0.0', '@kitz/cli@2.0.0'],
-      commits: [
-        Git.Memory.commit('feat(core): core feature'),
-        Git.Memory.commit('fix(cli): cli fix'),
-      ],
+    const result = await runOfficial({
+      git: {
+        tags: ['@kitz/core@1.0.0', '@kitz/cli@2.0.0'],
+        commits: [
+          Git.Memory.commit('feat(core): core feature'),
+          Git.Memory.commit('fix(cli): cli fix'),
+        ],
+      },
     })
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
 
     expect(result.releases).toHaveLength(2)
 
@@ -297,45 +311,35 @@ describe('Planner.official', () => {
   })
 
   test('respects package filter', async () => {
-    const layer = makeTestLayer({
-      tags: [],
-      commits: [Git.Memory.commit('feat(core): core'), Git.Memory.commit('feat(cli): cli')],
+    const result = await runOfficial({
+      git: {
+        tags: [],
+        commits: [Git.Memory.commit('feat(core): core'), Git.Memory.commit('feat(cli): cli')],
+      },
+      options: { packages: ['@kitz/core'] },
     })
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages, { packages: ['@kitz/core'] }), layer),
-    )
 
     expect(result.releases).toHaveLength(1)
     expect(result.releases[0]!.package.name.moniker).toBe('@kitz/core')
   })
 })
 
-// ─── Cascade Detection ──────────────────────────────────────────────
-
 describe('Cascade', () => {
   test('detects dependent packages', async () => {
-    const diskLayout: Fs.Memory.DiskLayout = {
-      '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-      '/repo/packages/cli/package.json': makePackageJson('@kitz/cli', '1.0.0', {
-        dependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-    }
-
-    const layer = Layer.mergeAll(
-      Git.Memory.make({
+    const result = await runOfficial({
+      git: {
         tags: ['@kitz/core@1.0.0', '@kitz/cli@1.0.0'],
         commits: [Git.Memory.commit('feat(core): new API')],
-      }),
-      Fs.Memory.layer(diskLayout),
-      testEnv,
-    )
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
+      },
+      diskLayout: packageJsons(
+        pkgJson('core'),
+        pkgJson('cli', {
+          dependencies: {
+            '@kitz/core': 'workspace:*',
+          },
+        }),
+      ),
+    })
 
     expect(result.releases).toHaveLength(1)
     expect(result.releases[0]!.package.name.moniker).toBe('@kitz/core')
@@ -346,32 +350,25 @@ describe('Cascade', () => {
   })
 
   test('detects transitive cascades', async () => {
-    const diskLayout: Fs.Memory.DiskLayout = {
-      '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-      '/repo/packages/cli/package.json': makePackageJson('@kitz/cli', '1.0.0', {
-        dependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-      '/repo/packages/utils/package.json': makePackageJson('@kitz/utils', '1.0.0', {
-        dependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-    }
-
-    const layer = Layer.mergeAll(
-      Git.Memory.make({
+    const result = await runOfficial({
+      git: {
         tags: ['@kitz/core@1.0.0', '@kitz/cli@1.0.0', '@kitz/utils@1.0.0'],
         commits: [Git.Memory.commit('feat(core): new API')],
-      }),
-      Fs.Memory.layer(diskLayout),
-      testEnv,
-    )
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
+      },
+      diskLayout: packageJsons(
+        pkgJson('core'),
+        pkgJson('cli', {
+          dependencies: {
+            '@kitz/core': 'workspace:*',
+          },
+        }),
+        pkgJson('utils', {
+          dependencies: {
+            '@kitz/core': 'workspace:*',
+          },
+        }),
+      ),
+    })
 
     expect(result.cascades).toHaveLength(2)
     const cascadeNames = result.cascades.map((c) => c.package.name.moniker)
@@ -380,27 +377,20 @@ describe('Cascade', () => {
   })
 
   test('annotates cascade commits with triggering primary release', async () => {
-    const diskLayout: Fs.Memory.DiskLayout = {
-      '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-      '/repo/packages/cli/package.json': makePackageJson('@kitz/cli', '1.0.0', {
-        dependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-    }
-
-    const layer = Layer.mergeAll(
-      Git.Memory.make({
+    const result = await runOfficial({
+      git: {
         tags: ['@kitz/core@1.0.0', '@kitz/cli@1.0.0'],
         commits: [Git.Memory.commit('feat(core): new API')],
-      }),
-      Fs.Memory.layer(diskLayout),
-      testEnv,
-    )
-
-    const result = await Effect.runPromise(
-      Effect.provide(analyzeAndPlanOfficial(mockPackages), layer),
-    )
+      },
+      diskLayout: packageJsons(
+        pkgJson('core'),
+        pkgJson('cli', {
+          dependencies: {
+            '@kitz/core': 'workspace:*',
+          },
+        }),
+      ),
+    })
 
     expect(result.cascades).toHaveLength(1)
     const cascade = result.cascades[0]!
@@ -412,81 +402,45 @@ describe('Cascade', () => {
 
 describe('Analyzer', () => {
   test('records cascade trigger packages in analysis output', async () => {
-    const diskLayout: Fs.Memory.DiskLayout = {
-      '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-      '/repo/packages/cli/package.json': makePackageJson('@kitz/cli', '1.0.0', {
-        dependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-    }
-
-    const layer = Layer.mergeAll(
-      Git.Memory.make({
+    const analysis = await analyzeWorkspace({
+      git: {
         tags: ['@kitz/core@1.0.0', '@kitz/cli@1.0.0'],
         commits: [Git.Memory.commit('feat(core): new API')],
-      }),
-      Fs.Memory.layer(diskLayout),
-      testEnv,
-    )
-
-    const analysis = await Effect.runPromise(
-      Effect.provide(
-        Effect.gen(function* () {
-          const git = yield* Git.Git
-          const tags = yield* git.getTags()
-          return yield* Analyzer.analyze({
-            packages: mockPackages,
-            tags,
-            resolvedConventionalCommitTypes: ReleaseConfig.resolveConventionalCommitTypes({}),
-          })
+      },
+      diskLayout: packageJsons(
+        pkgJson('core'),
+        pkgJson('cli', {
+          dependencies: {
+            '@kitz/core': 'workspace:*',
+          },
         }),
-        layer,
       ),
-    )
+    })
 
     expect(analysis.cascades).toHaveLength(1)
     expect(analysis.cascades[0]!.triggeredBy.map((pkg) => pkg.name.moniker)).toContain('@kitz/core')
   })
 
   test('ignores dev and peer dependency edges when recording cascades', async () => {
-    const diskLayout: Fs.Memory.DiskLayout = {
-      '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-      '/repo/packages/cli/package.json': makePackageJson('@kitz/cli', '1.0.0', {
-        devDependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-      '/repo/packages/utils/package.json': makePackageJson('@kitz/utils', '1.0.0', {
-        peerDependencies: {
-          '@kitz/core': 'workspace:*',
-        },
-      }),
-    }
-
-    const layer = Layer.mergeAll(
-      Git.Memory.make({
+    const analysis = await analyzeWorkspace({
+      git: {
         tags: ['@kitz/core@1.0.0', '@kitz/cli@1.0.0', '@kitz/utils@1.0.0'],
         commits: [Git.Memory.commit('feat(core): new API')],
-      }),
-      Fs.Memory.layer(diskLayout),
-      testEnv,
-    )
-
-    const analysis = await Effect.runPromise(
-      Effect.provide(
-        Effect.gen(function* () {
-          const git = yield* Git.Git
-          const tags = yield* git.getTags()
-          return yield* Analyzer.analyze({
-            packages: mockPackages,
-            tags,
-            resolvedConventionalCommitTypes: ReleaseConfig.resolveConventionalCommitTypes({}),
-          })
+      },
+      diskLayout: packageJsons(
+        pkgJson('core'),
+        pkgJson('cli', {
+          devDependencies: {
+            '@kitz/core': 'workspace:*',
+          },
         }),
-        layer,
+        pkgJson('utils', {
+          peerDependencies: {
+            '@kitz/core': 'workspace:*',
+          },
+        }),
       ),
-    )
+    })
 
     expect(analysis.impacts).toHaveLength(1)
     expect(analysis.impacts[0]!.package.name.moniker).toBe('@kitz/core')
@@ -497,29 +451,16 @@ describe('Analyzer', () => {
     const olderHash = Git.Sha.make('1111111')
     const newerHash = Git.Sha.make('2222222')
 
-    const layer = makeTestLayer({
-      tags: [],
-      commits: [
-        Git.Memory.commit('feat(core): should be excluded by until', { hash: newerHash }),
-        Git.Memory.commit('chore(core): boundary commit', { hash: olderHash }),
-      ],
+    const analysis = await analyzeWorkspace({
+      git: {
+        tags: [],
+        commits: [
+          Git.Memory.commit('feat(core): should be excluded by until', { hash: newerHash }),
+          Git.Memory.commit('chore(core): boundary commit', { hash: olderHash }),
+        ],
+      },
+      until: olderHash,
     })
-
-    const analysis = await Effect.runPromise(
-      Effect.provide(
-        Effect.gen(function* () {
-          const git = yield* Git.Git
-          const tags = yield* git.getTags()
-          return yield* Analyzer.analyze({
-            packages: mockPackages,
-            tags,
-            until: olderHash,
-            resolvedConventionalCommitTypes: ReleaseConfig.resolveConventionalCommitTypes({}),
-          })
-        }),
-        layer,
-      ),
-    )
 
     expect(analysis.impacts).toHaveLength(0)
   })

--- a/packages/release/src/api/executor/_.test.ts
+++ b/packages/release/src/api/executor/_.test.ts
@@ -54,6 +54,89 @@ const tagA = (version: string) => tag(Pkg.Moniker.parse('@kitz/a'), version)
 const tagB = (version: string) => tag(Pkg.Moniker.parse('@kitz/b'), version)
 const tagC = (version: string) => tag(Pkg.Moniker.parse('@kitz/c'), version)
 const quiet = <A, E, R>(effect: Effect.Effect<A, E, R>) => effect
+type HarnessOptions = Parameters<typeof makeHarness>[0]
+
+const coreGit: HarnessOptions['git'] = {
+  tags: [tagCore('1.0.0')],
+  commits: [Git.Memory.commit('feat(core): new API')],
+  isClean: true,
+}
+const coreDiskLayout = {
+  '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
+}
+const makeCoreHarness = (options?: {
+  readonly git?: Partial<HarnessOptions['git']>
+  readonly diskLayout?: Fs.Memory.DiskLayout
+  readonly failPackPackages?: readonly string[]
+  readonly failPublishPackages?: readonly string[]
+}) =>
+  makeHarness({
+    git: { ...coreGit, ...options?.git },
+    diskLayout: options?.diskLayout ?? coreDiskLayout,
+    ...(options?.failPackPackages ? { failPackPackages: options.failPackPackages } : {}),
+    ...(options?.failPublishPackages ? { failPublishPackages: options.failPublishPackages } : {}),
+  })
+
+const cycleGit: HarnessOptions['git'] = {
+  tags: [tagA('1.0.0'), tagB('1.0.0'), tagC('1.0.0')],
+  commits: [Git.Memory.commit('feat(a): add feature'), Git.Memory.commit('feat(b): add feature')],
+  isClean: true,
+}
+const cycleDiskLayout = {
+  '/repo/packages/a/package.json': makePackageJson('@kitz/a', '1.0.0', {
+    dependencies: {
+      '@kitz/b': 'workspace:^',
+    },
+  }),
+  '/repo/packages/b/package.json': makePackageJson('@kitz/b', '1.0.0', {
+    dependencies: {
+      '@kitz/a': 'workspace:^',
+    },
+  }),
+  '/repo/packages/c/package.json': makePackageJson('@kitz/c', '1.0.0', {
+    dependencies: {
+      '@kitz/a': 'workspace:^',
+    },
+  }),
+}
+const makeCycleHarness = () => makeHarness({ git: cycleGit, diskLayout: cycleDiskLayout })
+type FailureOutcome = {
+  readonly _tag: string
+  readonly failure?: {
+    readonly _tag: string
+    readonly context?: unknown
+  }
+}
+
+const expectFailure = (outcome: FailureOutcome, tag: string) => {
+  expect(outcome._tag).toBe('Failure')
+  if (outcome._tag !== 'Failure') throw new Error('expected failure')
+  expect(outcome.failure?._tag).toBe(tag)
+  return outcome.failure!
+}
+
+const expectPreflightFailure = (outcome: FailureOutcome, check: string) => {
+  const failure = expectFailure(outcome, 'ExecutorPreflightError') as {
+    readonly context: { readonly check: string }
+  }
+  expect(failure.context.check).toBe(check)
+}
+
+const expectDependencyCycleFailure = (outcome: FailureOutcome) => {
+  const failure = expectFailure(outcome, 'ExecutorDependencyCycleError') as {
+    readonly context: { readonly packages: readonly string[]; readonly edges: readonly string[] }
+  }
+  expect(failure.context.packages).toEqual(['@kitz/a', '@kitz/b'])
+  expect(failure.context.edges).toEqual(['@kitz/a -> @kitz/b', '@kitz/b -> @kitz/a'])
+}
+
+const expectRestoredCoreManifest = (manifestRaw: string) => {
+  const manifest = decodeJsonRecordSync(manifestRaw)
+  expect(
+    Semver.equivalence(decodeSemverFromManifest(manifest[`version`]), Semver.fromString('1.0.0')),
+  ).toBe(true)
+  return manifest
+}
 
 describe('Executor integration', () => {
   Test.live(
@@ -61,16 +144,7 @@ describe('Executor integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
-          })
+          const harness = yield* makeCoreHarness()
 
           const plan = yield* planOfficial(workspacePackages).pipe(
             Effect.provide(harness.planLayer),
@@ -111,13 +185,7 @@ describe('Executor integration', () => {
           const manifestRaw = yield* Fs.readString(coreManifestPath).pipe(
             Effect.provide(harness.workflowLayer),
           )
-          const manifest = decodeJsonRecordSync(manifestRaw)
-          expect(
-            Semver.equivalence(
-              decodeSemverFromManifest(manifest[`version`]),
-              Semver.fromString('1.0.0'),
-            ),
-          ).toBe(true)
+          expectRestoredCoreManifest(manifestRaw)
         }),
       ),
   )
@@ -125,16 +193,7 @@ describe('Executor integration', () => {
   Test.live('uses the frozen publish profile package-manager driver for pack and publish', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const contractedPlan = Plan.make({
@@ -167,16 +226,7 @@ describe('Executor integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
-          })
+          const harness = yield* makeCoreHarness()
 
           const plan = yield* planOfficial(workspacePackages).pipe(
             Effect.provide(harness.planLayer),
@@ -196,16 +246,7 @@ describe('Executor integration', () => {
   Test.live('fails preflight on conflicting tag and does not publish', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const plannedRelease = plan.releases[0]
@@ -221,13 +262,7 @@ describe('Executor integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPreflightError')
-          if (outcome.failure._tag === 'ExecutorPreflightError') {
-            expect(outcome.failure.context.check).toBe('plan.tags-unique')
-          }
-        }
+        expectPreflightFailure(outcome, 'plan.tags-unique')
 
         const publishAttempts = yield* Ref.get(harness.publishAttempts)
         expect(publishAttempts).toBe(0)
@@ -241,16 +276,7 @@ describe('Executor integration', () => {
   Test.live('fails preflight when git working tree is dirty', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: false,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness({ git: { isClean: false } })
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
 
@@ -259,13 +285,7 @@ describe('Executor integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPreflightError')
-          if (outcome.failure._tag === 'ExecutorPreflightError') {
-            expect(outcome.failure.context.check).toBe('env.git-clean')
-          }
-        }
+        expectPreflightFailure(outcome, 'env.git-clean')
 
         const publishAttempts = yield* Ref.get(harness.publishAttempts)
         expect(publishAttempts).toBe(0)
@@ -276,17 +296,7 @@ describe('Executor integration', () => {
   Test.live('fails preflight when official release is attempted off trunk', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            branch: 'feat/release',
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness({ git: { branch: 'feat/release' } })
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
 
@@ -295,13 +305,7 @@ describe('Executor integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPreflightError')
-          if (outcome.failure._tag === 'ExecutorPreflightError') {
-            expect(outcome.failure.context.check).toBe('env.release-branch-allowed')
-          }
-        }
+        expectPreflightFailure(outcome, 'env.release-branch-allowed')
 
         const publishAttempts = yield* Ref.get(harness.publishAttempts)
         expect(publishAttempts).toBe(0)
@@ -312,33 +316,7 @@ describe('Executor integration', () => {
   Test.live('fails before workflow start when planned packages form a local dependency cycle', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagA('1.0.0'), tagB('1.0.0'), tagC('1.0.0')],
-            commits: [
-              Git.Memory.commit('feat(a): add feature'),
-              Git.Memory.commit('feat(b): add feature'),
-            ],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/a/package.json': makePackageJson('@kitz/a', '1.0.0', {
-              dependencies: {
-                '@kitz/b': 'workspace:^',
-              },
-            }),
-            '/repo/packages/b/package.json': makePackageJson('@kitz/b', '1.0.0', {
-              dependencies: {
-                '@kitz/a': 'workspace:^',
-              },
-            }),
-            '/repo/packages/c/package.json': makePackageJson('@kitz/c', '1.0.0', {
-              dependencies: {
-                '@kitz/a': 'workspace:^',
-              },
-            }),
-          },
-        })
+        const harness = yield* makeCycleHarness()
 
         const plan = yield* planOfficial(cycleWorkspacePackages).pipe(
           Effect.provide(harness.planLayer),
@@ -351,17 +329,7 @@ describe('Executor integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorDependencyCycleError')
-          if (outcome.failure._tag === 'ExecutorDependencyCycleError') {
-            expect(outcome.failure.context.packages).toEqual(['@kitz/a', '@kitz/b'])
-            expect(outcome.failure.context.edges).toEqual([
-              '@kitz/a -> @kitz/b',
-              '@kitz/b -> @kitz/a',
-            ])
-          }
-        }
+        expectDependencyCycleFailure(outcome)
 
         const packCalls = yield* Ref.get(harness.packCalls)
         expect(packCalls).toHaveLength(0)
@@ -375,33 +343,7 @@ describe('Executor integration', () => {
   Test.live('direct payload construction fails for dependency cycles', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagA('1.0.0'), tagB('1.0.0'), tagC('1.0.0')],
-            commits: [
-              Git.Memory.commit('feat(a): add feature'),
-              Git.Memory.commit('feat(b): add feature'),
-            ],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/a/package.json': makePackageJson('@kitz/a', '1.0.0', {
-              dependencies: {
-                '@kitz/b': 'workspace:^',
-              },
-            }),
-            '/repo/packages/b/package.json': makePackageJson('@kitz/b', '1.0.0', {
-              dependencies: {
-                '@kitz/a': 'workspace:^',
-              },
-            }),
-            '/repo/packages/c/package.json': makePackageJson('@kitz/c', '1.0.0', {
-              dependencies: {
-                '@kitz/a': 'workspace:^',
-              },
-            }),
-          },
-        })
+        const harness = yield* makeCycleHarness()
 
         const plan = yield* planOfficial(cycleWorkspacePackages).pipe(
           Effect.provide(harness.planLayer),
@@ -412,27 +354,14 @@ describe('Executor integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorDependencyCycleError')
-          if (outcome.failure._tag === 'ExecutorDependencyCycleError') {
-            expect(outcome.failure.context.packages).toEqual(['@kitz/a', '@kitz/b'])
-            expect(outcome.failure.context.edges).toEqual([
-              '@kitz/a -> @kitz/b',
-              '@kitz/b -> @kitz/a',
-            ])
-          }
-        }
+        expectDependencyCycleFailure(outcome)
 
         const observableAttempt = yield* executeObservable(plan, {
           dryRun: true,
           dbPath: `/tmp/kitz-release-workflow-${Date.now()}-${Math.random().toString(16).slice(2)}.db`,
         }).pipe(Effect.provide(harness.planLayer), Effect.result)
 
-        expect(observableAttempt._tag).toBe('Failure')
-        if (observableAttempt._tag === 'Failure') {
-          expect(observableAttempt.failure._tag).toBe('ExecutorDependencyCycleError')
-        }
+        expectFailure(observableAttempt, 'ExecutorDependencyCycleError')
       }),
     ),
   )
@@ -442,15 +371,7 @@ describe('Executor integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
+          const harness = yield* makeCoreHarness({
             failPublishPackages: ['@kitz/core'],
           })
 
@@ -462,15 +383,11 @@ describe('Executor integration', () => {
             Effect.provide(harness.workflowLayer),
             Effect.result,
           )
-
-          expect(outcome._tag).toBe('Failure')
-          if (outcome._tag === 'Failure') {
-            expect(outcome.failure._tag).toBe('ExecutorPublishError')
-            if (outcome.failure._tag === 'ExecutorPublishError') {
-              expect(outcome.failure.context.packageName).toBe('@kitz/core')
-              expect(outcome.failure.context.detail).toContain('mock publish failure')
-            }
+          const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+            readonly context: { readonly packageName: string; readonly detail: string }
           }
+          expect(failure.context.packageName).toBe('@kitz/core')
+          expect(failure.context.detail).toContain('mock publish failure')
 
           const publishAttempts = yield* Ref.get(harness.publishAttempts)
           expect(publishAttempts).toBe(1)
@@ -481,13 +398,7 @@ describe('Executor integration', () => {
           const manifestRaw = yield* Fs.readString(coreManifestPath).pipe(
             Effect.provide(harness.workflowLayer),
           )
-          const manifest = decodeJsonRecordSync(manifestRaw)
-          expect(
-            Semver.equivalence(
-              decodeSemverFromManifest(manifest[`version`]),
-              Semver.fromString('1.0.0'),
-            ),
-          ).toBe(true)
+          expectRestoredCoreManifest(manifestRaw)
         }),
       ),
   )
@@ -495,12 +406,7 @@ describe('Executor integration', () => {
   Test.live('surfaces pack-hook cleanup guidance when artifact preparation fails', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
+        const harness = yield* makeCoreHarness({
           diskLayout: {
             '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
               imports: {
@@ -524,31 +430,18 @@ describe('Executor integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPublishError')
-          if (outcome.failure._tag === 'ExecutorPublishError') {
-            expect(outcome.failure.context.detail).toContain('mock pack failure')
-            expect(outcome.failure.context.detail).toContain(
-              'Source package manifests were not mutated',
-            )
-            expect(outcome.failure.context.detail).toContain('Pack hooks detected (prepack)')
-            expect(outcome.failure.context.detail).toContain(
-              'plan.packages-runtime-targets-source-oriented',
-            )
-          }
+        const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+          readonly context: { readonly detail: string }
         }
+        expect(failure.context.detail).toContain('mock pack failure')
+        expect(failure.context.detail).toContain('Source package manifests were not mutated')
+        expect(failure.context.detail).toContain('Pack hooks detected (prepack)')
+        expect(failure.context.detail).toContain('plan.packages-runtime-targets-source-oriented')
 
         const manifestRaw = yield* Fs.readString(coreManifestPath).pipe(
           Effect.provide(harness.workflowLayer),
         )
-        const manifest = decodeJsonRecordSync(manifestRaw)
-        expect(
-          Semver.equivalence(
-            decodeSemverFromManifest(manifest[`version`]),
-            Semver.fromString('1.0.0'),
-          ),
-        ).toBe(true)
+        const manifest = expectRestoredCoreManifest(manifestRaw)
         expect(manifest['imports']).toEqual({
           '#core': './src/_.ts',
         })
@@ -562,15 +455,8 @@ describe('Executor integration', () => {
   Test.live('updates existing GitHub candidate release when tag option is next', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0'), tagCore('1.1.0-next.1')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
+        const harness = yield* makeCoreHarness({
+          git: { tags: [tagCore('1.0.0'), tagCore('1.1.0-next.1')] },
         })
 
         const plan = yield* planCandidate(workspacePackages).pipe(Effect.provide(harness.planLayer))
@@ -610,16 +496,7 @@ describe('Executor integration', () => {
   Test.live('publishes candidate releases to the default next dist-tag', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planCandidate(workspacePackages).pipe(Effect.provide(harness.planLayer))
 
@@ -636,16 +513,7 @@ describe('Executor integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
-          })
+          const harness = yield* makeCoreHarness()
 
           const plan = yield* planCandidate(workspacePackages).pipe(
             Effect.provide(harness.planLayer),
@@ -667,15 +535,8 @@ describe('Executor integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0'), tagCore('1.1.0-next.1')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
+          const harness = yield* makeCoreHarness({
+            git: { tags: [tagCore('1.0.0'), tagCore('1.1.0-next.1')] },
           })
 
           const plan = yield* planCandidate(workspacePackages).pipe(
@@ -722,16 +583,7 @@ describe('Executor integration', () => {
   Test.live('creates a new GitHub candidate release with the custom candidate dist-tag title', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planCandidate(workspacePackages).pipe(Effect.provide(harness.planLayer))
 
@@ -767,16 +619,8 @@ describe('Executor integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-              headSha: Git.Sha.make('abc1234'),
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
+          const harness = yield* makeCoreHarness({
+            git: { headSha: Git.Sha.make('abc1234') },
           })
 
           const plan = yield* planEphemeral(workspacePackages, { prNumber: 42 }).pipe(
@@ -804,16 +648,8 @@ describe('Executor integration', () => {
   Test.live('publishes ephemeral releases to the default PR dist-tag', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-            headSha: Git.Sha.make('abc1234'),
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
+        const harness = yield* makeCoreHarness({
+          git: { headSha: Git.Sha.make('abc1234') },
         })
 
         const plan = yield* planEphemeral(workspacePackages, { prNumber: 42 }).pipe(
@@ -831,15 +667,7 @@ describe('Executor integration', () => {
   Test.live('observable workflow exposes graph in dry-run mode', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
 
@@ -863,15 +691,7 @@ describe('Executor integration', () => {
   Test.live('observable workflow builds the release payload only once', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const manifestReads = yield* Ref.make(0)
@@ -906,16 +726,7 @@ describe('Executor integration', () => {
   Test.live('observable execution uses caller-provided runtime services', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
 

--- a/packages/release/src/api/executor/execute.ts
+++ b/packages/release/src/api/executor/execute.ts
@@ -296,9 +296,14 @@ const executionStateTone = (state: ExecutionStatus['state']) => {
   }
 }
 
+export interface FormatExecutionStatusOptions extends Cli.Terminal.TerminalFormatOptions {
+  readonly nextApplyCommand?: string
+  readonly resumeCommand?: string
+}
+
 export const formatExecutionStatus = (
   status: ExecutionStatus,
-  options?: Cli.Terminal.TerminalFormatOptions,
+  options?: FormatExecutionStatusOptions,
 ): string => {
   const output = Str.Builder()
   const theme = Cli.Terminal.createTerminalTheme(options)
@@ -316,7 +321,7 @@ export const formatExecutionStatus = (
   if (status.state === 'not-started') {
     output``
     output`No persisted workflow state exists for this plan yet.`
-    output`${theme.key('Next')} Run ${theme.code('release apply')} to start the workflow.`
+    output`${theme.key('Next')} Run ${theme.code(options?.nextApplyCommand ?? 'release apply')} to start the workflow.`
     return output.render()
   }
 
@@ -328,7 +333,7 @@ export const formatExecutionStatus = (
     }
     output``
     output(
-      `${theme.key('Resume')} Fix the blocking issue, then run ${theme.code('release resume')} with the same plan.`,
+      `${theme.key('Resume')} Fix the blocking issue, then run ${theme.code(options?.resumeCommand ?? 'release resume')} with the same plan.`,
     )
     return output.render()
   }

--- a/packages/release/src/api/executor/status.test.ts
+++ b/packages/release/src/api/executor/status.test.ts
@@ -63,6 +63,22 @@ describe('Executor status', () => {
     expect(rendered).toContain('workflow crashed')
   })
 
+  test('preserves custom plan paths in not-started next-step guidance', () => {
+    const rendered = formatExecutionStatus(
+      {
+        state: 'not-started',
+        executionId: 'release-official:test',
+        lifecycle: 'official',
+        plannedPackages: ['@kitz/core'],
+      },
+      {
+        nextApplyCommand: 'release apply --from ./.release/custom-plan.json',
+      },
+    )
+
+    expect(rendered).toContain('Run `release apply --from ./.release/custom-plan.json`')
+  })
+
   test('renders colored success summaries without changing the stripped text semantics', () => {
     const rendered = formatExecutionStatus(
       {
@@ -128,6 +144,11 @@ describe('Executor status', () => {
       const rendered = formatExecutionStatus(workflowStatus)
       expect(rendered).toContain('[SUSPENDED]')
       expect(rendered).toContain('Resume: Fix the blocking issue, then run `release resume`')
+      expect(
+        formatExecutionStatus(workflowStatus, {
+          resumeCommand: 'release resume --from ./.release/custom-plan.json',
+        }),
+      ).toContain('run `release resume --from ./.release/custom-plan.json`')
     }),
   )
 

--- a/packages/release/src/cli/commands/apply.test.ts
+++ b/packages/release/src/cli/commands/apply.test.ts
@@ -1,0 +1,89 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, test } from 'bun:test'
+import { Schema } from 'effect'
+import * as Api from '../../api/__.js'
+
+const cliPath = path.resolve(import.meta.dir, '../cli.ts')
+const plan = Api.Planner.Plan.make({
+  lifecycle: 'official',
+  timestamp: '2026-06-09T00:00:00.000Z',
+  releases: [],
+  cascades: [],
+  planDigest: Api.ReleaseContract.PlanDigest.make({
+    algorithm: 'sha256',
+    value: 'a'.repeat(64),
+  }),
+  publishIntent: Api.ReleaseContract.publishIntentFromSemantics({
+    semantics: Api.Publishing.resolvePublishSemantics({ lifecycle: 'official' }),
+    trunk: 'main',
+  }),
+})
+const encodedPlan = `${JSON.stringify(Schema.encodeSync(Api.Planner.Plan)(plan), null, 2)}\n`
+const digest = Api.Proof.digestForPlan(plan)
+const lockFile = (rootDir: string) =>
+  path.join(rootDir, '.release', 'locks', `${digest.value}.json`)
+const writePlan = (rootDir: string) => {
+  mkdirSync(path.join(rootDir, '.release'), { recursive: true })
+  writeFileSync(path.join(rootDir, '.release', 'plan.json'), encodedPlan)
+}
+const withFixture = (name: string, run: (rootDir: string) => void) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), `kitz-release-apply-${name}-`))
+
+  try {
+    writePlan(rootDir)
+    run(rootDir)
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true })
+  }
+}
+const runApply = (rootDir: string, args: readonly string[], input?: string) =>
+  spawnSync('bun', [cliPath, 'apply', '--from', './.release/plan.json', ...args], {
+    cwd: rootDir,
+    encoding: 'utf8',
+    input,
+  })
+const writeActiveLock = (rootDir: string) => {
+  mkdirSync(path.dirname(lockFile(rootDir)), { recursive: true })
+  writeFileSync(
+    lockFile(rootDir),
+    `${JSON.stringify(
+      Schema.encodeSync(Api.ReleaseContract.ExecutionLock)(
+        Api.Lock.make({
+          planDigest: digest,
+          ownerId: 'other',
+          acquiredAt: new Date(Date.now() + 60_000).toISOString(),
+          ttlSeconds: 3_600,
+        }),
+      ),
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+describe('release apply command', () => {
+  test('does not leave a release lock when the confirmation prompt is declined', () => {
+    withFixture('cancel', (rootDir) => {
+      const result = runApply(rootDir, [], 'n\n')
+
+      expect(result.status).toBe(1)
+      expect(result.stdout).toContain('Release canceled.')
+      expect(existsSync(lockFile(rootDir))).toBe(false)
+    })
+  })
+
+  test('checks the release lock before locked validation can continue', () => {
+    withFixture('locked', (rootDir) => {
+      writeActiveLock(rootDir)
+      const result = runApply(rootDir, ['--yes'])
+      const output = `${result.stdout}\n${result.stderr}`
+
+      expect(result.status).toBe(1)
+      expect(output).toContain('Active release lock already exists')
+      expect(output).not.toContain('Plan-bound proof is missing')
+    })
+  })
+})

--- a/packages/release/src/cli/commands/apply.ts
+++ b/packages/release/src/cli/commands/apply.ts
@@ -121,14 +121,35 @@ export const apply = Command.make(
       const publish = Api.Publishing.publishSemanticsFromIntent(intentResult.success)
       const planDigest = Api.Proof.digestForPlan(plan)
 
-      yield* Api.Lock.withLocal(
-        {
-          planDigest,
-          ownerId: env.vars['USER'] ?? 'local-operator',
-          ownerHost: env.vars['HOST'] ?? env.vars['HOSTNAME'] ?? 'local-host',
-          ownerProcess: env.vars['KITZ_RELEASE_PROCESS_ID'] ?? 'local-process',
-          now: new Date().toISOString(),
-        },
+      const lockParams = {
+        planDigest,
+        ownerId: env.vars['USER'] ?? 'local-operator',
+        ownerHost: env.vars['HOST'] ?? env.vars['HOSTNAME'] ?? 'local-host',
+        ownerProcess: env.vars['KITZ_RELEASE_PROCESS_ID'] ?? 'local-process',
+        now: new Date().toISOString(),
+      } satisfies Api.Lock.LocalLockParams
+
+      // Confirmation prompt (unless --yes)
+      if (!yes) {
+        const releaseCommand = yield* Api.Config.load().pipe(
+          Effect.map((config) => config.operator.releaseCommand),
+          Effect.catch(() => Effect.succeed('release')),
+        )
+        yield* Console.log(
+          Api.Renderer.renderApplyConfirmation(plan, publish, {
+            env: env.vars,
+            releaseCommand,
+          }),
+        )
+        const approved = yield* confirm('Proceed with release? [y/N] ')
+        if (!approved) {
+          yield* Console.log('Release canceled.')
+          return env.exit(1)
+        }
+      }
+
+      const applied = yield* Api.Lock.withLocal(
+        lockParams,
         Effect.gen(function* () {
           if (prove) {
             const localObservations = yield* Api.Proof.collectLocalObservations(plan)
@@ -154,31 +175,12 @@ export const apply = Command.make(
               yield* Console.error(
                 'Plan proof contains blocking records. Run `release prove` for detail.',
               )
-              return env.exit(1)
+              return false
             }
           }
 
           if (rehearse) {
             yield* Api.Artifact.rehearse(plan)
-          }
-
-          // Confirmation prompt (unless --yes)
-          if (!yes) {
-            const releaseCommand = yield* Api.Config.load().pipe(
-              Effect.map((config) => config.operator.releaseCommand),
-              Effect.catch(() => Effect.succeed('release')),
-            )
-            yield* Console.log(
-              Api.Renderer.renderApplyConfirmation(plan, publish, {
-                env: env.vars,
-                releaseCommand,
-              }),
-            )
-            const approved = yield* confirm('Proceed with release? [y/N] ')
-            if (!approved) {
-              yield* Console.log('Release canceled.')
-              return env.exit(1)
-            }
           }
 
           const proof = yield* Api.Proof.readForPlan(plan)
@@ -187,14 +189,14 @@ export const apply = Command.make(
             yield* Console.error(
               'Run `release prove` or `release apply --prove --rehearse` before publishing.',
             )
-            return env.exit(1)
+            return false
           }
           if (Api.Proof.hasBlockingProof(proof.value)) {
             yield* Console.error('Plan-bound proof contains blocking records.')
             yield* Console.error(
               'Run `release prove` and resolve every failed or unprovable proof.',
             )
-            return env.exit(1)
+            return false
           }
 
           const artifacts = yield* Api.Artifact.readManifest(plan)
@@ -203,7 +205,7 @@ export const apply = Command.make(
             yield* Console.error(
               'Run `release rehearse` or `release apply --prove --rehearse` before publishing.',
             )
-            return env.exit(1)
+            return false
           }
           const artifactIssues = yield* Api.Artifact.validateManifestFilesForPlan(
             plan,
@@ -213,7 +215,7 @@ export const apply = Command.make(
             yield* Console.error('Artifact manifest does not match the frozen plan.')
             for (const issue of artifactIssues)
               yield* Console.error(`${issue.code}: ${issue.detail}`)
-            return env.exit(1)
+            return false
           }
           if (plan.source !== undefined) {
             // Validate the full staleness proof set (config digest, head SHA,
@@ -225,7 +227,7 @@ export const apply = Command.make(
                 'Cannot verify release staleness: failed to load the current release config.',
               )
               yield* Console.error(configResult.failure.message)
-              return env.exit(1)
+              return false
             }
             const observedSource = yield* Api.Planner.buildSourceSnapshot({
               config: configResult.success,
@@ -235,7 +237,7 @@ export const apply = Command.make(
               yield* Console.error('Release source snapshot is stale.')
               for (const issue of sourceIssues)
                 yield* Console.error(`${issue.code}: ${issue.detail}`)
-              return env.exit(1)
+              return false
             }
           }
           const scriptPolicyIssues = yield* Api.Artifact.validateScriptPolicyForPlan(plan)
@@ -244,7 +246,7 @@ export const apply = Command.make(
             for (const issue of scriptPolicyIssues) {
               yield* Console.error(`${issue.code}: ${issue.detail}`)
             }
-            return env.exit(1)
+            return false
           }
           const enginePolicyIssues = yield* Api.Artifact.validateEnginePolicyForPlan(plan)
           if (enginePolicyIssues.length > 0) {
@@ -252,7 +254,7 @@ export const apply = Command.make(
             for (const issue of enginePolicyIssues) {
               yield* Console.error(`${issue.code}: ${issue.detail}`)
             }
-            return env.exit(1)
+            return false
           }
 
           const runtime = yield* Api.Explorer.explore()
@@ -260,7 +262,7 @@ export const apply = Command.make(
           if (!runtimeConfig.github) {
             yield* Console.error('GitHub release target and token are required for release apply.')
             yield* Console.error('Set GITHUB_TOKEN and ensure origin points to GitHub, then retry.')
-            return env.exit(1)
+            return false
           }
 
           // Execute with observable workflow
@@ -305,8 +307,14 @@ export const apply = Command.make(
           if (planPath === undefined) {
             yield* Api.Planner.Store.deleteActive
           }
+
+          return true
         }),
       )
+
+      if (!applied) {
+        return env.exit(1)
+      }
     }),
 ).pipe(
   Command.withDescription('Execute the release plan'),

--- a/packages/release/src/cli/commands/doctor.test.ts
+++ b/packages/release/src/cli/commands/doctor.test.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { describe, expect, test } from 'bun:test'
+
+const cliPath = path.resolve(import.meta.dir, '../cli.ts')
+const repoRoot = path.resolve(import.meta.dir, '../../../../../')
+
+describe('release doctor command', () => {
+  test('reports missing custom plans without runtime error noise', () => {
+    const result = spawnSync('bun', [cliPath, 'doctor', '--from', './.release/missing.json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+    const output = `${result.stdout}\n${result.stderr}`
+
+    expect(result.status).toBe(1)
+    expect(output).toContain('Release plan not found')
+    for (const noise of ['DoctorFailures', 'ERROR (#']) expect(output).not.toContain(noise)
+  })
+})

--- a/packages/release/src/cli/commands/doctor.ts
+++ b/packages/release/src/cli/commands/doctor.ts
@@ -114,12 +114,12 @@ export const doctor = Command.make(
 
       if (args.lifecycle && args.all) {
         yield* Console.error('Choose either --lifecycle or --all, not both.')
-        return yield* Effect.fail({ _tag: 'DoctorFailures' as const })
+        return env.exit(1)
       }
 
       if (args.from && (args.lifecycle || args.all)) {
         yield* Console.error('Choose either --from or --lifecycle/--all, not both.')
-        return yield* Effect.fail({ _tag: 'DoctorFailures' as const })
+        return env.exit(1)
       }
 
       const workspace = yield* loadCommandWorkspace({
@@ -146,7 +146,7 @@ export const doctor = Command.make(
         for (const line of formatMissingPlanMessage(activePlanState)) {
           yield* Console.error(line)
         }
-        return yield* Effect.fail({ _tag: 'DoctorFailures' as const })
+        return env.exit(1)
       }
       if (activePlanState?._tag === 'PlanInvalid') {
         const lines =
@@ -157,7 +157,7 @@ export const doctor = Command.make(
           yield* Console.error(line)
         }
         if (activePlanState.source === 'custom') {
-          return yield* Effect.fail({ _tag: 'DoctorFailures' as const })
+          return env.exit(1)
         }
       }
       const activePlan =
@@ -258,7 +258,7 @@ export const doctor = Command.make(
       }
 
       if (Api.Doctor.hasBlockingIssues(evaluation)) {
-        return yield* Effect.fail({ _tag: 'DoctorFailures' as const })
+        return env.exit(1)
       }
     }),
 ).pipe(

--- a/packages/release/src/cli/commands/forecast-lib.test.ts
+++ b/packages/release/src/cli/commands/forecast-lib.test.ts
@@ -1,8 +1,9 @@
 import { Fs } from '@kitz/fs'
 import { Pkg } from '@kitz/pkg'
-import { Effect } from 'effect'
+import { Effect, Option } from 'effect'
 import { describe, expect, test } from 'bun:test'
 import * as Api from '../../api/__.js'
+import { Analysis, Impact, makeCascadeCommit } from '../../api/analyzer/models/__.js'
 import { makeHarness } from '../../api/executor/test-support.js'
 import { noPackagesFoundMessage } from './command-workspace.js'
 import { buildForecastInput, loadForecastInputFromFile } from './forecast-lib.js'
@@ -27,6 +28,45 @@ const makeResolvedConfig = (
     resolvedConventionalCommitTypes: Api.Config.resolveConventionalCommitTypes({}),
     commitOverrides: {},
     lint: Api.Lint.resolveConfig({}),
+  })
+
+const workspacePackage = (scope: string) => ({
+  scope,
+  name: Pkg.Moniker.parse(`@kitz/${scope}`),
+  path: Fs.Path.AbsDir.fromString(`/repo/packages/${scope}/`),
+})
+
+const makeForecast = (headSha = 'abc1234') =>
+  Api.Forecaster.Forecast.make({
+    owner: 'jasonkuhrt',
+    repo: 'kitz',
+    branch: 'main',
+    headSha,
+    releases: [],
+    cascades: [],
+  })
+
+const makeRecon = (): Api.Explorer.Recon => ({
+  ci: { detected: false, provider: null, prNumber: null },
+  github: {
+    target: { owner: 'jasonkuhrt', repo: 'kitz', source: 'git:origin' },
+    credentials: null,
+  },
+  npm: { authenticated: false, username: null, registry: null },
+  git: {
+    root: Fs.Path.AbsDir.fromString('/repo/'),
+    clean: true,
+    branch: 'main',
+    headSha: 'abc1234',
+    remotes: {},
+  },
+})
+
+const packageJson = (scope: string, fields: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    name: `@kitz/${scope}`,
+    version: '0.0.0-kitz-release',
+    ...fields,
   })
 
 describe('forecast-lib', () => {
@@ -61,22 +101,11 @@ describe('forecast-lib', () => {
   })
 
   test('builds forecast input from analyzed workspace packages', async () => {
-    const pkg = {
-      scope: 'core',
-      name: Pkg.Moniker.parse('@kitz/core'),
-      path: Fs.Path.AbsDir.fromString('/repo/packages/core/'),
-    }
+    const pkg = workspacePackage('core')
     const tags = ['@kitz/core@1.0.0']
     const analysis = { _tag: 'Analysis' } as any
     const recon = { _tag: 'Recon' } as any
-    const forecast = Api.Forecaster.Forecast.make({
-      owner: 'jasonkuhrt',
-      repo: 'kitz',
-      branch: 'main',
-      headSha: 'abc1234',
-      releases: [],
-      cascades: [],
-    })
+    const forecast = makeForecast()
     let analysisInput: Parameters<typeof Api.Analyzer.analyze>[0] | undefined
     let forecastArgs:
       | {
@@ -135,6 +164,54 @@ describe('forecast-lib', () => {
     expect(result.interactiveChecklist).toBe(true)
   })
 
+  test('includes runtime dependency closure cascades from official planning', async () => {
+    const appPackage = workspacePackage('app')
+    const platformPackage = workspacePackage('platform')
+    const docsPackage = workspacePackage('docs')
+    const analysis = Analysis.make({
+      impacts: [
+        Impact.make({
+          package: appPackage,
+          bump: 'patch',
+          commits: [makeCascadeCommit('app', 'fix')],
+          currentVersion: Option.none(),
+        }),
+      ],
+      cascades: [],
+      unchanged: [platformPackage, docsPackage],
+      tags: [],
+    })
+
+    const result = await Effect.runPromise(
+      buildForecastInput({
+        loadWorkspace: Effect.succeed({
+          _tag: 'ReadyCommandWorkspace',
+          config: makeResolvedConfig(),
+          packages: [appPackage, platformPackage, docsPackage],
+        }),
+        tags: Effect.succeed([]),
+        analyze: (() => Effect.succeed(analysis)) as typeof Api.Analyzer.analyze,
+        explore: Effect.succeed(makeRecon()),
+        log: () => Effect.void,
+      }).pipe(
+        Effect.provide(
+          Fs.Memory.layer({
+            '/repo/packages/app/package.json': packageJson('app', {
+              dependencies: {
+                '@kitz/platform': 'workspace:*',
+              },
+            }),
+            '/repo/packages/platform/package.json': packageJson('platform'),
+            '/repo/packages/docs/package.json': packageJson('docs'),
+          }),
+        ),
+      ),
+    )
+
+    expect(result.forecast.releases.map((item) => item.packageName)).toEqual(['@kitz/app'])
+    expect(result.forecast.cascades.map((item) => item.packageName)).toEqual(['@kitz/platform'])
+  })
+
   test('falls back to git tags when custom tag loading is not provided', async () => {
     const harness = await Effect.runPromise(
       makeHarness({
@@ -147,21 +224,10 @@ describe('forecast-lib', () => {
         diskLayout: {},
       }),
     )
-    const pkg = {
-      scope: 'core',
-      name: Pkg.Moniker.parse('@kitz/core'),
-      path: Fs.Path.AbsDir.fromString('/repo/packages/core/'),
-    }
+    const pkg = workspacePackage('core')
     const analysis = { _tag: 'Analysis' } as any
     const recon = { _tag: 'Recon' } as any
-    const forecast = Api.Forecaster.Forecast.make({
-      owner: 'jasonkuhrt',
-      repo: 'kitz',
-      branch: 'main',
-      headSha: 'abc1234',
-      releases: [],
-      cascades: [],
-    })
+    const forecast = makeForecast()
     let analysisInput: Parameters<typeof Api.Analyzer.analyze>[0] | undefined
 
     const result = await Effect.runPromise(
@@ -191,14 +257,7 @@ describe('forecast-lib', () => {
         git: { root: '/repo', tags: [], commits: [], isClean: true },
         diskLayout: {
           '/tmp/forecast.json': Api.Forecaster.encodeForecastEnvelope({
-            forecast: Api.Forecaster.Forecast.make({
-              owner: 'jasonkuhrt',
-              repo: 'kitz',
-              branch: 'main',
-              headSha: 'abc1234',
-              releases: [],
-              cascades: [],
-            }),
+            forecast: makeForecast(),
             publishState: 'published',
             publishHistory: [
               {
@@ -230,16 +289,7 @@ describe('forecast-lib', () => {
         git: { root: '/repo', tags: [], commits: [], isClean: true },
         diskLayout: {
           '/tmp/raw-forecast.json': JSON.stringify(
-            Api.Forecaster.Forecast.encodeSync(
-              Api.Forecaster.Forecast.make({
-                owner: 'jasonkuhrt',
-                repo: 'kitz',
-                branch: 'main',
-                headSha: 'def5678',
-                releases: [],
-                cascades: [],
-              }),
-            ),
+            Api.Forecaster.Forecast.encodeSync(makeForecast('def5678')),
           ),
         },
       }),

--- a/packages/release/src/cli/commands/forecast-lib.ts
+++ b/packages/release/src/cli/commands/forecast-lib.ts
@@ -2,8 +2,9 @@ import { FileSystem } from 'effect'
 import { Env } from '@kitz/env'
 import { Git } from '@kitz/git'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Layer, Option, Schema } from 'effect'
+import { Console, Effect, HashSet, Layer, Option, Schema } from 'effect'
 import * as Api from '../../api/__.js'
+import { Analysis, CascadeImpact } from '../../api/analyzer/models/__.js'
 import { ChildProcessSpawnerLayer, ServicesLayer, FileSystemLayer } from '../../platform.js'
 import {
   type CommandWorkspace,
@@ -24,7 +25,7 @@ export interface BuildForecastInputDependencies {
   readonly tags: Effect.Effect<readonly string[], Error>
   readonly analyze: typeof Api.Analyzer.analyze
   readonly explore: Effect.Effect<any, Error>
-  readonly forecast: typeof Api.Forecaster.forecast
+  readonly forecast?: typeof Api.Forecaster.forecast
   readonly log: typeof Console.log
 }
 
@@ -82,8 +83,12 @@ export function buildForecastInput(
       resolvedConventionalCommitTypes: config.resolvedConventionalCommitTypes,
       commitOverrides: config.commitOverrides,
     })
+    const forecastAnalysis =
+      dependencies?.forecast === undefined
+        ? yield* addOfficialPlanCascades(analysis, packages)
+        : analysis
     const recon = yield* explore
-    const renderedForecast = forecast(analysis, recon)
+    const renderedForecast = forecast(forecastAnalysis, recon)
 
     return {
       forecast: renderedForecast,
@@ -91,6 +96,44 @@ export function buildForecastInput(
       publishHistory: [],
       interactiveChecklist: (config.publishing.ephemeral ?? { mode: 'manual' }).mode !== 'manual',
     }
+  })
+}
+
+export const addOfficialPlanCascades = (
+  analysis: Analysis,
+  packages: readonly Api.Analyzer.Workspace.Package[],
+): Effect.Effect<Analysis, Error, Effect.Services<ReturnType<typeof Api.Planner.official>>> =>
+  Effect.gen(function* () {
+    return withOfficialPlanCascades(analysis, yield* Api.Planner.official(analysis, { packages }))
+  })
+
+const withOfficialPlanCascades = (
+  analysis: Analysis,
+  plan: Api.Planner.PlanOf<'official'>,
+): Analysis => {
+  const existingCascadeNames = HashSet.fromIterable(
+    analysis.cascades.map((cascade) => cascade.package.name.moniker),
+  )
+  const planOnlyCascades = plan.cascades.filter(
+    (cascade) => !HashSet.has(existingCascadeNames, cascade.package.name.moniker),
+  )
+
+  if (planOnlyCascades.length === 0) return analysis
+
+  return Analysis.make({
+    impacts: analysis.impacts,
+    cascades: [
+      ...analysis.cascades,
+      ...planOnlyCascades.map((cascade) =>
+        CascadeImpact.make({
+          package: cascade.package,
+          currentVersion: cascade.currentVersion,
+          triggeredBy: [],
+        }),
+      ),
+    ],
+    unchanged: analysis.unchanged,
+    tags: analysis.tags,
   })
 }
 

--- a/packages/release/src/cli/commands/plan-file.test.ts
+++ b/packages/release/src/cli/commands/plan-file.test.ts
@@ -1,11 +1,12 @@
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
-import { Effect, Layer } from 'effect'
+import { Effect, Layer, Option } from 'effect'
 import { describe, expect, test } from 'bun:test'
 import {
   formatIgnoredInvalidPlanMessage,
   formatInvalidPlanMessage,
   formatMissingPlanMessage,
+  formatPlanCommand,
   formatUnsupportedExecutionPlanMessage,
   hasExecutablePlanContract,
   loadActivePlan,
@@ -100,5 +101,17 @@ describe('plan-file helpers', () => {
       'Missing field(s): planDigest, publishIntent.',
       'Run `release plan --lifecycle <official|candidate|ephemeral>` again with the current @kitz/release before executing, resuming, graphing, or checking durable status.',
     ])
+  })
+
+  test('formats plan follow-up commands with shell-safe custom paths', () => {
+    const custom = Option.some('./tmp/release plan.json')
+
+    expect(formatPlanCommand('release apply', Option.none())).toBe('release apply')
+    expect(formatPlanCommand('release apply', custom)).toBe(
+      "release apply --from './tmp/release plan.json'",
+    )
+    expect(formatPlanCommand('release resume', custom)).toBe(
+      "release resume --from './tmp/release plan.json'",
+    )
   })
 })

--- a/packages/release/src/cli/commands/plan-file.ts
+++ b/packages/release/src/cli/commands/plan-file.ts
@@ -44,6 +44,14 @@ const renderRegenerateCommand = (state: PlanMissingState | PlanInvalidState): st
     state.source === 'custom' ? ` --out ${renderPlanPath(state.location)}` : ''
   }`
 
+const shellSafeArgPattern = /^[A-Za-z0-9_/:=.,@%+-]+$/u
+
+export const quoteShellArg = (value: string): string =>
+  shellSafeArgPattern.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`
+
+export const formatPlanCommand = (command: string, from: Option.Option<string>): string =>
+  Option.isSome(from) ? `${command} --from ${quoteShellArg(from.value)}` : command
+
 export const loadPlan = (
   context: PlanLookupContext,
 ): Effect.Effect<PlanState, never, Env.Env | FileSystem.FileSystem> =>

--- a/packages/release/src/cli/commands/resume.ts
+++ b/packages/release/src/cli/commands/resume.ts
@@ -14,6 +14,7 @@ import { ChildProcessSpawnerLayer, FileSystemLayer, TerminalLayer } from '../../
 import {
   formatInvalidPlanMessage,
   formatMissingPlanMessage,
+  formatPlanCommand,
   formatUnsupportedExecutionPlanMessage,
   hasExecutablePlanContract,
   loadActivePlan,
@@ -114,7 +115,12 @@ export const resume = Command.make(
 
       const { events, execute, status: workflowStatus } = resumeAttempt.success
 
-      yield* Console.log(Api.Executor.formatExecutionStatus(workflowStatus, { env: env.vars }))
+      yield* Console.log(
+        Api.Executor.formatExecutionStatus(workflowStatus, {
+          env: env.vars,
+          resumeCommand: formatPlanCommand('release resume', from),
+        }),
+      )
 
       if (!yes) {
         const approved = yield* confirm('Resume interrupted release? [y/N] ')

--- a/packages/release/src/cli/commands/status.ts
+++ b/packages/release/src/cli/commands/status.ts
@@ -15,6 +15,7 @@ import { FileSystemLayer } from '../../platform.js'
 import {
   formatInvalidPlanMessage,
   formatMissingPlanMessage,
+  formatPlanCommand,
   formatUnsupportedExecutionPlanMessage,
   hasExecutablePlanContract,
   loadActivePlan,
@@ -81,11 +82,14 @@ export const status = Command.make(
         publishing,
         trunk: plan.publishIntent.git.trunk,
       }).pipe(Effect.provide(Api.Executor.makeWorkflowRuntime()))
-
       yield* Console.log(
         format === 'json'
           ? JSON.stringify(workflowStatus, null, 2)
-          : Api.Executor.formatExecutionStatus(workflowStatus, { env: env.vars }),
+          : Api.Executor.formatExecutionStatus(workflowStatus, {
+              env: env.vars,
+              nextApplyCommand: formatPlanCommand('release apply', from),
+              resumeCommand: formatPlanCommand('release resume', from),
+            }),
       )
     }),
 ).pipe(

--- a/packages/release/src/cli/pr-preview.coverage.test.ts
+++ b/packages/release/src/cli/pr-preview.coverage.test.ts
@@ -18,6 +18,7 @@ import { makeHarness, makePackageJson } from '../api/executor/test-support.js'
 import { loadPullRequestDiff } from './pr-preview-diff.js'
 import {
   type PreviewCommentUpdateParams,
+  type RunPrPreviewDependencies,
   PreviewBlockingError,
   buildPreviewDoctorSummary,
   runPrPreview,
@@ -33,6 +34,7 @@ const makePackage = (scope: string) => ({
 
 const corePackage = makePackage('core')
 const utilsPackage = makePackage('utils')
+const docsPackage = makePackage('docs')
 
 const makeConfig = (
   publishing: Api.Config.ResolvedConfig['publishing'] = Api.Publishing.defaultPublishing(),
@@ -124,6 +126,39 @@ const baseForecast = Forecast.make({
   headSha: 'abc1234',
   releases: [],
   cascades: [],
+})
+
+const changedCoreDiff = {
+  files: [{ path: 'packages/core/src/index.ts', status: 'modified' as const }],
+  affectedPackages: ['core'],
+}
+
+const renderedPreviewComment = {
+  body: 'rendered preview',
+  issueComment: {
+    id: 41,
+    body: 'rendered preview',
+    html_url: 'https://github.com/org/repo/pull/129#issuecomment-41',
+  },
+}
+
+const capturePreviewComment =
+  (capture: (params: PreviewCommentUpdateParams) => void) =>
+  (params: PreviewCommentUpdateParams) => {
+    capture(params)
+    return Effect.succeed(renderedPreviewComment)
+  }
+
+const previewDeps = (overrides: RunPrPreviewDependencies = {}): RunPrPreviewDependencies => ({
+  loadConfig: () => Effect.succeed(makeConfig()),
+  resolvePackages: () => Effect.succeed([corePackage]),
+  resolvePullRequestContext: () => Effect.succeed(makePullRequestContext()),
+  exploreFromContext: () => Effect.succeed(makeRuntime()),
+  getTags: () => Effect.succeed([]),
+  analyze: () => Effect.succeed(makeAnalysis()),
+  loadPullRequestDiff: () => Effect.succeed({ files: [], affectedPackages: [] }),
+  buildPreviewDoctorSummary: () => Effect.succeed({ blocking: false }),
+  ...overrides,
 })
 
 const makeHandle = (stdout: string): ChildProcessSpawner.ChildProcessHandle =>
@@ -515,10 +550,9 @@ describe('pr preview coverage', () => {
       assumePure(
         runPrPreview(
           {},
-          {
-            loadConfig: () => Effect.succeed(makeConfig()),
+          previewDeps({
             resolvePackages: () => Effect.succeed([]),
-          },
+          }),
         ).pipe(Effect.result),
       ),
     )
@@ -536,9 +570,7 @@ describe('pr preview coverage', () => {
       assumePure(
         runPrPreview(
           {},
-          {
-            loadConfig: () => Effect.succeed(makeConfig()),
-            resolvePackages: () => Effect.succeed([corePackage]),
+          previewDeps({
             resolvePullRequestContext: () =>
               Effect.fail(
                 new Api.Explorer.ExplorerError({
@@ -547,7 +579,7 @@ describe('pr preview coverage', () => {
                   },
                 }),
               ),
-          },
+          }),
         ).pipe(Effect.result),
       ),
     )
@@ -565,13 +597,10 @@ describe('pr preview coverage', () => {
       assumePure(
         runPrPreview(
           {},
-          {
-            loadConfig: () => Effect.succeed(makeConfig()),
-            resolvePackages: () => Effect.succeed([corePackage]),
+          previewDeps({
             resolvePullRequestContext: () =>
               Effect.succeed(makePullRequestContext({ pullRequest: null })),
-            exploreFromContext: () => Effect.succeed(makeRuntime()),
-          },
+          }),
         ).pipe(Effect.result),
       ),
     )
@@ -589,9 +618,7 @@ describe('pr preview coverage', () => {
       assumePure(
         runPrPreview(
           {},
-          {
-            loadConfig: () => Effect.succeed(makeConfig()),
-            resolvePackages: () => Effect.succeed([corePackage]),
+          previewDeps({
             resolvePullRequestContext: () =>
               Effect.succeed(makePullRequestContext({ token: null })),
             exploreFromContext: () =>
@@ -600,7 +627,7 @@ describe('pr preview coverage', () => {
                   credentials: null,
                 }),
               ),
-          },
+          }),
         ).pipe(Effect.result),
       ),
     )
@@ -618,16 +645,9 @@ describe('pr preview coverage', () => {
       assumePure(
         runPrPreview(
           { checkOnly: true },
-          {
-            loadConfig: () => Effect.succeed(makeConfig()),
-            resolvePackages: () => Effect.succeed([corePackage]),
-            resolvePullRequestContext: () => Effect.succeed(makePullRequestContext()),
-            exploreFromContext: () => Effect.succeed(makeRuntime()),
-            getTags: () => Effect.succeed([]),
-            analyze: () => Effect.succeed(makeAnalysis()),
-            loadPullRequestDiff: () => Effect.succeed({ files: [], affectedPackages: [] }),
+          previewDeps({
             buildPreviewDoctorSummary: () => Effect.succeed({ blocking: true }),
-          },
+          }),
         ).pipe(Effect.result),
       ),
     )
@@ -642,21 +662,7 @@ describe('pr preview coverage', () => {
 
   test('returns a checked result in check-only mode when doctor checks pass', async () => {
     const result = await Effect.runPromise(
-      assumePure(
-        runPrPreview(
-          { checkOnly: true },
-          {
-            loadConfig: () => Effect.succeed(makeConfig()),
-            resolvePackages: () => Effect.succeed([corePackage]),
-            resolvePullRequestContext: () => Effect.succeed(makePullRequestContext()),
-            exploreFromContext: () => Effect.succeed(makeRuntime()),
-            getTags: () => Effect.succeed([]),
-            analyze: () => Effect.succeed(makeAnalysis()),
-            loadPullRequestDiff: () => Effect.succeed({ files: [], affectedPackages: [] }),
-            buildPreviewDoctorSummary: () => Effect.succeed({ blocking: false }),
-          },
-        ),
-      ),
+      assumePure(runPrPreview({ checkOnly: true }, previewDeps())),
     )
 
     expect(result).toEqual({
@@ -680,7 +686,7 @@ describe('pr preview coverage', () => {
       assumePure(
         runPrPreview(
           {},
-          {
+          previewDeps({
             loadConfig: () =>
               Effect.succeed(
                 makeConfig(
@@ -695,16 +701,8 @@ describe('pr preview coverage', () => {
                   }),
                 ),
               ),
-            resolvePackages: () => Effect.succeed([corePackage]),
-            resolvePullRequestContext: () => Effect.succeed(makePullRequestContext()),
-            exploreFromContext: () => Effect.succeed(makeRuntime()),
-            getTags: () => Effect.succeed([]),
             analyze: () => Effect.succeed(analysis),
-            loadPullRequestDiff: () =>
-              Effect.succeed({
-                files: [{ path: 'packages/core/src/index.ts', status: 'modified' }],
-                affectedPackages: ['core'],
-              }),
+            loadPullRequestDiff: () => Effect.succeed(changedCoreDiff),
             buildPreviewDoctorSummary: () =>
               Effect.succeed({
                 blocking: false,
@@ -722,33 +720,72 @@ describe('pr preview coverage', () => {
                 },
               }),
             forecast: () => baseForecast,
-            upsertPullRequestPreviewComment: (params: PreviewCommentUpdateParams) => {
+            upsertPullRequestPreviewComment: capturePreviewComment((params) => {
               capturedUpdate = params
-              return Effect.succeed({
-                body: 'rendered preview',
-                issueComment: {
-                  id: 41,
-                  body: 'rendered preview',
-                  html_url: 'https://github.com/org/repo/pull/129#issuecomment-41',
-                },
-              })
-            },
-          },
+            }),
+          }),
         ),
       ),
     )
 
     expect(result).toEqual({
       _tag: 'updated',
-      body: 'rendered preview',
-      issueComment: {
-        id: 41,
-        body: 'rendered preview',
-        html_url: 'https://github.com/org/repo/pull/129#issuecomment-41',
-      },
+      ...renderedPreviewComment,
     })
     expect(capturedUpdate?.interactiveChecklist).toBe(true)
     expect(capturedUpdate?.projectedSquashCommit?.projectedHeader).toContain('feat(core)')
+  })
+
+  test('includes runtime dependency closure cascades in default preview forecasts', async () => {
+    const analysis = Analysis.make({
+      impacts: [
+        Impact.make({
+          package: corePackage,
+          bump: 'patch',
+          commits: [],
+          currentVersion: Option.none(),
+        }),
+      ],
+      cascades: [],
+      unchanged: [utilsPackage, docsPackage],
+      tags: [],
+    })
+    let capturedUpdate: PreviewCommentUpdateParams | undefined
+
+    await Effect.runPromise(
+      assumePure(
+        runPrPreview(
+          {},
+          previewDeps({
+            resolvePackages: () => Effect.succeed([corePackage, utilsPackage, docsPackage]),
+            analyze: () => Effect.succeed(analysis),
+            loadPullRequestDiff: () => Effect.succeed(changedCoreDiff),
+            upsertPullRequestPreviewComment: capturePreviewComment((params) => {
+              capturedUpdate = params
+            }),
+          }),
+        ).pipe(
+          Effect.provide(
+            Fs.Memory.layer({
+              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
+                dependencies: {
+                  '@kitz/utils': 'workspace:*',
+                },
+              }),
+              '/repo/packages/utils/package.json': makePackageJson('@kitz/utils', '1.0.0'),
+              '/repo/packages/docs/package.json': makePackageJson('@kitz/docs', '1.0.0'),
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(capturedUpdate?.forecast.releases.map((item) => item.packageName)).toEqual([
+      '@kitz/core',
+    ])
+    expect(capturedUpdate?.forecast.cascades.map((item) => item.packageName)).toEqual([
+      '@kitz/utils',
+    ])
   })
 
   test('passes resolved remote (not hard-coded origin) to analyzer since parameter', async () => {

--- a/packages/release/src/cli/pr-preview.ts
+++ b/packages/release/src/cli/pr-preview.ts
@@ -10,6 +10,7 @@ import {
   createCommandLintConfig,
   type CommandLintRuleSpec,
 } from './lint-rule-config.js'
+import { addOfficialPlanCascades } from './commands/forecast-lib.js'
 import { loadPullRequestDiff, resolveDiffRemote } from './pr-preview-diff.js'
 
 const manualPreviewDeferredRules = [
@@ -475,7 +476,11 @@ export const runPrPreview = (
       } satisfies RunPrPreviewResult
     }
 
-    const forecast = (dependencies.forecast ?? Api.Forecaster.forecast)(analysis, runtime)
+    const forecastAnalysis =
+      dependencies.forecast === undefined
+        ? yield* addOfficialPlanCascades(analysis, packages)
+        : analysis
+    const forecast = (dependencies.forecast ?? Api.Forecaster.forecast)(forecastAnalysis, runtime)
     const previewEffect = (
       dependencies.upsertPullRequestPreviewComment ?? upsertPullRequestPreviewComment
     )({


### PR DESCRIPTION
## Summary

- Align `release forecast` and PR preview with official runtime dependency closure cascades.
- Clean expected doctor exits and preserve custom `--from` plan paths in status/resume guidance.
- Prompt before apply locking, then keep validation and publish execution under the release lock.
- Add red coverage for the QA failures while reducing touched test LOC from 2845 to 2826 (-19).

## QA

- Dry-run official plan/forecast preview: 41 primary releases + 5 cascades = 46 total packages.
- Verified canceling `release apply` exits without leaving `.release/locks/*`.
- `bun run --cwd packages/release test src/_.test.ts src/cli/commands/plan-file.test.ts src/api/executor/status.test.ts src/cli/commands/forecast-lib.test.ts src/cli/commands/apply.test.ts src/cli/commands/doctor.test.ts src/cli/pr-preview.coverage.test.ts`
- `bun run release:verify`