### PR TITLE
fix(release): centralize typed persistence resources

### DIFF
--- a/packages/release/src/api/artifact.ts
+++ b/packages/release/src/api/artifact.ts
@@ -23,12 +23,14 @@ import {
   type PreparedArtifact,
   type ReleaseInfo,
 } from './executor/publish.js'
+import { jsonFile } from './persistence.js'
 import type { Plan } from './planner/models/plan.js'
 import { digestForPlan } from './proof.js'
 import { ArtifactManifest } from './release-contract.js'
 
 const artifactDir = Fs.Path.RelDir.fromString('./.release/artifacts/')
 const artifactManifestFile = Fs.Path.RelFile.fromString('./manifest.json')
+const artifactManifestResource = jsonFile(Schema.Array(ArtifactManifest))
 const PackageJsonScriptsFromString = Schema.fromJsonString(
   Schema.Struct({
     scripts: Schema.optional(Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown))),
@@ -433,36 +435,22 @@ export const validateEnginePolicyForPlan = (
 export const writeManifest = (
   plan: Plan,
   manifests: readonly ArtifactManifest[],
-): Effect.Effect<void, PlatformError.PlatformError, Env.Env | FileSystem.FileSystem> =>
+): Effect.Effect<void, Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
-    const fs = yield* FileSystem.FileSystem
-    const path = manifestPathFor(env.cwd, plan)
-    yield* fs.makeDirectory(Fs.Path.toString(Fs.Path.toDir(path)), { recursive: true })
-    yield* fs.writeFileString(
-      Fs.Path.toString(path),
-      `${JSON.stringify(Schema.encodeSync(Schema.Array(ArtifactManifest))([...manifests]), null, 2)}\n`,
-    )
+    yield* artifactManifestResource.write([...manifests], manifestPathFor(env.cwd, plan))
   })
 
 export const readManifest = (
   plan: Plan,
 ): Effect.Effect<
   Option.Option<readonly ArtifactManifest[]>,
-  PlatformError.PlatformError | Schema.SchemaError,
+  Resource.ResourceError,
   Env.Env | FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
     const env = yield* Env.Env
-    const fs = yield* FileSystem.FileSystem
-    const path = manifestPathFor(env.cwd, plan)
-    const exists = yield* fs.exists(Fs.Path.toString(path))
-    if (!exists) return Option.none()
-    const text = yield* fs.readFileString(Fs.Path.toString(path))
-    const decoded = yield* Schema.decodeUnknownEffect(
-      Schema.fromJsonString(Schema.Array(ArtifactManifest)),
-    )(text)
-    return Option.some(decoded)
+    return yield* artifactManifestResource.read(manifestPathFor(env.cwd, plan))
   })
 
 export interface RehearseOptions {

--- a/packages/release/src/api/journal.ts
+++ b/packages/release/src/api/journal.ts
@@ -1,10 +1,13 @@
-import { PlatformError, Effect, FileSystem, Schema } from 'effect'
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
+import { Resource } from '@kitz/resource'
+import { Effect, FileSystem, Schema } from 'effect'
 import { sha256Json } from './digest.js'
+import { jsonLinesFile } from './persistence.js'
 import { PlanDigest, SideEffectEntry, type SideEffectKind } from './release-contract.js'
 
 const journalDir = Fs.Path.RelDir.fromString('./.release/journal/')
+const journalResource = jsonLinesFile(SideEffectEntry)
 
 export interface SideEffectInput {
   readonly planDigest: string | PlanDigest
@@ -60,39 +63,14 @@ export const journalPathFor = (
 
 export const readEntries = (
   path: Fs.Path.AbsFile,
-): Effect.Effect<
-  readonly SideEffectEntry[],
-  PlatformError.PlatformError | Schema.SchemaError,
-  FileSystem.FileSystem
-> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const exists = yield* fs.exists(Fs.Path.toString(path))
-    if (!exists) return []
-    const text = yield* fs.readFileString(Fs.Path.toString(path))
-    const lines = text
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-    return yield* Effect.all(
-      lines.map((line) => Schema.decodeUnknownEffect(Schema.fromJsonString(SideEffectEntry))(line)),
-    )
-  })
+): Effect.Effect<readonly SideEffectEntry[], Resource.ResourceError, FileSystem.FileSystem> =>
+  journalResource.read(path)
 
 export const writeEntries = (
   path: Fs.Path.AbsFile,
   entries: readonly SideEffectEntry[],
-): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    yield* fs.makeDirectory(Fs.Path.toString(Fs.Path.toDir(path)), { recursive: true })
-    yield* fs.writeFileString(
-      Fs.Path.toString(path),
-      `${entries
-        .map((entry) => JSON.stringify(Schema.encodeSync(SideEffectEntry)(entry)))
-        .join('\n')}\n`,
-    )
-  })
+): Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem> =>
+  journalResource.write(entries, path)
 
 export const makeEntry = (input: SideEffectInput, previous?: SideEffectEntry): SideEffectEntry => {
   const planDigest =
@@ -122,11 +100,7 @@ export const makeEntry = (input: SideEffectInput, previous?: SideEffectEntry): S
 
 export const appendSideEffect = (
   input: SideEffectInput,
-): Effect.Effect<
-  SideEffectEntry,
-  PlatformError.PlatformError | Schema.SchemaError,
-  Env.Env | FileSystem.FileSystem
-> =>
+): Effect.Effect<SideEffectEntry, Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
     const path = journalPathFor(env.cwd, input.planDigest)

