### PR TITLE
refactor(release): keep artifact staging paths typed

### DIFF
--- a/packages/release/src/api/artifact.test.ts
+++ b/packages/release/src/api/artifact.test.ts
@@ -176,6 +176,13 @@ const rehearseCorePackage = ({
   })
 
 describe('artifact manifest', () => {
+  const artifactCopyHelperSource = () => {
+    const source = readFileSync(new URL('./executor/publish.ts', import.meta.url), 'utf8')
+    const start = source.indexOf('const copyPackageDirectory =')
+    const end = source.indexOf('\nconst workspaceVersionsFor', start)
+    return source.slice(start, end)
+  }
+
   test('records actual tarball bytes, packlist, and npm metadata from prepared artifacts', async () => {
     const manifests = await Effect.runPromise(
       makeManifestFromPrepared(plan, [artifact]).pipe(
@@ -355,6 +362,15 @@ describe('artifact manifest', () => {
     } finally {
       rmSync(rootDir, { recursive: true, force: true })
     }
+  })
+
+  test('artifact staging copy stays on the typed filesystem facade', () => {
+    const source = artifactCopyHelperSource()
+
+    expect(source).toContain('Fs.read(')
+    expect(source).toContain('Fs.write(')
+    expect(source).not.toContain('yield* FileSystem.FileSystem')
+    expect(source).not.toMatch(/\bfs\./u)
   })
 
   test('rehearsal rejects malformed source manifests before pack', async () => {

--- a/packages/release/src/api/executor/publish.ts
+++ b/packages/release/src/api/executor/publish.ts
@@ -134,36 +134,29 @@ const stagedPackageDirFor = (repoRoot: Fs.Path.AbsDir, release: ReleaseInfo): Fs
     ),
   )
 
+const childDir = (parent: Fs.Path.AbsDir, name: string): Fs.Path.AbsDir =>
+  Fs.Path.join(parent, Fs.Path.RelDir.fromString(`./${name}/`))
+
+const childFile = (parent: Fs.Path.AbsDir, name: string): Fs.Path.AbsFile =>
+  Fs.Path.join(parent, Fs.Path.RelFile.fromString(`./${name}`))
+
 const copyPackageDirectory = (
   from: Fs.Path.AbsDir,
   to: Fs.Path.AbsDir,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const fromString = Fs.Path.toString(from)
-    const toString = Fs.Path.toString(to)
+    yield* Fs.write(to, { recursive: true })
 
-    yield* fs.makeDirectory(toString, { recursive: true })
-    const entries = yield* fs.readDirectory(fromString)
+    for (const source of yield* Fs.read(from)) {
+      if (stagingIgnore.includes(source.name)) continue
 
-    for (const entry of entries) {
-      if (stagingIgnore.includes(entry)) continue
-
-      const source = `${fromString}${entry}`
-      const target = `${toString}${entry}`
-      const stat = yield* fs.stat(source)
-
-      if (stat.type === 'Directory') {
-        yield* copyPackageDirectory(
-          Fs.Path.AbsDir.fromString(`${source}/`),
-          Fs.Path.AbsDir.fromString(`${target}/`),
-        )
+      if (Fs.Path.AbsDir.is(source)) {
+        yield* copyPackageDirectory(source, childDir(to, source.name))
         continue
       }
 
-      if (stat.type === 'File') {
-        const bytes = yield* fs.readFile(source)
-        yield* fs.writeFile(target, bytes)
+      if (Fs.Path.AbsFile.is(source)) {
+        yield* Fs.write(childFile(to, source.name), yield* Fs.read(source))
       }
     }
   })
@@ -243,13 +236,11 @@ export const preparePackageArtifact = (
   Effect.gen(function* () {
     const cli = yield* NpmRegistry.NpmCli
     const env = yield* Env.Env
-    const fs = yield* FileSystem.FileSystem
     const packageJsonPath = Fs.Path.join(
       release.package.path,
       Fs.Path.RelFile.fromString('./package.json'),
     )
     const rootPackageJsonPath = Fs.Path.join(env.cwd, Fs.Path.RelFile.fromString('./package.json'))
-    const packageJsonPathString = Fs.Path.toString(packageJsonPath)
     const artifactDir = artifactDirectoryFor(env.cwd, options)
     const artifactPath = artifactPathFor(env.cwd, release, options)
     const stagedPackageDir = stagedPackageDirFor(env.cwd, release)
@@ -258,9 +249,9 @@ export const preparePackageArtifact = (
       Fs.Path.RelFile.fromString('./package.json'),
     )
 
-    const originalJson = yield* fs.readFileString(packageJsonPathString)
+    const originalJson = yield* Fs.readString(packageJsonPath)
     const originalManifest = yield* decodeJsonRecordOrFail(release.package.path, originalJson)
-    const catalogVersions = yield* fs.readFileString(Fs.Path.toString(rootPackageJsonPath)).pipe(
+    const catalogVersions = yield* Fs.readString(rootPackageJsonPath).pipe(
       Effect.flatMap((rootJson) => decodeJsonRecordOrFail(env.cwd, rootJson)),
       Effect.map(catalogVersionsFrom),
       Effect.orElseSucceed(() => ({})),
@@ -284,16 +275,11 @@ export const preparePackageArtifact = (
       )
     }
 
-    yield* fs
-      .remove(Fs.Path.toString(stagedPackageDir), { recursive: true, force: true })
-      .pipe(Effect.ignore)
+    yield* Fs.remove(stagedPackageDir, { recursive: true, force: true }).pipe(Effect.ignore)
     yield* copyPackageDirectory(release.package.path, stagedPackageDir)
-    yield* fs.writeFileString(
-      Fs.Path.toString(stagedPackageJsonPath),
-      JSON.stringify(rewrittenManifest, null, 2) + '\n',
-    )
-    yield* fs.makeDirectory(Fs.Path.toString(artifactDir), { recursive: true })
-    yield* fs.remove(Fs.Path.toString(artifactPath), { force: true }).pipe(Effect.ignore)
+    yield* Fs.write(stagedPackageJsonPath, JSON.stringify(rewrittenManifest, null, 2) + '\n')
+    yield* Fs.write(artifactDir, { recursive: true })
+    yield* Fs.remove(artifactPath, { force: true }).pipe(Effect.ignore)
 
     const packResult = yield* cli
       .pack({
@@ -321,7 +307,7 @@ export const preparePackageArtifact = (
     }
 
     if (Fs.Path.toString(packResult.success.tarball) !== Fs.Path.toString(artifactPath)) {
-      yield* fs.rename(Fs.Path.toString(packResult.success.tarball), Fs.Path.toString(artifactPath))
+      yield* Fs.rename(packResult.success.tarball, artifactPath)
     }
 
     return {


### PR DESCRIPTION
Continues #259.

Phase: Item 2, path-boundary slice.

What changed:
- Replaces artifact staging's manual absolute path recomposition with typed `@kitz/fs` path operations.
- Copies staged package directories through `Fs.read`, `Fs.write`, `Fs.remove`, and `Fs.rename` instead of direct `FileSystem` string calls in the staging path.
- Keeps child entry names converted at the `RelFile`/`RelDir` constructor boundary and joined under typed `AbsDir` parents.

Red test captured:
- `bun run --cwd packages/release test src/api/artifact.test.ts` failed while the artifact copy helper still reached for `yield* FileSystem.FileSystem` and `fs.*` service calls instead of staying on the typed `Fs` facade.

Verification:
- `bun run --cwd packages/release test src/api/artifact.test.ts`
- `bun run --cwd packages/release check:types && bun run --cwd packages/release check:lint`
- `bun run fix:format && bun run release:verify`

Notes:
- This intentionally does not try to eliminate every raw `FileSystem` requirement from release in one pass; it removes the concrete unsafe staging path seam called out in #259 while staying reviewable.
