### PR TITLE
refactor(release): share observable command execution

### DIFF
--- a/packages/release/src/cli/commands/apply.ts
+++ b/packages/release/src/cli/commands/apply.ts
@@ -13,20 +13,12 @@ import { Fs } from '@kitz/fs'
 import { Git } from '@kitz/git'
 import { Github } from '@kitz/github'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Fiber, Layer, Option, Stream, Terminal } from 'effect'
+import { Console, Effect, Layer, Option } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer, TerminalLayer } from '../../platform.js'
+import { confirm, runObservableCommand } from './execution.js'
 import { loadExecutableCommandPlan } from './plan-file.js'
-
-const confirm = (message: string) =>
-  Effect.gen(function* () {
-    const terminal = yield* Terminal.Terminal
-    yield* terminal.display(message)
-    const answer = yield* terminal.readLine.pipe(Effect.catch(() => Effect.succeed('')))
-    const normalized = answer.trim().toLowerCase()
-    return normalized === 'y' || normalized === 'yes'
-  })
 
 const commandLayer = ChildProcessSpawnerLayer
 const npmLayer = NpmRegistry.NpmCliLive.pipe(Layer.provide(commandLayer))
@@ -233,39 +225,17 @@ export const apply = Command.make(
             return false
           }
 
-          // Execute with observable workflow
-          const { events, execute } = yield* Api.Executor.executeObservable(plan, {
-            dryRun: false,
-            tag: publish.distTag,
-            rehearsedArtifacts: true,
-            ...(plan.publishIntent !== undefined
-              ? { registry: plan.publishIntent.registry.url }
-              : {}),
-            ...(plan.publishIntent !== undefined ? { trunk: plan.publishIntent.git.trunk } : {}),
-            github: runtimeConfig.github,
-          })
-
-          // Fork event consumer to stream status updates
-          const eventFiber = yield* events.pipe(
-            Stream.tap((event) => {
-              const line = Api.Executor.formatLifecycleEvent(event, { env: env.vars })
-              if (!line) return Effect.void
-              return line.level === 'error'
-                ? Console.error(line.message)
-                : Console.log(line.message)
+          const result = yield* runObservableCommand(
+            yield* Api.Executor.executeObservable(plan, {
+              dryRun: false,
+              tag: publish.distTag,
+              rehearsedArtifacts: true,
+              ...(plan.publishIntent !== undefined
+                ? { registry: plan.publishIntent.registry.url }
+                : {}),
+              ...(plan.publishIntent !== undefined ? { trunk: plan.publishIntent.git.trunk } : {}),
+              github: runtimeConfig.github,
             }),
-            Stream.runDrain,
-            Effect.forkChild,
-          )
-
-          // Run workflow
-          const result = yield* execute
-
-          // Wait for events to flush
-          yield* Fiber.join(eventFiber)
-
-          yield* Console.log(
-            Api.Renderer.renderApplyDone(result.releasedPackages.length, { env: env.vars }),
           )
 
           // Archive the executed plan immutably by digest, then clear the

--- a/packages/release/src/cli/commands/execution.test.ts
+++ b/packages/release/src/cli/commands/execution.test.ts
@@ -1,0 +1,106 @@
+import { Env } from '@kitz/env'
+import { Flo } from '@kitz/flo'
+import { Test } from '@kitz/test'
+import { Effect, Exit, Layer, Stream, Terminal } from 'effect'
+import { TestConsole } from 'effect/testing'
+import { describe, expect } from 'bun:test'
+import * as Api from '../../api/__.js'
+import { confirm, runObservableCommand } from './execution.js'
+
+describe('command execution helpers', () => {
+  const date = new Date('2026-01-01T00:00:00.000Z')
+  const executionResult = {
+    releasedPackages: ['@kitz/core'],
+    createdTags: [],
+    createdGHReleases: [],
+  }
+  const layer = Layer.mergeAll(Env.Test(), TestConsole.layer)
+  const activityStarted = Flo.Activity.Started.make({
+    activity: 'publish',
+    timestamp: date,
+    resumed: false,
+  })
+  const activityCompleted = Flo.Activity.Completed.make({
+    activity: 'publish',
+    timestamp: date,
+    resumed: false,
+    durationMs: 1,
+  })
+  const activityFailed = Flo.Activity.Failed.make({
+    activity: 'publish',
+    timestamp: date,
+    error: 'boom',
+  })
+  const terminalLayer = (input: Effect.Effect<string, Terminal.QuitError>) =>
+    Layer.succeed(Terminal.Terminal)(
+      Terminal.make({
+        columns: Effect.succeed(80),
+        rows: Effect.succeed(24),
+        readInput: Effect.never,
+        readLine: input,
+        display: () => Effect.void,
+      }),
+    )
+
+  Test.effect('streams lifecycle events before the shared completion summary', () =>
+    Effect.gen(function* () {
+      const execution = yield* runObservableCommand({
+        events: Stream.fromIterable([activityStarted, activityCompleted]),
+        execute: Effect.succeed(executionResult),
+      })
+      const logs = yield* TestConsole.logLines
+
+      expect(execution.releasedPackages).toEqual(['@kitz/core'])
+      expect(logs.slice(0, 2)).toEqual(['  › Starting: publish', '✓ Completed: publish'])
+      expect(logs[2]).toContain('[DONE] 1 package released.')
+    }).pipe(Effect.provide(layer)),
+  )
+
+  Test.effect('routes failed lifecycle events to stderr', () =>
+    Effect.gen(function* () {
+      yield* runObservableCommand({
+        events: Stream.fromIterable([activityStarted, activityFailed]),
+        execute: Effect.succeed(executionResult),
+      })
+      const logs = yield* TestConsole.logLines
+      const errors = yield* TestConsole.errorLines
+
+      expect(logs[0]).toBe('  › Starting: publish')
+      expect(logs[1]).toContain('[DONE] 1 package released.')
+      expect(errors).toEqual(['✗ Failed: publish - boom'])
+    }).pipe(Effect.provide(layer)),
+  )
+
+  Test.effect('does not render completion summary when execute fails', () =>
+    Effect.gen(function* () {
+      const failure = new Api.Executor.Errors.ExecutorPreflightError({
+        context: { check: 'env.npm-authenticated', detail: 'missing token' },
+      })
+      const exit = yield* Effect.exit(
+        runObservableCommand({
+          events: Stream.fromIterable([activityStarted]),
+          execute: Effect.fail(failure),
+        }),
+      )
+      const logs = yield* TestConsole.logLines
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(logs.join('\n')).not.toContain('[DONE]')
+    }).pipe(Effect.provide(layer)),
+  )
+
+  Test.effect('confirms only yes-like answers and treats input failure as no', () =>
+    Effect.gen(function* () {
+      const results = yield* Effect.all([
+        confirm('Continue?').pipe(Effect.provide(terminalLayer(Effect.succeed('y')))),
+        confirm('Continue?').pipe(Effect.provide(terminalLayer(Effect.succeed(' YES ')))),
+        confirm('Continue?').pipe(Effect.provide(terminalLayer(Effect.succeed('no')))),
+        confirm('Continue?').pipe(
+          Effect.provide(terminalLayer(Effect.fail(new Terminal.QuitError()))),
+        ),
+      ])
+
+      expect(results).toEqual([true, true, false, false])
+    }),
+  )
+})

--- a/packages/release/src/cli/commands/execution.ts
+++ b/packages/release/src/cli/commands/execution.ts
@@ -1,0 +1,39 @@
+import { Env } from '@kitz/env'
+import { Console, Effect, Fiber, Stream, Terminal } from 'effect'
+import * as Api from '../../api/__.js'
+
+export const confirm = (message: string) =>
+  Effect.gen(function* () {
+    const terminal = yield* Terminal.Terminal
+    yield* terminal.display(message)
+    const answer = yield* terminal.readLine.pipe(Effect.catch(() => Effect.succeed('')))
+    const normalized = answer.trim().toLowerCase()
+    return normalized === 'y' || normalized === 'yes'
+  })
+
+export const runObservableCommand = <R>(
+  observable: Pick<Api.Executor.ObservableResult<R>, 'events' | 'execute'>,
+): Effect.Effect<
+  Api.Executor.ExecutionResult,
+  Api.Executor.ObservableExecutionError,
+  Env.Env | R
+> =>
+  Effect.gen(function* () {
+    const env = yield* Env.Env
+    const eventFiber = yield* observable.events.pipe(
+      Stream.tap((event) => {
+        const line = Api.Executor.formatLifecycleEvent(event, { env: env.vars })
+        if (!line) return Effect.void
+        return line.level === 'error' ? Console.error(line.message) : Console.log(line.message)
+      }),
+      Stream.runDrain,
+      Effect.forkChild,
+    )
+
+    const result = yield* observable.execute
+    yield* Fiber.join(eventFiber)
+    yield* Console.log(
+      Api.Renderer.renderApplyDone(result.releasedPackages.length, { env: env.vars }),
+    )
+    return result
+  })

--- a/packages/release/src/cli/commands/resume.ts
+++ b/packages/release/src/cli/commands/resume.ts
@@ -6,20 +6,12 @@
 import { Env } from '@kitz/env'
 import { Git } from '@kitz/git'
 import { NpmRegistry } from '@kitz/npm-registry'
-import { Console, Effect, Fiber, Layer, Option, Stream, Terminal } from 'effect'
+import { Console, Effect, Layer, Option } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import * as Api from '../../api/__.js'
 import { ChildProcessSpawnerLayer, FileSystemLayer, TerminalLayer } from '../../platform.js'
+import { confirm, runObservableCommand } from './execution.js'
 import { formatPlanCommand, loadExecutableCommandPlan } from './plan-file.js'
-
-const confirm = (message: string) =>
-  Effect.gen(function* () {
-    const terminal = yield* Terminal.Terminal
-    yield* terminal.display(message)
-    const answer = yield* terminal.readLine.pipe(Effect.catch(() => Effect.succeed('')))
-    const normalized = answer.trim().toLowerCase()
-    return normalized === 'y' || normalized === 'yes'
-  })
 
 const commandLayer = ChildProcessSpawnerLayer
 const npmLayer = NpmRegistry.NpmCliLive.pipe(Layer.provide(commandLayer))
@@ -95,23 +87,7 @@ export const resume = Command.make(
         }
       }
 
-      const eventFiber = yield* events.pipe(
-        Stream.tap((event) => {
-          const line = Api.Executor.formatLifecycleEvent(event, { env: env.vars })
-          if (!line) return Effect.void
-          return line.level === 'error' ? Console.error(line.message) : Console.log(line.message)
-        }),
-        Stream.runDrain,
-        Effect.forkChild,
-      )
-
-      const result = yield* execute
-
-      yield* Fiber.join(eventFiber)
-
-      yield* Console.log(
-        Api.Renderer.renderApplyDone(result.releasedPackages.length, { env: env.vars }),
-      )
+      yield* runObservableCommand({ events, execute })
 
       yield* Api.Planner.Store.deleteActive
     }),


### PR DESCRIPTION
Refs #259

## Summary
- Extract shared release command helpers for apply/resume confirmation and observable execution.
- Route lifecycle event logging, stderr handling, execution, event flushing, and done summary rendering through one Effect helper.
- Add compact Effect-backed tests for lifecycle ordering, failed-event stderr output, execute-failure behavior, and confirm fallback handling.

## Verification
- bun run --cwd packages/release check:types
- GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-3 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-3 bun run --cwd packages/release check:lint
- GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-3 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-3 bun run --cwd packages/release test

## Review
- Fermat sub-agent reviewed the initial diff for FP, Effect correctness, type safety, simplicity, and code compactness.
- Fermat requested stronger helper tests; those were added and re-reviewed with no material findings.