--- a/packages/release/src/api/lock.ts
+++ b/packages/release/src/api/lock.ts
@@ -1,9 +1,12 @@
-import { PlatformError, Effect, FileSystem, Option, Schema } from 'effect'
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
+import { Resource } from '@kitz/resource'
+import { Effect, FileSystem, Option } from 'effect'
+import { jsonFile } from './persistence.js'
 import { ExecutionLock, type PlanDigest, PrincipalRef } from './release-contract.js'
 
 const lockDir = Fs.Path.RelDir.fromString('./.release/locks/')
+const lockResource = jsonFile(ExecutionLock)
 
 export interface LockIssue {
   readonly code: string
@@ -64,40 +67,18 @@ export const validate = (lock: ExecutionLock, now: string): readonly LockIssue[]
 
 export const read = (
   path: Fs.Path.AbsFile,
-): Effect.Effect<
-  Option.Option<ExecutionLock>,
-  PlatformError.PlatformError | Schema.SchemaError,
-  FileSystem.FileSystem
-> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const exists = yield* fs.exists(Fs.Path.toString(path))
-    if (!exists) return Option.none()
-    const text = yield* fs.readFileString(Fs.Path.toString(path))
-    const lock = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(ExecutionLock))(text)
-    return Option.some(lock)
-  })
+): Effect.Effect<Option.Option<ExecutionLock>, Resource.ResourceError, FileSystem.FileSystem> =>
+  lockResource.read(path)
 
 export const write = (
   path: Fs.Path.AbsFile,
   lock: ExecutionLock,
-): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    yield* fs.makeDirectory(Fs.Path.toString(Fs.Path.toDir(path)), { recursive: true })
-    yield* fs.writeFileString(
-      Fs.Path.toString(path),
-      `${JSON.stringify(Schema.encodeSync(ExecutionLock)(lock), null, 2)}\n`,
-    )
-  })
+): Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem> =>
+  lockResource.write(lock, path)
 
 export const acquireLocal = (
   params: LocalLockParams,
-): Effect.Effect<
-  ExecutionLock,
-  Error | PlatformError.PlatformError | Schema.SchemaError,
-  Env.Env | FileSystem.FileSystem
-> =>
+): Effect.Effect<ExecutionLock, Error | Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
     const path = lockPathFor(env.cwd, params.planDigest)
@@ -123,13 +104,11 @@ export const acquireLocal = (
 
 export const releaseLocal = (
   planDigest: PlanDigest,
-): Effect.Effect<void, PlatformError.PlatformError, Env.Env | FileSystem.FileSystem> =>
+): Effect.Effect<void, Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
-    const fs = yield* FileSystem.FileSystem
     const path = lockPathFor(env.cwd, planDigest)
-    const exists = yield* fs.exists(Fs.Path.toString(path))
-    if (exists) yield* fs.remove(Fs.Path.toString(path))
+    yield* lockResource.delete(path)
   })
 
 // oxlint-disable-next-line kitz/error/require-tagged-error-types -- withLocal preserves the wrapped effect's error channel exactly.
@@ -140,7 +119,7 @@ export const withLocal = <A, E, R>(
 ): Effect.Effect<
   A,
   // oxlint-disable-next-line kitz/error/require-tagged-error-types -- withLocal preserves the wrapped effect's error channel exactly.
