### PR TITLE
fix(release): require frozen command plans

### DIFF
--- a/packages/release/src/cli/commands/apply.ts
+++ b/packages/release/src/cli/commands/apply.ts
@@ -17,13 +17,7 @@ import { Console, Effect, Fiber, Layer, Option, Stream, Terminal } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer, TerminalLayer } from '../../platform.js'
-import {
-  formatInvalidPlanMessage,
-  formatMissingPlanMessage,
-  formatUnsupportedExecutionPlanMessage,
-  hasExecutablePlanContract,
-  loadPlan,
-} from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 const confirm = (message: string) =>
   Effect.gen(function* () {
@@ -80,34 +74,8 @@ export const apply = Command.make(
         return env.exit(1)
       }
 
-      const planPath = Option.isSome(from) ? Fs.Path.fromString(from.value) : undefined
-      const planState = yield* loadPlan({
-        ...(planPath !== undefined ? { path: planPath } : {}),
-        source: planPath === undefined ? 'active' : 'custom',
-      })
-
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      // Plan file now stores rich PlannedRelease data directly - no conversion needed
-      const plan = planState.plan
-      if (!hasExecutablePlanContract(plan)) {
-        for (const line of formatUnsupportedExecutionPlanMessage(plan)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
+      const executablePlan = yield* loadExecutableCommandPlan(from)
+      const plan = executablePlan.plan
 
       // Single intent resolver: resolves the frozen publish intent and enforces
       // the prerelease-to-`latest` guard before any mutation.
@@ -119,7 +87,7 @@ export const apply = Command.make(
         return env.exit(1)
       }
       const publish = Api.Publishing.publishSemanticsFromIntent(intentResult.success)
-      const planDigest = Api.Proof.digestForPlan(plan)
+      const planDigest = executablePlan.planDigest
 
       const lockParams = {
         planDigest,
@@ -304,7 +272,7 @@ export const apply = Command.make(
           // active pointer (instead of deleting the only copy of the plan).
           const archiveFile = yield* Api.Planner.Store.archive(plan, planDigest)
           yield* Console.log(`Plan archived to ${Fs.Path.toString(archiveFile)}`)
-          if (planPath === undefined) {
+          if (executablePlan.source === 'active') {
             yield* Api.Planner.Store.deleteActive
           }
 

--- a/packages/release/src/cli/commands/archive.ts
+++ b/packages/release/src/cli/commands/archive.ts
@@ -10,7 +10,7 @@ import { Console, Effect, FileSystem, Layer, Option, Schema } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { FileSystemLayer } from '../../platform.js'
-import { formatInvalidPlanMessage, formatMissingPlanMessage, loadPlan } from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 const archiveExport = Command.make(
   'export',
@@ -25,26 +25,9 @@ const archiveExport = Command.make(
     Effect.gen(function* () {
       const env = yield* Env.Env
       const fs = yield* FileSystem.FileSystem
-
-      const planPath = Option.isSome(from) ? Fs.Path.fromString(from.value) : undefined
-      const planState = yield* loadPlan({
-        ...(planPath !== undefined ? { path: planPath } : {}),
-        source: planPath === undefined ? 'active' : 'custom',
-      })
-
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      const proof = yield* Api.Proof.readForPlan(planState.plan)
-      const artifacts = yield* Api.Artifact.readManifest(planState.plan)
-      const digest = Api.Proof.digestForPlan(planState.plan)
+      const { plan, planDigest: digest } = yield* loadExecutableCommandPlan(from)
+      const proof = yield* Api.Proof.readForPlan(plan)
+      const artifacts = yield* Api.Artifact.readManifest(plan)
       const journalEntries = yield* Api.Journal.readEntries(
         Api.Journal.journalPathFor(env.cwd, digest),
       )
@@ -58,7 +41,7 @@ const archiveExport = Command.make(
         payloads: [
           {
             path: Fs.Path.RelFile.fromString('./plan.json'),
-            content: `${JSON.stringify(Schema.encodeSync(Api.Planner.Plan)(planState.plan), null, 2)}\n`,
+            content: `${JSON.stringify(Schema.encodeSync(Api.Planner.Plan)(plan), null, 2)}\n`,
           },
           {
             path: Fs.Path.RelFile.fromString('./proof.json'),

--- a/packages/release/src/cli/commands/graph.ts
+++ b/packages/release/src/cli/commands/graph.ts
@@ -4,19 +4,11 @@
  * Render the release execution DAG for the active release plan.
  */
 import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
 import { Console, Effect, Layer, Option } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { FileSystemLayer } from '../../platform.js'
-import {
-  formatInvalidPlanMessage,
-  formatMissingPlanMessage,
-  formatUnsupportedExecutionPlanMessage,
-  hasExecutablePlanContract,
-  loadActivePlan,
-  loadPlan,
-} from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 export const graph = Command.make(
   'graph',
@@ -39,39 +31,13 @@ export const graph = Command.make(
   ({ format, tag, from }) =>
     Effect.gen(function* () {
       const env = yield* Env.Env
-      const planState = yield* Option.isSome(from)
-        ? loadPlan({
-            path: Fs.Path.fromString(from.value),
-            source: 'custom',
-          })
-        : loadActivePlan()
-
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      const plan = planState.plan
       if (Option.isSome(tag)) {
         yield* Console.error(
           'Graph uses the frozen plan dist-tag; --tag cannot alter workflow identity.',
         )
         return env.exit(1)
       }
-      if (!hasExecutablePlanContract(plan)) {
-        for (const line of formatUnsupportedExecutionPlanMessage(plan)) yield* Console.error(line)
-        return env.exit(1)
-      }
-      const publishing = Api.Publishing.publishingFromIntent(plan.publishIntent)
+      const { plan, publishing } = yield* loadExecutableCommandPlan(from)
 
       const workflowGraph = yield* Api.Executor.graph(plan, {
         dryRun: false,

--- a/packages/release/src/cli/commands/plan-contract.test.ts
+++ b/packages/release/src/cli/commands/plan-contract.test.ts
@@ -1,0 +1,58 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, test } from 'bun:test'
+import * as Api from '../../api/__.js'
+
+const cliPath = path.resolve(import.meta.dir, '../cli.ts')
+const stalePlan = `${JSON.stringify(Api.Planner.Plan.encodeSync(Api.Planner.Plan.empty), null, 2)}\n`
+const unsupportedContractMessage = 'This release plan is missing the frozen v2 execution contract.'
+
+const withStalePlan = (run: (rootDir: string) => void): void => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), 'kitz-release-plan-contract-'))
+  try {
+    mkdirSync(path.join(rootDir, '.release'), { recursive: true })
+    writeFileSync(path.join(rootDir, '.release', 'stale-plan.json'), stalePlan)
+    run(rootDir)
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true })
+  }
+}
+
+const runRelease = (rootDir: string, args: readonly string[]) =>
+  spawnSync('bun', [cliPath, ...args], { cwd: rootDir, encoding: 'utf8' })
+
+const planBoundCommands = [
+  'apply --yes',
+  'resume --yes',
+  'status',
+  'graph',
+  'prove',
+  'rehearse',
+  'reconcile',
+  'repair',
+  'archive export',
+]
+
+describe('release plan execution contract', () => {
+  test('plan-bound commands reject stale plans while preview can inspect them', () => {
+    withStalePlan((rootDir) => {
+      for (const command of planBoundCommands) {
+        const args = [...command.split(' '), '--from', './.release/stale-plan.json']
+        const result = runRelease(rootDir, args)
+
+        expect(result.status).toBe(1)
+        expect(`${result.stdout}\n${result.stderr}`).toContain(unsupportedContractMessage)
+        if (command === 'prove') {
+          expect(existsSync(path.join(rootDir, '.release', 'proofs'))).toBe(false)
+        }
+      }
+      const result = runRelease(rootDir, ['preview', '--from', './.release/stale-plan.json'])
+
+      expect(result.status).toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain(unsupportedContractMessage)
+      expect(`${result.stdout}\n${result.stderr}`).toContain('No releases planned.')
+    })
+  }, 15_000)
+})

--- a/packages/release/src/cli/commands/plan-file.test.ts
+++ b/packages/release/src/cli/commands/plan-file.test.ts
@@ -1,6 +1,6 @@
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
-import { Effect, Layer, Option } from 'effect'
+import { Effect, FileSystem, Layer, Option } from 'effect'
 import { describe, expect, test } from 'bun:test'
 import {
   formatIgnoredInvalidPlanMessage,
@@ -14,98 +14,64 @@ import {
 } from './plan-file.js'
 import * as Api from '../../api/__.js'
 
+const cwd = Fs.Path.AbsDir.fromString('/repo/')
+const run = <A>(
+  effect: Effect.Effect<A, never, Env.Env | FileSystem.FileSystem>,
+  files: Record<string, string> = {},
+) =>
+  Effect.runPromise(
+    effect.pipe(Effect.provide(Layer.mergeAll(Fs.Memory.layer(files), Env.Test({ cwd })))),
+  )
+
 describe('plan-file helpers', () => {
-  test('loads a missing active plan as PlanMissing', async () => {
-    const result = await Effect.runPromise(
-      loadActivePlan().pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Fs.Memory.layer({}),
-            Env.Test({ cwd: Fs.Path.AbsDir.fromString('/repo/') }),
-          ),
-        ),
-      ),
-    )
-
-    expect(result._tag).toBe('PlanMissing')
-    if (result._tag !== 'PlanMissing') {
-      throw new Error('expected missing plan')
-    }
-
-    expect(formatMissingPlanMessage(result)).toEqual([
+  test('formats plan states and follow-up commands', async () => {
+    const missing = await run(loadActivePlan())
+    if (missing._tag !== 'PlanMissing') throw new Error('expected missing plan')
+    expect(formatMissingPlanMessage(missing)).toEqual([
       'Active release plan not found at /repo/.release/plan.json.',
       "Run 'release plan --lifecycle <official|candidate|ephemeral>' first to generate a plan.",
     ])
-  })
 
-  test('formats invalid active plans with regeneration and ignore guidance', async () => {
-    const result = await Effect.runPromise(
-      loadActivePlan().pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Fs.Memory.layer({
-              '/repo/.release/plan.json': '{"broken":true}',
-            }),
-            Env.Test({ cwd: Fs.Path.AbsDir.fromString('/repo/') }),
-          ),
-        ),
-      ),
+    const invalid = await run(loadActivePlan(), { '/repo/.release/plan.json': '{"broken":true}' })
+    if (invalid._tag !== 'PlanInvalid') throw new Error('expected invalid plan')
+    expect(formatInvalidPlanMessage(invalid).join('\n')).toContain(
+      'stale, malformed, or written by an older @kitz/release schema',
+    )
+    expect(formatIgnoredInvalidPlanMessage(invalid).join('\n')).toContain(
+      'Ignoring the invalid active plan',
     )
 
-    expect(result._tag).toBe('PlanInvalid')
-    if (result._tag !== 'PlanInvalid') {
-      throw new Error('expected invalid plan')
-    }
-
-    const message = formatInvalidPlanMessage(result).join('\n')
-    expect(message).toContain('Active release plan at /repo/.release/plan.json is unreadable.')
-    expect(message).toContain('stale, malformed, or written by an older @kitz/release schema')
-    expect(message).toContain("Run 'release plan --lifecycle <official|candidate|ephemeral>'")
-    expect(message).toContain('delete /repo/.release/plan.json')
-
-    const ignored = formatIgnoredInvalidPlanMessage(result).join('\n')
-    expect(ignored).toContain('Ignoring the invalid active plan')
-  })
-
-  test('formats missing custom plans with an --out regeneration hint', async () => {
-    const result = await Effect.runPromise(
-      loadPlan({
-        path: Fs.Path.fromString('./tmp/release-plan.json'),
-        source: 'custom',
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Fs.Memory.layer({}),
-            Env.Test({ cwd: Fs.Path.AbsDir.fromString('/repo/') }),
-          ),
-        ),
-      ),
+    const customMissing = await run(
+      loadPlan({ path: Fs.Path.fromString('./tmp/release-plan.json'), source: 'custom' }),
+    )
+    if (customMissing._tag !== 'PlanMissing') throw new Error('expected missing custom plan')
+    expect(formatMissingPlanMessage(customMissing).join('\n')).toContain(
+      '--out /repo/tmp/release-plan.json',
     )
 
-    expect(result._tag).toBe('PlanMissing')
-    if (result._tag !== 'PlanMissing') {
-      throw new Error('expected missing custom plan')
-    }
-
-    const message = formatMissingPlanMessage(result).join('\n')
-    expect(message).toContain('/repo/tmp/release-plan.json')
-    expect(message).toContain('--out /repo/tmp/release-plan.json')
-  })
-
-  test('formats unsupported execution plans with the missing frozen contract fields', () => {
     const plan = Api.Planner.Plan.empty
-
     expect(hasExecutablePlanContract(plan)).toBe(false)
     expect(formatUnsupportedExecutionPlanMessage(plan)).toEqual([
       'This release plan is missing the frozen v2 execution contract.',
       'Missing field(s): planDigest, publishIntent.',
       'Run `release plan --lifecycle <official|candidate|ephemeral>` again with the current @kitz/release before executing, resuming, graphing, or checking durable status.',
     ])
-  })
+    expect(
+      formatUnsupportedExecutionPlanMessage(
+        Api.Planner.Plan.make({
+          lifecycle: 'official',
+          timestamp: '',
+          releases: [],
+          cascades: [],
+          planDigest: Api.ReleaseContract.PlanDigest.make({
+            algorithm: 'sha256',
+            value: 'a'.repeat(64),
+          }),
+        }),
+      )[1],
+    ).toBe('Missing field(s): publishIntent.')
 
-  test('formats plan follow-up commands with shell-safe custom paths', () => {
     const custom = Option.some('./tmp/release plan.json')
-
     expect(formatPlanCommand('release apply', Option.none())).toBe('release apply')
     expect(formatPlanCommand('release apply', custom)).toBe(
       "release apply --from './tmp/release plan.json'",

--- a/packages/release/src/cli/commands/plan-file.ts
+++ b/packages/release/src/cli/commands/plan-file.ts
@@ -1,8 +1,7 @@
-import { FileSystem } from 'effect'
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
 import { Resource } from '@kitz/resource'
-import { Effect, Option } from 'effect'
+import { Console, Effect, FileSystem, Option } from 'effect'
 import * as Api from '../../api/__.js'
 
 type PlanSource = 'active' | 'custom'
@@ -32,6 +31,18 @@ export interface PlanInvalidState extends BasePlanState {
 }
 
 export type PlanState = PlanLoadedState | PlanMissingState | PlanInvalidState
+
+export type ExecutablePlan = Api.Planner.Plan & {
+  readonly planDigest: Api.ReleaseContract.PlanDigest
+  readonly publishIntent: Api.ReleaseContract.PublishIntent
+}
+
+export interface ExecutableCommandPlan extends Omit<PlanLoadedState, 'plan'> {
+  readonly plan: ExecutablePlan
+  readonly planDigest: Api.ReleaseContract.PlanDigest
+  readonly publishIntent: Api.ReleaseContract.PublishIntent
+  readonly publishing: Api.Publishing.Publishing
+}
 
 const renderPlanLabel = (source: PlanSource): string =>
   source === 'active' ? 'Active release plan' : 'Release plan'
@@ -89,6 +100,59 @@ export const loadActivePlan = (): Effect.Effect<
   never,
   Env.Env | FileSystem.FileSystem
 > => loadPlan({ source: 'active' })
+
+const planLookupFromFlag = (from: Option.Option<string>): PlanLookupContext =>
+  Option.isSome(from)
+    ? {
+        path: Fs.Path.fromString(from.value),
+        source: 'custom',
+      }
+    : { source: 'active' }
+
+const writeErrorLines = (lines: readonly string[]): Effect.Effect<void> =>
+  Effect.forEach(lines, (line) => Console.error(line), { discard: true })
+
+const exitWithPlanMessage = (lines: readonly string[]): Effect.Effect<never, never, Env.Env> =>
+  Effect.gen(function* () {
+    const env = yield* Env.Env
+    yield* writeErrorLines(lines)
+    return env.exit(1)
+  })
+
+export const loadCommandPlan = (
+  from: Option.Option<string>,
+): Effect.Effect<PlanLoadedState, never, Env.Env | FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const state = yield* loadPlan(planLookupFromFlag(from))
+
+    switch (state._tag) {
+      case 'PlanLoaded':
+        return state
+      case 'PlanMissing':
+        return yield* exitWithPlanMessage(formatMissingPlanMessage(state))
+      case 'PlanInvalid':
+        return yield* exitWithPlanMessage(formatInvalidPlanMessage(state))
+    }
+  })
+
+export const loadExecutableCommandPlan = (
+  from: Option.Option<string>,
+): Effect.Effect<ExecutableCommandPlan, never, Env.Env | FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const loaded = yield* loadCommandPlan(from)
+
+    if (!hasExecutablePlanContract(loaded.plan)) {
+      return yield* exitWithPlanMessage(formatUnsupportedExecutionPlanMessage(loaded.plan))
+    }
+
+    return {
+      ...loaded,
+      plan: loaded.plan,
+      planDigest: loaded.plan.planDigest,
+      publishIntent: loaded.plan.publishIntent,
+      publishing: Api.Publishing.publishingFromIntent(loaded.plan.publishIntent),
+    } satisfies ExecutableCommandPlan
+  })
 
 export const formatMissingPlanMessage = (state: PlanMissingState): readonly string[] => [
   `${renderPlanLabel(state.source)} not found at ${renderPlanPath(state.location)}.`,

--- a/packages/release/src/cli/commands/prove.ts
+++ b/packages/release/src/cli/commands/prove.ts
@@ -3,11 +3,11 @@ import { Fs } from '@kitz/fs'
 import { Git } from '@kitz/git'
 import { Github } from '@kitz/github'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Layer, Option } from 'effect'
+import { Console, Effect, Layer } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer } from '../../platform.js'
-import { formatInvalidPlanMessage, formatMissingPlanMessage, loadPlan } from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 const npmLayer = NpmRegistry.NpmCliLive.pipe(Layer.provide(ChildProcessSpawnerLayer))
 
@@ -23,26 +23,12 @@ export const prove = Command.make(
   ({ from }) =>
     Effect.gen(function* () {
       const env = yield* Env.Env
-      const planPath = Option.isSome(from) ? Fs.Path.fromString(from.value) : undefined
-      const planState = yield* loadPlan({
-        ...(planPath !== undefined ? { path: planPath } : {}),
-        source: planPath === undefined ? 'active' : 'custom',
-      })
+      const { plan } = yield* loadExecutableCommandPlan(from)
 
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      const localObservations = yield* Api.Proof.collectLocalObservations(planState.plan)
+      const localObservations = yield* Api.Proof.collectLocalObservations(plan)
       const githubObservations = yield* Api.Explorer.resolveGitHubContext().pipe(
         Effect.flatMap((context) =>
-          Api.Proof.collectGithubObservations(planState.plan).pipe(
+          Api.Proof.collectGithubObservations(plan).pipe(
             Effect.provide(
               Github.LiveFetch({
                 owner: context.target.owner,
@@ -54,11 +40,11 @@ export const prove = Command.make(
         ),
         Effect.catch(() => Effect.succeed({})),
       )
-      const proof = yield* Api.Proof.prove(planState.plan, {
+      const proof = yield* Api.Proof.prove(plan, {
         ...localObservations,
         ...githubObservations,
       })
-      const proofPath = Api.Proof.proofPathFor(env.cwd, planState.plan)
+      const proofPath = Api.Proof.proofPathFor(env.cwd, plan)
       yield* Console.log(`Proof written to ${Fs.Path.toString(proofPath)}`)
       for (const record of proof.records) {
         yield* Console.log(`${record.status.padEnd(14)} ${record.id}`)

--- a/packages/release/src/cli/commands/reconcile.ts
+++ b/packages/release/src/cli/commands/reconcile.ts
@@ -1,11 +1,10 @@
 import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Layer, Option } from 'effect'
+import { Console, Effect, Layer } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer } from '../../platform.js'
-import { formatInvalidPlanMessage, formatMissingPlanMessage, loadPlan } from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 const npmLayer = NpmRegistry.NpmCliLive.pipe(Layer.provide(ChildProcessSpawnerLayer))
 
@@ -24,24 +23,9 @@ export const reconcile = Command.make(
   },
   ({ from, explain }) =>
     Effect.gen(function* () {
-      const env = yield* Env.Env
-      const planPath = Option.isSome(from) ? Fs.Path.fromString(from.value) : undefined
-      const planState = yield* loadPlan({
-        ...(planPath !== undefined ? { path: planPath } : {}),
-        source: planPath === undefined ? 'active' : 'custom',
-      })
+      const { plan } = yield* loadExecutableCommandPlan(from)
 
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      const decision = yield* Api.Reconciler.reconcile(planState.plan)
+      const decision = yield* Api.Reconciler.reconcile(plan)
       yield* Console.log(`Reconcile result: ${decision.classification}`)
       yield* Console.log(`Plan digest: ${decision.planDigest.value}`)
       if (explain) {

--- a/packages/release/src/cli/commands/rehearse.ts
+++ b/packages/release/src/cli/commands/rehearse.ts
@@ -1,11 +1,10 @@
 import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Layer, Option } from 'effect'
+import { Console, Effect, Layer } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer } from '../../platform.js'
-import { formatInvalidPlanMessage, formatMissingPlanMessage, loadPlan } from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 const npmLayer = NpmRegistry.NpmCliLive.pipe(Layer.provide(ChildProcessSpawnerLayer))
 
@@ -24,24 +23,9 @@ export const rehearse = Command.make(
   },
   ({ from, publishDryRun }) =>
     Effect.gen(function* () {
-      const env = yield* Env.Env
-      const planPath = Option.isSome(from) ? Fs.Path.fromString(from.value) : undefined
-      const planState = yield* loadPlan({
-        ...(planPath !== undefined ? { path: planPath } : {}),
-        source: planPath === undefined ? 'active' : 'custom',
-      })
+      const { plan } = yield* loadExecutableCommandPlan(from)
 
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      const manifests = yield* Api.Artifact.rehearse(planState.plan, { publishDryRun })
+      const manifests = yield* Api.Artifact.rehearse(plan, { publishDryRun })
       yield* Console.log(`Artifact manifest written for ${manifests.length} package(s).`)
     }),
 ).pipe(

--- a/packages/release/src/cli/commands/repair.ts
+++ b/packages/release/src/cli/commands/repair.ts
@@ -1,11 +1,10 @@
 import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Layer, Option } from 'effect'
+import { Console, Effect, Layer } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer } from '../../platform.js'
-import { formatInvalidPlanMessage, formatMissingPlanMessage, loadPlan } from './plan-file.js'
+import { loadExecutableCommandPlan } from './plan-file.js'
 
 const npmLayer = NpmRegistry.NpmCliLive.pipe(Layer.provide(ChildProcessSpawnerLayer))
 
@@ -24,24 +23,9 @@ export const repair = Command.make(
   },
   ({ from, yes }) =>
     Effect.gen(function* () {
-      const env = yield* Env.Env
-      const planPath = Option.isSome(from) ? Fs.Path.fromString(from.value) : undefined
-      const planState = yield* loadPlan({
-        ...(planPath !== undefined ? { path: planPath } : {}),
-        source: planPath === undefined ? 'active' : 'custom',
-      })
+      const { plan } = yield* loadExecutableCommandPlan(from)
 
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) yield* Console.error(line)
-        return env.exit(1)
-      }
-
-      const decision = yield* Api.Reconciler.reconcile(planState.plan)
+      const decision = yield* Api.Reconciler.reconcile(plan)
 
       yield* Console.log(`Repair classification: ${decision.classification}`)
       yield* Console.log(`Next command: ${decision.nextCommand}`)

--- a/packages/release/src/cli/commands/resume.ts
+++ b/packages/release/src/cli/commands/resume.ts
@@ -4,22 +4,13 @@
  * Resume an interrupted durable release workflow for the active release plan.
  */
 import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
 import { Git } from '@kitz/git'
 import { NpmRegistry } from '@kitz/npm-registry'
 import { Console, Effect, Fiber, Layer, Option, Stream, Terminal } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer, TerminalLayer } from '../../platform.js'
-import {
-  formatInvalidPlanMessage,
-  formatMissingPlanMessage,
-  formatPlanCommand,
-  formatUnsupportedExecutionPlanMessage,
-  hasExecutablePlanContract,
-  loadActivePlan,
-  loadPlan,
-} from './plan-file.js'
+import { formatPlanCommand, loadExecutableCommandPlan } from './plan-file.js'
 
 const confirm = (message: string) =>
   Effect.gen(function* () {
@@ -54,39 +45,13 @@ export const resume = Command.make(
   ({ yes, tag, from }) =>
     Effect.gen(function* () {
       const env = yield* Env.Env
-      const planState = yield* Option.isSome(from)
-        ? loadPlan({
-            path: Fs.Path.fromString(from.value),
-            source: 'custom',
-          })
-        : loadActivePlan()
-
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      const plan = planState.plan
       if (Option.isSome(tag)) {
         yield* Console.error(
           'Resume uses the frozen plan dist-tag; --tag cannot alter workflow identity.',
         )
         return env.exit(1)
       }
-      if (!hasExecutablePlanContract(plan)) {
-        for (const line of formatUnsupportedExecutionPlanMessage(plan)) yield* Console.error(line)
-        return env.exit(1)
-      }
-      const publishing = Api.Publishing.publishingFromIntent(plan.publishIntent)
+      const { plan, publishing } = yield* loadExecutableCommandPlan(from)
 
       const runtime = yield* Api.Explorer.explore()
       const runtimeConfig = Api.Explorer.toExecutorRuntimeConfig(runtime)

--- a/packages/release/src/cli/commands/status.ts
+++ b/packages/release/src/cli/commands/status.ts
@@ -7,20 +7,11 @@
  * `release apply`, and polls the durable workflow runtime for its current state.
  */
 import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
 import { Console, Effect, Layer, Option } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { FileSystemLayer } from '../../platform.js'
-import {
-  formatInvalidPlanMessage,
-  formatMissingPlanMessage,
-  formatPlanCommand,
-  formatUnsupportedExecutionPlanMessage,
-  hasExecutablePlanContract,
-  loadActivePlan,
-  loadPlan,
-} from './plan-file.js'
+import { formatPlanCommand, loadExecutableCommandPlan } from './plan-file.js'
 
 export const status = Command.make(
   'status',
@@ -43,39 +34,13 @@ export const status = Command.make(
   ({ format, tag, from }) =>
     Effect.gen(function* () {
       const env = yield* Env.Env
-      const planState = yield* Option.isSome(from)
-        ? loadPlan({
-            path: Fs.Path.fromString(from.value),
-            source: 'custom',
-          })
-        : loadActivePlan()
-
-      if (planState._tag === 'PlanMissing') {
-        for (const line of formatMissingPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      if (planState._tag === 'PlanInvalid') {
-        for (const line of formatInvalidPlanMessage(planState)) {
-          yield* Console.error(line)
-        }
-        return env.exit(1)
-      }
-
-      const plan = planState.plan
       if (Option.isSome(tag)) {
         yield* Console.error(
           'Status uses the frozen plan dist-tag; --tag cannot alter workflow identity.',
         )
         return env.exit(1)
       }
-      if (!hasExecutablePlanContract(plan)) {
-        for (const line of formatUnsupportedExecutionPlanMessage(plan)) yield* Console.error(line)
-        return env.exit(1)
-      }
-      const publishing = Api.Publishing.publishingFromIntent(plan.publishIntent)
+      const { plan, publishing } = yield* loadExecutableCommandPlan(from)
 
       const workflowStatus = yield* Api.Executor.status(plan, {
         tag: plan.publishIntent.distTag,


### PR DESCRIPTION
## Summary
- Add a shared command-plan loader for decoded and executable release plans.
- Route apply/resume/status/graph/prove/rehearse/reconcile/repair/archive through the executable loader.
- Keep preview as the loose decoded-plan inspector while stale plans are blocked before plan-bound side effects.

Closes part of #259, item 3.

## QA
- bun test packages/release/src/cli/commands/plan-file.test.ts packages/release/src/cli/commands/plan-contract.test.ts
- bun run --cwd packages/release check:types
- bun run --cwd packages/release check:lint
- bun run --cwd packages/release test

## Review
- Sub-agent review by Pasteur found the stale-plan CLI table initially missed apply/resume/status/graph; addressed by adding them to the regression table.