-  E | Error | PlatformError.PlatformError | Schema.SchemaError,
+  E | Error | Resource.ResourceError,
   R | Env.Env | FileSystem.FileSystem
 > =>
   Effect.gen(function* () {

--- a/packages/release/src/api/persistence.test.ts
+++ b/packages/release/src/api/persistence.test.ts
@@ -57,4 +57,22 @@ describe('release persistence helpers', () => {
     ])
     expect(result.raw.trim().split('\n')).toHaveLength(2)
   })
+
+  test('maps JSON stringify failures to encode errors', async () => {
+    const file = Fs.Path.AbsFile.fromString('/repo/.release/unstringifiable.json')
+    const lines = Fs.Path.AbsFile.fromString('/repo/.release/unstringifiable.jsonl')
+    const json = jsonFile(Schema.Unknown)
+    const jsonl = jsonLinesFile(Schema.Unknown)
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fileError = yield* json.write(1n, file).pipe(Effect.flip)
+        const linesError = yield* jsonl.write([1n], lines).pipe(Effect.flip)
+        return { fileError, linesError }
+      }).pipe(Effect.provide(Fs.Memory.layer({}))),
+    )
+
+    expect(result.fileError).toBeInstanceOf(Resource.EncodeError)
+    expect(result.linesError).toBeInstanceOf(Resource.EncodeError)
+  })
 })

--- a/packages/release/src/api/persistence.test.ts
+++ b/packages/release/src/api/persistence.test.ts
@@ -1,0 +1,60 @@
+import { Fs } from '@kitz/fs'
+import { Resource } from '@kitz/resource'
+import { Effect, Option, Schema } from 'effect'
+import { describe, expect, test } from 'bun:test'
+import { jsonFile, jsonLinesFile } from './persistence.js'
+
+const Entry = Schema.Struct({
+  id: Schema.String,
+  count: Schema.Number,
+})
+
+describe('release persistence helpers', () => {
+  test('read and write typed JSON files with resource errors', async () => {
+    const file = Fs.Path.AbsFile.fromString('/repo/.release/example.json')
+    const json = jsonFile(Entry)
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const missing = yield* json.read(file)
+        yield* json.write({ id: 'first', count: 1 }, file)
+        const written = yield* json.readRequired(file)
+        yield* Fs.write(file, '{ nope')
+        const malformed = yield* json.readRequired(file).pipe(Effect.flip)
+        return { missing, written, malformed }
+      }).pipe(Effect.provide(Fs.Memory.layer({}))),
+    )
+
+    expect(Option.isNone(result.missing)).toBe(true)
+    expect(result.written).toEqual({ id: 'first', count: 1 })
+    expect(result.malformed).toBeInstanceOf(Resource.ParseError)
+  })
+
+  test('read and write typed JSONL files', async () => {
+    const file = Fs.Path.AbsFile.fromString('/repo/.release/journal/example.jsonl')
+    const jsonl = jsonLinesFile(Entry)
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const missing = yield* jsonl.read(file)
+        yield* jsonl.write(
+          [
+            { id: 'first', count: 1 },
+            { id: 'second', count: 2 },
+          ],
+          file,
+        )
+        const written = yield* jsonl.read(file)
+        const raw = yield* Fs.readString(file)
+        return { missing, written, raw }
+      }).pipe(Effect.provide(Fs.Memory.layer({}))),
+    )
+
+    expect(result.missing).toEqual([])
+    expect(result.written).toEqual([
+      { id: 'first', count: 1 },
+      { id: 'second', count: 2 },
+    ])
+    expect(result.raw.trim().split('\n')).toHaveLength(2)
+  })
+})

--- a/packages/release/src/api/persistence.ts
+++ b/packages/release/src/api/persistence.ts
@@ -1,0 +1,169 @@
+import { Fs } from '@kitz/fs'
+import { Resource } from '@kitz/resource'
+import { Effect, Option, PlatformError, Schema, SchemaAST, SchemaIssue, FileSystem } from 'effect'
+
+const formatSchemaIssue = SchemaIssue.makeFormatterDefault()
+const UnknownJsonFromString = Schema.fromJsonString(Schema.Unknown)
+
+const mapReadError = (path: Fs.Path.AbsFile, detail: string): Resource.ReadError =>
+  new Resource.ReadError({ context: { path, detail } })
+
+const mapWriteError = (path: Fs.Path.AbsFile, detail: string): Resource.WriteError =>
+  new Resource.WriteError({ context: { path, detail } })
+
+const mapParseError = (path: Fs.Path.AbsFile, detail: string): Resource.ParseError =>
+  new Resource.ParseError({ context: { path, detail } })
+
+const mapEncodeError = (path: Fs.Path.AbsFile, detail: string): Resource.EncodeError =>
+  new Resource.EncodeError({ context: { path, detail } })
+
+const readStringIfExists = (
+  path: Fs.Path.AbsFile,
+): Effect.Effect<Option.Option<string>, Resource.ResourceError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const exists = yield* Fs.exists(path).pipe(
+      Effect.mapError((error: PlatformError.PlatformError) =>
+        mapReadError(path, `check exists: ${error.message}`),
+      ),
+    )
+    if (!exists) return Option.none()
+    return Option.some(
+      yield* Fs.readString(path).pipe(
+        Effect.mapError((error: PlatformError.PlatformError) => mapReadError(path, error.message)),
+      ),
+    )
+  })
+
+const writeString = (
+  path: Fs.Path.AbsFile,
+  content: string,
+): Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem> =>
+  Fs.write(path, content).pipe(
+    Effect.mapError((error: PlatformError.PlatformError) => mapWriteError(path, error.message)),
+  )
+
+const parseJson = (path: Fs.Path.AbsFile, content: string) =>
+  Schema.decodeUnknownEffect(UnknownJsonFromString)(content).pipe(
+    Effect.mapError((error) => mapParseError(path, formatSchemaIssue(error.issue))),
+  )
+
+const decodeUnknown =
+  <A, I, R>(path: Fs.Path.AbsFile, schema: Schema.Codec<A, I, R>) =>
+  (input: unknown) =>
+    Schema.decodeUnknownEffect(schema)(input).pipe(
+      Effect.mapError((error) => mapParseError(path, formatSchemaIssue(error.issue))),
+    )
+
+const encodeUnknown = <A, I, R>(
+  path: Fs.Path.AbsFile,
+  schema: Schema.Codec<A, I, R>,
+  value: A,
+  options?: SchemaAST.ParseOptions,
+) =>
+  Schema.encodeEffect(schema)(value, options).pipe(
+    Effect.mapError((error) => mapEncodeError(path, formatSchemaIssue(error.issue))),
+  )
+
+export interface JsonFile<A, R = never> {
+  readonly read: (
+    path: Fs.Path.AbsFile,
+  ) => Effect.Effect<Option.Option<A>, Resource.ResourceError, FileSystem.FileSystem | R>
+  readonly readRequired: (
+    path: Fs.Path.AbsFile,
+  ) => Effect.Effect<A, Resource.ResourceError, FileSystem.FileSystem | R>
+  readonly write: (
+    value: A,
+    path: Fs.Path.AbsFile,
+  ) => Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem | R>
+  readonly delete: (
+    path: Fs.Path.AbsFile,
+  ) => Effect.Effect<boolean, Resource.ResourceError, FileSystem.FileSystem>
+}
+
+export const jsonFile = <A, I, R = never>(
+  schema: Schema.Codec<A, I, R>,
+  options?: Resource.CreateOptions,
+): JsonFile<A, R> => {
+  const parseOptions: SchemaAST.ParseOptions | undefined = options?.preserveExcessProperties
+    ? { onExcessProperty: 'preserve' }
+    : undefined
+
+  const read = (path: Fs.Path.AbsFile) =>
+    Effect.gen(function* () {
+      const content = yield* readStringIfExists(path)
+      if (Option.isNone(content)) return Option.none()
+      const parsed = yield* parseJson(path, content.value)
+      return Option.some(yield* decodeUnknown(path, schema)(parsed))
+    })
+
+  const readRequired = (path: Fs.Path.AbsFile) =>
+    Effect.gen(function* () {
+      const result = yield* read(path)
+      if (Option.isSome(result)) return result.value
+      return yield* Effect.fail(new Resource.NotFoundError({ context: { path } }))
+    })
+
+  const write = (value: A, path: Fs.Path.AbsFile) =>
+    Effect.gen(function* () {
+      const encoded = yield* encodeUnknown(path, schema, value, parseOptions)
+      yield* writeString(path, `${JSON.stringify(encoded, null, 2)}\n`)
+    })
+
+  const delete_ = (path: Fs.Path.AbsFile) =>
+    Effect.gen(function* () {
+      const exists = yield* Fs.exists(path).pipe(
+        Effect.mapError((error: PlatformError.PlatformError) =>
+          mapWriteError(path, `check exists: ${error.message}`),
+        ),
+      )
+      if (!exists) return false
+      yield* Fs.remove(path).pipe(
+        Effect.mapError((error: PlatformError.PlatformError) =>
+          mapWriteError(path, `delete: ${error.message}`),
+        ),
+      )
+      return true
+    })
+
+  return { read, readRequired, write, delete: delete_ }
+}
+
+export interface JsonLinesFile<A, R = never> {
+  readonly read: (
+    path: Fs.Path.AbsFile,
+  ) => Effect.Effect<readonly A[], Resource.ResourceError, FileSystem.FileSystem | R>
+  readonly write: (
+    values: readonly A[],
+    path: Fs.Path.AbsFile,
+  ) => Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem | R>
+}
+
+export const jsonLinesFile = <A, I, R = never>(
+  schema: Schema.Codec<A, I, R>,
+): JsonLinesFile<A, R> => {
+  const read = (path: Fs.Path.AbsFile) =>
+    Effect.gen(function* () {
+      const content = yield* readStringIfExists(path)
+      if (Option.isNone(content)) return []
+      return yield* Effect.all(
+        content.value
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0)
+          .map((line) =>
+            Effect.gen(function* () {
+              const parsed = yield* parseJson(path, line)
+              return yield* decodeUnknown(path, schema)(parsed)
+            }),
+          ),
+      )
+    })
+
+  const write = (values: readonly A[], path: Fs.Path.AbsFile) =>
+    Effect.gen(function* () {
+      const encoded = yield* Effect.all(values.map((value) => encodeUnknown(path, schema, value)))
+      yield* writeString(path, `${encoded.map((value) => JSON.stringify(value)).join('\n')}\n`)
+    })
+
+  return { read, write }
+}

--- a/packages/release/src/api/persistence.ts
+++ b/packages/release/src/api/persistence.ts
@@ -64,6 +64,22 @@ const encodeUnknown = <A, I, R>(
     Effect.mapError((error) => mapEncodeError(path, formatSchemaIssue(error.issue))),
   )
 
+const stringifyJson = (
+  path: Fs.Path.AbsFile,
+  value: unknown,
+  space?: number,
+): Effect.Effect<string, Resource.ResourceError> =>
+  Effect.try({
+    try: () => {
+      const result = JSON.stringify(value, null, space)
+      if (result === undefined) {
+        throw new TypeError('JSON.stringify returned undefined')
+      }
+      return result
+    },
+    catch: (cause) => mapEncodeError(path, cause instanceof Error ? cause.message : String(cause)),
+  })
+
 export interface JsonFile<A, R = never> {
   readonly read: (
     path: Fs.Path.AbsFile,
@@ -106,7 +122,8 @@ export const jsonFile = <A, I, R = never>(
   const write = (value: A, path: Fs.Path.AbsFile) =>
     Effect.gen(function* () {
       const encoded = yield* encodeUnknown(path, schema, value, parseOptions)
-      yield* writeString(path, `${JSON.stringify(encoded, null, 2)}\n`)
+      const content = yield* stringifyJson(path, encoded, 2)
+      yield* writeString(path, `${content}\n`)
     })
 
   const delete_ = (path: Fs.Path.AbsFile) =>
@@ -162,7 +179,8 @@ export const jsonLinesFile = <A, I, R = never>(
   const write = (values: readonly A[], path: Fs.Path.AbsFile) =>
     Effect.gen(function* () {
       const encoded = yield* Effect.all(values.map((value) => encodeUnknown(path, schema, value)))
-      yield* writeString(path, `${encoded.map((value) => JSON.stringify(value)).join('\n')}\n`)
+      const lines = yield* Effect.all(encoded.map((value) => stringifyJson(path, value)))
+      yield* writeString(path, `${lines.join('\n')}\n`)
     })
 
   return { read, write }

--- a/packages/release/src/api/proof.ts
+++ b/packages/release/src/api/proof.ts
@@ -4,17 +4,10 @@ import { Git } from '@kitz/git'
 import { Github } from '@kitz/github'
 import { NpmRegistry } from '@kitz/npm-registry'
 import { Pkg } from '@kitz/pkg'
-import {
-  Array as A,
-  Clock,
-  Effect,
-  FileSystem,
-  Option,
-  PlatformError,
-  Result,
-  Schema,
-} from 'effect'
+import { Resource } from '@kitz/resource'
+import { Array as A, Clock, Effect, FileSystem, Option, Result, Schema } from 'effect'
 import { sha256Json } from './digest.js'
+import { jsonFile } from './persistence.js'
 import type { Plan } from './planner/models/plan.js'
 import * as Capability from './publishing/models/capability.js'
 import {
@@ -26,6 +19,7 @@ import {
 } from './release-contract.js'
 
 const proofDir = Fs.Path.RelDir.fromString('./.release/proofs/')
+const proofResource = jsonFile(ProofArtifact)
 
 export interface ProofIssue {
   readonly recordId: string
@@ -754,36 +748,18 @@ export const validateProof = (
 export const write = (
   proof: ProofArtifact,
   path: Fs.Path.AbsFile,
-): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    yield* fs.makeDirectory(Fs.Path.toString(Fs.Path.toDir(path)), { recursive: true })
-    yield* fs.writeFileString(
-      Fs.Path.toString(path),
-      `${JSON.stringify(Schema.encodeSync(ProofArtifact)(proof), null, 2)}\n`,
-    )
-  })
+): Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem> =>
+  proofResource.write(proof, path)
 
 export const read = (
   path: Fs.Path.AbsFile,
-): Effect.Effect<
-  Option.Option<ProofArtifact>,
-  PlatformError.PlatformError | Schema.SchemaError,
-  FileSystem.FileSystem
-> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const exists = yield* fs.exists(Fs.Path.toString(path))
-    if (!exists) return Option.none()
-    const text = yield* fs.readFileString(Fs.Path.toString(path))
-    const decoded = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(ProofArtifact))(text)
-    return Option.some(decoded)
-  })
+): Effect.Effect<Option.Option<ProofArtifact>, Resource.ResourceError, FileSystem.FileSystem> =>
+  proofResource.read(path)
 
 export const prove = (
   plan: Plan,
   observations: ProofObservations = {},
-): Effect.Effect<ProofArtifact, PlatformError.PlatformError, Env.Env | FileSystem.FileSystem> =>
+): Effect.Effect<ProofArtifact, Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
     const now = yield* Clock.currentTimeMillis
@@ -796,7 +772,7 @@ export const readForPlan = (
   plan: Plan,
 ): Effect.Effect<
   Option.Option<ProofArtifact>,
-  PlatformError.PlatformError | Schema.SchemaError,
+  Resource.ResourceError,
   Env.Env | FileSystem.FileSystem
 > =>
   Effect.gen(function* () {

--- a/packages/release/src/api/reconciler.ts
+++ b/packages/release/src/api/reconciler.ts
@@ -1,7 +1,8 @@
 import { Env } from '@kitz/env'
 import { NpmRegistry } from '@kitz/npm-registry'
 import { Pkg } from '@kitz/pkg'
-import { PlatformError, Effect, FileSystem, HashSet, Option, Schema } from 'effect'
+import { Resource } from '@kitz/resource'
+import { Effect, FileSystem, HashSet, Option, Schema } from 'effect'
 import * as Journal from './journal.js'
 import type { Plan } from './planner/models/plan.js'
 import { digestForPlan } from './proof.js'
@@ -152,7 +153,7 @@ export const reconcile = (
   plan: Plan,
 ): Effect.Effect<
   ReconcileDecision,
-  PlatformError.PlatformError | Schema.SchemaError | NpmRegistry.NpmCliError,
+  Resource.ResourceError | NpmRegistry.NpmCliError,
   Env.Env | FileSystem.FileSystem | NpmRegistry.NpmCli
 > =>
   Effect.gen(function* () {


### PR DESCRIPTION
Closes part of #259.

Phase: Items 1 and 2, first persistence slice.

What changed:
- Adds a release-local typed persistence kernel for JSON and JSONL files.
- Routes artifact manifests, proofs, locks, and journal entries through that kernel.
- Maps persisted-state filesystem/schema failures to `Resource.ResourceError` instead of leaking repeated `PlatformError | SchemaError` unions.
- Keeps persisted release paths typed as `Fs.Path.AbsFile` at the call sites.

Red test captured:
- `bun run --cwd packages/release test src/api/persistence.test.ts` initially failed before implementation because `./persistence.js` did not exist.

Verification:
- `bun run --cwd packages/release test src/api/persistence.test.ts src/api/lock.test.ts src/api/journal.test.ts src/api/proof.test.ts src/api/artifact.test.ts`
- `bun run fix:format && bun run release:verify`

Notes:
- This intentionally leaves the existing raw lock `Error` and direct time seams for the later Item 8 slice.
