### PR TITLE
refactor(release): split workflow activities

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on:
   pull_request: {}
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@kitz/otel": "workspace:*",
     "@kitz/test": "workspace:*",
+    "@kitz/yaml": "workspace:*",
     "@types/react": "^19.2.16"
   }
 }

--- a/packages/release/src/api/executor/registry-verification.ts
+++ b/packages/release/src/api/executor/registry-verification.ts
@@ -1,0 +1,114 @@
+import { Env } from '@kitz/env'
+import { Fs } from '@kitz/fs'
+import { NpmRegistry } from '@kitz/npm-registry'
+import { Pkg } from '@kitz/pkg'
+import { Semver } from '@kitz/semver'
+import { Clock, Effect } from 'effect'
+import { Digest, sha256Bytes } from '../digest.js'
+import type { PublishDriverId } from '../publishing/models/driver-id.js'
+import {
+  verifyRegistryObservation,
+  type PublishVerificationResult,
+} from '../publishing/verification.js'
+import {
+  ArtifactManifest,
+  PlanDigest,
+  PublishReceipt,
+  RegistryObservation,
+} from '../release-contract.js'
+import { artifactPathFor, type ReleaseInfo } from './publish.js'
+
+export interface RegistryPublicationRequest {
+  readonly packageName: string
+  readonly nextVersion: string
+  readonly releaseInfo: ReleaseInfo
+  readonly planDigest?: string
+  readonly packDriver: PublishDriverId
+  readonly registry?: string
+  readonly distTag: string
+  readonly official: boolean
+}
+
+export interface RegistryPublicationVerification extends PublishVerificationResult {
+  readonly artifact: ArtifactManifest
+  readonly observation: RegistryObservation
+}
+
+const isoStringFromEpochMillis = (epochMillis: number): string =>
+  new Date(epochMillis).toISOString()
+
+export const verifyRegistryPublication = (request: RegistryPublicationRequest) =>
+  Effect.gen(function* () {
+    const env = yield* Env.Env
+    const cli = yield* NpmRegistry.NpmCli
+    const tarball = artifactPathFor(
+      env.cwd,
+      request.releaseInfo,
+      request.planDigest === undefined ? undefined : { planDigest: request.planDigest },
+    )
+    const tarballBytes = yield* Fs.read(tarball)
+    const tarballSha256 = sha256Bytes(tarballBytes)
+    const observed = yield* cli.observeVersion(request.packageName, request.nextVersion, {
+      ...(request.registry !== undefined ? { registry: request.registry } : {}),
+      downloadTarball: request.official,
+    })
+    const planDigest = PlanDigest.make({
+      algorithm: 'sha256',
+      value: request.planDigest ?? 'unknown',
+    })
+    const observation = RegistryObservation.make({
+      packageName: Pkg.Moniker.parse(request.packageName),
+      version: Semver.fromString(request.nextVersion),
+      registry: request.registry ?? 'https://registry.npmjs.org/',
+      observedAt: isoStringFromEpochMillis(yield* Clock.currentTimeMillis),
+      versionMetadata: observed.versionMetadata,
+      distTags: { ...observed.distTags },
+      ...(observed.tarballUrl !== undefined ? { tarballUrl: observed.tarballUrl } : {}),
+      ...(observed.shasum !== undefined ? { shasum: observed.shasum } : {}),
+      ...(observed.integrity !== undefined ? { integrity: observed.integrity } : {}),
+      ...(observed.downloadedTarballSha256 !== undefined
+        ? {
+            downloadedTarballSha256: Digest.make({
+              algorithm: 'sha256',
+              value: observed.downloadedTarballSha256,
+            }),
+          }
+        : {}),
+    })
+    const receipt = PublishReceipt.make({
+      schemaVersion: 1,
+      planDigest,
+      tarballSha256,
+      observation,
+      verifiedAt: isoStringFromEpochMillis(yield* Clock.currentTimeMillis),
+    })
+    const artifact = ArtifactManifest.make({
+      schemaVersion: 1,
+      planDigest,
+      packageName: request.releaseInfo.package.name,
+      version: request.releaseInfo.nextVersion,
+      driver: request.packDriver,
+      tarball,
+      sha256: tarballSha256,
+      sizeBytes: tarballBytes.length,
+      manifest: {
+        name: request.packageName,
+        version: request.nextVersion,
+      },
+      packlist: [],
+      rewrittenFields: ['version', 'dependencies', 'devDependencies', 'peerDependencies'],
+    })
+
+    return {
+      ...verifyRegistryObservation({
+        artifact,
+        observation,
+        distTag: request.distTag,
+        official: request.official,
+        requestedAccess: 'public',
+        receipt,
+      }),
+      artifact,
+      observation,
+    }
+  })

--- a/packages/release/src/api/executor/workflow.structure.test.ts
+++ b/packages/release/src/api/executor/workflow.structure.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, test } from 'bun:test'
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8')
+const importSources = (code: string): readonly string[] =>
+  [...code.matchAll(/^\s*import\s+(?:type\s+)?[\s\S]*?\s+from\s+['"]([^'"]+)['"]/gmu)].map(
+    (match) => match[1]!,
+  )
+
+describe('ReleaseWorkflow structure', () => {
+  test('workflow graph delegates payload, identity, and registry verification details', () => {
+    const workflow = source('./workflow.ts')
+    const imports = importSources(workflow)
+
+    expect(imports.filter((entry) => !entry.startsWith('./workflow/'))).toEqual([
+      '@kitz/flo',
+      '../publishing.js',
+      './errors.js',
+    ])
+    expect(workflow).not.toContain('export const ReleasePayload = Schema.Struct')
+    expect(workflow).not.toContain('const releaseWorkflowIdempotencyKey =')
+    expect(workflow).not.toContain('ArtifactManifest.make')
+    expect(workflow).not.toContain('PublishReceipt.make')
+    expect(workflow).not.toContain('RegistryObservation.make')
+    expect(workflow).not.toContain('fs.readFile')
+    expect(workflow).not.toContain('new Date().toISOString()')
+  })
+
+  test('workflow module keeps release identity helpers internal unless intentionally exported', () => {
+    const workflow = source('./workflow.ts')
+
+    expect(workflow).not.toMatch(
+      /export\s*\{[^}]*tagForRelease[^}]*\}\s*from\s*['"]\.\/workflow\/release-info\.js['"]/u,
+    )
+  })
+
+  test('registry verification activity delegates proof construction to a producer module', () => {
+    const activity = source('./workflow/activities/verify.ts')
+
+    expect(activity).toContain('../../registry-verification.js')
+    expect(activity).not.toContain('FileSystem')
+    expect(activity).not.toContain('NpmRegistry.NpmCli')
+    expect(activity).not.toContain('ArtifactManifest.make')
+    expect(activity).not.toContain('PublishReceipt.make')
+    expect(activity).not.toContain('RegistryObservation.make')
+    expect(activity).not.toContain('sha256Bytes')
+    expect(activity).not.toContain('new Date')
+  })
+
+  test('rehearsed artifact activity uses typed kitz filesystem operations', () => {
+    const activity = source('./workflow/activities/prepare.ts')
+
+    expect(activity).toContain('Fs.exists(artifact)')
+    expect(activity).toContain('Fs.read(artifact)')
+    expect(activity).not.toContain('FileSystem')
+    expect(activity).not.toContain('fs.exists')
+    expect(activity).not.toContain('fs.readFile')
+  })
+})

--- a/packages/release/src/api/executor/workflow.ts
+++ b/packages/release/src/api/executor/workflow.ts
@@ -11,258 +11,26 @@
  * ```
  */
 
-import { ConventionalCommits } from '@kitz/conventional-commits'
 import { Flo } from '@kitz/flo'
-import { Env } from '@kitz/env'
-import { Fs } from '@kitz/fs'
-import { Git } from '@kitz/git'
-import { Github } from '@kitz/github'
-import { NpmRegistry } from '@kitz/npm-registry'
-import { Pkg } from '@kitz/pkg'
-import { Semver } from '@kitz/semver'
-import { PlatformError, Effect, FileSystem, Option, Schema } from 'effect'
-import * as Notes from '../notes/__.js'
-import { Digest, sha256Bytes } from '../digest.js'
-import { formatGithubReleaseTitle, Publishing, resolvePublishSemantics } from '../publishing.js'
-import {
-  ArtifactManifest,
-  PlanDigest,
-  PublishReceipt,
-  RegistryObservation,
-} from '../release-contract.js'
-import { verifyRegistryObservation } from '../publishing/verification.js'
-import { PublishDriverId } from '../publishing/models/driver-id.js'
-import { EphemeralSchema } from '../version/models/ephemeral.js'
-import { LifecycleSchema } from '../version/models/lifecycle.js'
-import {
-  ExecutorError as ExecutorErrorSchema,
-  ExecutorGHReleaseError,
-  ExecutorPublishError,
-  ExecutorTagError,
-} from './errors.js'
-import * as Journal from '../journal.js'
-import type { ExecutorError } from './errors.js'
-import {
-  artifactPathFor,
-  preparePackageArtifact,
-  publishPreparedArtifact,
-  PublishError,
-  type ReleaseInfo,
-} from './publish.js'
+import { resolvePublishSemantics } from '../publishing.js'
+import { ExecutorError as ExecutorErrorSchema } from './errors.js'
+import { createGithubRelease } from './workflow/activities/github.js'
+import { createTag, pushTag, pushTagsAtomic } from './workflow/activities/git.js'
+import { prepareRelease } from './workflow/activities/prepare.js'
+import { publishRelease } from './workflow/activities/publish.js'
+import { verifyPublishedRelease } from './workflow/activities/verify.js'
+import { releaseWorkflowIdempotencyKey } from './workflow/idempotency.js'
+import { ReleasePayload } from './workflow/payload.js'
+import { resolvePayloadPrNumber } from './workflow/pr-number.js'
+import { tagForRelease, toReleaseInfo } from './workflow/release-info.js'
 
-/** Format a release tag from package name and version. */
-export const formatTag = (name: Pkg.Moniker.Moniker, version: Semver.Semver): string =>
-  Pkg.Pin.toString(Pkg.Pin.Exact.make({ name, version }))
-
-// ============================================================================
-// Payload Schema
-// ============================================================================
-
-/**
- * Schema for a structured commit entry.
- */
-export const CommitEntrySchema = Schema.Struct({
-  type: Schema.String,
-  message: Schema.String,
-  hash: Git.Sha.Sha,
-  breaking: Schema.Boolean,
-})
-
-/**
- * Schema for a single release in the payload.
- */
-export const ReleaseSchema = Schema.Struct({
-  packageName: Schema.String,
-  packagePath: Schema.String,
-  currentVersion: Schema.OptionFromNullOr(Schema.String),
-  nextVersion: Schema.String,
-  bump: Schema.UndefinedOr(Schema.Literals(['major', 'minor', 'patch'])),
-  commits: Schema.Array(CommitEntrySchema),
-  dependsOn: Schema.Array(Schema.String),
-})
-
-/**
- * Payload for the release workflow.
- */
-export const ReleasePayload = Schema.Struct({
-  releases: Schema.Array(ReleaseSchema),
-  options: Schema.Struct({
-    dryRun: Schema.Boolean,
-    tag: Schema.optional(Schema.String),
-    registry: Schema.optional(Schema.String),
-    planDigest: Schema.optional(Schema.String),
-    rehearsedArtifacts: Schema.Boolean,
-    atomicTagPush: Schema.Boolean,
-    lifecycle: Schema.optional(LifecycleSchema),
-    publishing: Schema.optional(Publishing),
-    trunk: Schema.optional(Schema.String),
-    packDriver: PublishDriverId,
-    publishInvoker: PublishDriverId,
-  }),
-})
-
-export type ReleasePayloadType = typeof ReleasePayload.Type
-
-const releaseWorkflowIdempotencyKey = (payload: ReleasePayloadType): string =>
-  JSON.stringify({
-    options: {
-      dryRun: payload.options.dryRun,
-      tag: payload.options.tag ?? null,
-      registry: payload.options.registry ?? null,
-      planDigest: payload.options.planDigest ?? null,
-      rehearsedArtifacts: payload.options.rehearsedArtifacts,
-      atomicTagPush: payload.options.atomicTagPush,
-      lifecycle: payload.options.lifecycle ?? null,
-      trunk: payload.options.trunk ?? null,
-      packDriver: payload.options.packDriver,
-      publishInvoker: payload.options.publishInvoker,
-    },
-    releases: payload.releases
-      .toSorted((a, b) => a.packageName.localeCompare(b.packageName))
-      .map((release) => ({
-        packageName: release.packageName,
-        nextVersion: release.nextVersion,
-        currentVersion: release.currentVersion,
-        bump: release.bump,
-        dependsOn: release.dependsOn.toSorted(),
-        commits: release.commits.map((commit) => ({
-          hash: commit.hash,
-          type: commit.type,
-          breaking: commit.breaking,
-        })),
-      })),
-  })
-
-// ============================================================================
-// Activity Helpers
-// ============================================================================
-
-/**
- * Convert a workflow release payload to ReleaseInfo for publishing.
- */
-export const toReleaseInfo = (release: ReleasePayloadType['releases'][number]): ReleaseInfo => ({
-  package: {
-    name: Pkg.Moniker.parse(release.packageName),
-    path: Fs.Path.AbsDir.fromString(release.packagePath),
-    scope: release.packageName.startsWith('@')
-      ? release.packageName.split('/')[1]!
-      : release.packageName,
-  },
-  nextVersion: Semver.fromString(release.nextVersion),
-})
-
-const recordSideEffect = <E, R>(params: {
-  readonly payload: ReleasePayloadType
-  readonly kind: Journal.SideEffectInput['kind']
-  readonly subject: string
-  readonly planned: Readonly<Record<string, unknown>>
-  // oxlint-disable-next-line kitz/error/require-tagged-error-types -- side-effect recording preserves the wrapped operation's native error channel.
-  readonly effect: Effect.Effect<string, E, R>
-  // oxlint-disable-next-line kitz/error/require-tagged-error-types -- side-effect recording preserves the wrapped operation's native error channel.
-}): Effect.Effect<string, E, R | Env.Env | FileSystem.FileSystem> => {
-  if (params.payload.options.dryRun || params.payload.options.planDigest === undefined) {
-    return params.effect
-  }
-
-  return Effect.gen(function* () {
-    yield* Journal.appendSideEffect({
-      planDigest: params.payload.options.planDigest!,
-      kind: params.kind,
-      subject: params.subject,
-      planned: params.planned,
-      result: 'attempting',
-    }).pipe(Effect.orDie)
-    return yield* params.effect.pipe(
-      Effect.tap(() =>
-        Journal.appendSideEffect({
-          planDigest: params.payload.options.planDigest!,
-          kind: params.kind,
-          subject: params.subject,
-          planned: params.planned,
-          result: 'succeeded',
-        }).pipe(Effect.orDie),
-      ),
-      Effect.tapError((error) =>
-        Journal.appendSideEffect({
-          planDigest: params.payload.options.planDigest!,
-          kind: params.kind,
-          subject: params.subject,
-          planned: {
-            ...params.planned,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          result: 'failed',
-        }).pipe(Effect.orDie),
-      ),
-    )
-  })
-}
-
-const legacyCandidateSemantics = (distTag: string) =>
-  resolvePublishSemantics({
-    lifecycle: 'candidate',
-    tag: distTag,
-  })
-
-const resolvePayloadPrNumber = (payload: ReleasePayloadType): number | undefined => {
-  if (payload.options.lifecycle !== 'ephemeral') return undefined
-
-  for (const release of payload.releases) {
-    const prerelease = Semver.getPrerelease(Semver.fromString(release.nextVersion))
-    if (prerelease === undefined) continue
-
-    const decoded = Schema.decodeUnknownOption(EphemeralSchema)(prerelease.join('.'))
-    if (Option.isSome(decoded)) return decoded.value.prNumber
-  }
-
-  return undefined
-}
-
-const assertRehearsedArtifactExists = (
-  release: ReleaseInfo,
-  planDigest: string | undefined,
-): Effect.Effect<
-  void,
-  PublishError | PlatformError.PlatformError,
-  Env.Env | FileSystem.FileSystem
-> =>
-  Effect.gen(function* () {
-    const env = yield* Env.Env
-    const fs = yield* FileSystem.FileSystem
-    const artifact = artifactPathFor(
-      env.cwd,
-      release,
-      planDigest === undefined ? undefined : { planDigest },
-    )
-    const artifactPath = Fs.Path.toString(artifact)
-    const exists = yield* fs.exists(artifactPath).pipe(Effect.orElseSucceed(() => false))
-    if (!exists) {
-      return yield* Effect.fail(
-        new PublishError({
-          context: {
-            package: release.package.path,
-            detail: `Rehearsed artifact is missing at ${artifactPath}. Run \`release rehearse\` before \`release apply\`.`,
-          },
-        }),
-      )
-    }
-
-    const bytes = yield* fs.readFile(artifactPath)
-    if (bytes.length === 0) {
-      return yield* Effect.fail(
-        new PublishError({
-          context: {
-            package: release.package.path,
-            detail: `Rehearsed artifact is empty at ${artifactPath}. Run \`release rehearse\` before \`release apply\`.`,
-          },
-        }),
-      )
-    }
-  })
-
-// ============================================================================
-// Workflow Definition (Declarative DAG)
-// ============================================================================
+export {
+  CommitEntrySchema,
+  ReleasePayload,
+  ReleaseSchema,
+  type ReleasePayloadType,
+} from './workflow/payload.js'
+export { formatTag, toReleaseInfo } from './workflow/release-info.js'
 
 /**
  * The main release workflow using declarative DAG execution.
@@ -300,37 +68,11 @@ export const ReleaseWorkflow = Flo.Workflow.make({
     const prepares = payload.releases.map((release) =>
       node(
         `Prepare:${release.packageName}`,
-        Effect.gen(function* () {
-          const releaseInfo = toReleaseInfo(release)
-
-          const tag = formatTag(releaseInfo.package.name, releaseInfo.nextVersion)
-          if (payload.options.dryRun) {
-            yield* Effect.log(`[dry-run] Would prepare ${tag}`)
-          } else if (payload.options.rehearsedArtifacts) {
-            yield* Effect.log(`Using rehearsed artifact for ${tag}...`)
-            yield* assertRehearsedArtifactExists(releaseInfo, payload.options.planDigest)
-          } else {
-            yield* Effect.log(`Preparing ${tag}...`)
-            yield* preparePackageArtifact(releaseInfo, plannedReleases, {
-              packageManager: payload.options.packDriver,
-              ...(payload.options.planDigest === undefined
-                ? {}
-                : { planDigest: payload.options.planDigest }),
-            })
-          }
-
-          return release.packageName
-        }).pipe(
-          Effect.mapError(
-            (e) =>
-              new ExecutorPublishError({
-                context: {
-                  packageName: release.packageName,
-                  detail: e instanceof Error ? e.message : String(e),
-                },
-              }),
-          ),
-        ),
+        prepareRelease({
+          payload,
+          plannedReleases,
+          release,
+        }),
         {},
       ),
     )
@@ -340,7 +82,6 @@ export const ReleaseWorkflow = Flo.Workflow.make({
       readonly handle: Flo.Workflow.NodeHandle<string>
     }> = []
 
-    // Layer 1: Publish prepared tarballs after all preparation succeeds.
     const publishes = payload.releases.map((release) => {
       const dependencies = release.dependsOn
         .map(
@@ -351,61 +92,15 @@ export const ReleaseWorkflow = Flo.Workflow.make({
           (dependency): dependency is Flo.Workflow.NodeHandle<string> => dependency !== undefined,
         )
       const after = [...prepares, ...dependencies]
+      const publishTag = publishSemantics?.distTag ?? payload.options.tag
 
       const handle = node(
         `Publish:${release.packageName}`,
-        Effect.gen(function* () {
-          const releaseInfo = toReleaseInfo(release)
-          const tag = formatTag(releaseInfo.package.name, releaseInfo.nextVersion)
-          const publishTag = publishSemantics?.distTag ?? payload.options.tag
-
-          if (payload.options.dryRun) {
-            yield* Effect.log(`[dry-run] Would publish ${tag}`)
-          } else {
-            const env = yield* Env.Env
-            yield* Effect.log(`Publishing ${tag}...`)
-            yield* recordSideEffect({
-              payload,
-              kind: 'registry-publish',
-              subject: tag,
-              planned: {
-                packageName: release.packageName,
-                version: release.nextVersion,
-                distTag: publishTag ?? null,
-                registry: payload.options.registry ?? null,
-              },
-              effect: publishPreparedArtifact(
-                {
-                  ...releaseInfo,
-                  tarball: artifactPathFor(
-                    env.cwd,
-                    releaseInfo,
-                    payload.options.planDigest === undefined
-                      ? undefined
-                      : { planDigest: payload.options.planDigest },
-                  ),
-                },
-                {
-                  ...(publishTag !== undefined ? { tag: publishTag } : {}),
-                  ...(payload.options.registry && { registry: payload.options.registry }),
-                  packageManager: payload.options.publishInvoker,
-                },
-              ).pipe(Effect.as(release.packageName)),
-            })
-          }
-
-          return release.packageName
-        }).pipe(
-          Effect.mapError(
-            (e) =>
-              new ExecutorPublishError({
-                context: {
-                  packageName: release.packageName,
-                  detail: e instanceof Error ? e.message : String(e),
-                },
-              }),
-          ),
-        ),
+        publishRelease({
+          payload,
+          publishTag,
+          release,
+        }),
         after.length > 0 ? { after } : undefined,
       )
 
@@ -416,366 +111,69 @@ export const ReleaseWorkflow = Flo.Workflow.make({
     const verifyPublishes = payload.releases.map((release, i) =>
       node(
         `VerifyPublish:${release.packageName}`,
-        Effect.gen(function* () {
-          if (payload.options.dryRun) {
-            yield* Effect.log(
-              `[dry-run] Would verify registry version: ${release.packageName}@${release.nextVersion}`,
-            )
-            return release.packageName
-          }
-
-          yield* Effect.log(
-            `Verifying registry version: ${release.packageName}@${release.nextVersion}`,
-          )
-          const env = yield* Env.Env
-          const fs = yield* FileSystem.FileSystem
-          const cli = yield* NpmRegistry.NpmCli
-          const releaseInfo = toReleaseInfo(release)
-          const tarball = artifactPathFor(
-            env.cwd,
-            releaseInfo,
-            payload.options.planDigest === undefined
-              ? undefined
-              : { planDigest: payload.options.planDigest },
-          )
-          const tarballBytes = yield* fs.readFile(Fs.Path.toString(tarball))
-          const tarballSha256 = sha256Bytes(tarballBytes)
-          const publishTag = publishSemantics?.distTag ?? payload.options.tag ?? 'latest'
-          const observed = yield* cli.observeVersion(release.packageName, release.nextVersion, {
-            ...(payload.options.registry !== undefined
-              ? { registry: payload.options.registry }
-              : {}),
-            downloadTarball: payload.options.lifecycle === 'official',
-          })
-          const planDigest = PlanDigest.make({
-            algorithm: 'sha256',
-            value: payload.options.planDigest ?? 'unknown',
-          })
-          const observation = RegistryObservation.make({
-            packageName: Pkg.Moniker.parse(release.packageName),
-            version: Semver.fromString(release.nextVersion),
-            registry: payload.options.registry ?? 'https://registry.npmjs.org/',
-            observedAt: new Date().toISOString(),
-            versionMetadata: observed.versionMetadata,
-            distTags: { ...observed.distTags },
-            ...(observed.tarballUrl !== undefined ? { tarballUrl: observed.tarballUrl } : {}),
-            ...(observed.shasum !== undefined ? { shasum: observed.shasum } : {}),
-            ...(observed.integrity !== undefined ? { integrity: observed.integrity } : {}),
-            ...(observed.downloadedTarballSha256 !== undefined
-              ? {
-                  downloadedTarballSha256: Digest.make({
-                    algorithm: 'sha256',
-                    value: observed.downloadedTarballSha256,
-                  }),
-                }
-              : {}),
-          })
-          const receipt = PublishReceipt.make({
-            schemaVersion: 1,
-            planDigest,
-            tarballSha256,
-            observation,
-            verifiedAt: new Date().toISOString(),
-          })
-          const artifact = ArtifactManifest.make({
-            schemaVersion: 1,
-            planDigest,
-            packageName: releaseInfo.package.name,
-            version: releaseInfo.nextVersion,
-            driver: payload.options.packDriver,
-            tarball,
-            sha256: tarballSha256,
-            sizeBytes: tarballBytes.length,
-            manifest: {
-              name: release.packageName,
-              version: release.nextVersion,
-            },
-            packlist: [],
-            rewrittenFields: ['version', 'dependencies', 'devDependencies', 'peerDependencies'],
-          })
-          const verification = verifyRegistryObservation({
-            artifact,
-            observation,
-            distTag: publishTag,
-            official: payload.options.lifecycle === 'official',
-            requestedAccess: 'public',
-            receipt,
-          })
-          if (verification.issues.length > 0) {
-            return yield* Effect.fail(
-              new ExecutorPublishError({
-                context: {
-                  packageName: release.packageName,
-                  detail: verification.issues.map((issue) => issue.detail).join('\n'),
-                },
-              }),
-            )
-          }
-
-          return release.packageName
-        }).pipe(
-          Effect.mapError((e): ExecutorPublishError => {
-            if ((e as { readonly _tag?: string })._tag === 'ExecutorPublishError') {
-              return e as ExecutorPublishError
-            }
-            return new ExecutorPublishError({
-              context: {
-                packageName: release.packageName,
-                detail: e instanceof Error ? e.message : String(e),
-              },
-            })
-          }),
-        ),
+        verifyPublishedRelease({
+          payload,
+          publishTag: publishSemantics?.distTag ?? payload.options.tag,
+          release,
+        }),
         { after: publishes[i]! },
       ),
     )
 
-    // Layer 2: Create git tags (each depends on its corresponding verified publish)
     const createTags = payload.releases.map((release, i) => {
-      const tag = formatTag(
-        Pkg.Moniker.parse(release.packageName),
-        Semver.fromString(release.nextVersion),
-      )
+      const tag = tagForRelease(release)
       return node(
         `CreateTag:${tag}`,
-        Effect.gen(function* () {
-          if (payload.options.dryRun) {
-            yield* Effect.log(`[dry-run] Would create tag: ${tag}`)
-          } else {
-            yield* Effect.log(`Creating tag: ${tag}`)
-            const gitService = yield* Git.Git
-            yield* recordSideEffect({
-              payload,
-              kind: 'git-tag-create',
-              subject: tag,
-              planned: { tag, message: `Release ${tag}` },
-              effect: gitService.createTag(tag, `Release ${tag}`).pipe(Effect.as(tag)),
-            })
-          }
-          return tag
-        }).pipe(
-          Effect.mapError(
-            (e) =>
-              new ExecutorTagError({
-                context: {
-                  tag,
-                  detail: e instanceof Error ? e.message : String(e),
-                },
-              }),
-          ),
-        ),
+        createTag({
+          payload,
+          tag,
+        }),
         { after: verifyPublishes[i]! },
       )
     })
 
-    // Layer 3: Push tags after local tag creation. Official contracted
-    // multi-package releases use one atomic push so no remote receives a
-    // partial tag set.
     const shouldAtomicPushTags =
       payload.options.atomicTagPush && payload.releases.length > 1 && !payload.options.dryRun
     const atomicPushTagHandle = shouldAtomicPushTags
       ? node(
           `PushTagsAtomic:${payload.releases.length}`,
-          Effect.gen(function* () {
-            const tags = payload.releases.map((release) =>
-              formatTag(
-                Pkg.Moniker.parse(release.packageName),
-                Semver.fromString(release.nextVersion),
-              ),
-            )
-            yield* Effect.log(`Pushing ${tags.length} tags atomically`)
-            const gitService = yield* Git.Git
-            yield* recordSideEffect({
-              payload,
-              kind: 'git-tag-push',
-              subject: tags.join(','),
-              planned: { tags, remote: 'origin', atomic: true },
-              effect: gitService
-                .pushTagsAtomic(tags, 'origin', false)
-                .pipe(Effect.as(tags.join(','))),
-            })
-            return tags.join(',')
-          }).pipe(
-            Effect.mapError(
-              (e) =>
-                new ExecutorTagError({
-                  context: {
-                    tag: 'atomic-tag-push',
-                    detail: e instanceof Error ? e.message : String(e),
-                  },
-                }),
-            ),
-          ),
+          pushTagsAtomic({
+            payload,
+            tags: payload.releases.map(tagForRelease),
+          }),
           { after: createTags },
         )
       : undefined
 
     const pushTags = payload.releases.map((release, i) => {
-      const tag = formatTag(
-        Pkg.Moniker.parse(release.packageName),
-        Semver.fromString(release.nextVersion),
-      )
+      const tag = tagForRelease(release)
       if (atomicPushTagHandle !== undefined) return atomicPushTagHandle
 
       return node(
         `PushTag:${tag}`,
-        Effect.gen(function* () {
-          if (payload.options.dryRun) {
-            yield* Effect.log(`[dry-run] Would push tag: ${tag}`)
-          } else {
-            yield* Effect.log(`Pushing tag: ${tag}`)
-            const gitService = yield* Git.Git
-            const force =
-              publishSemantics?.forcePushTag ??
-              (payload.options.lifecycle === undefined && payload.options.tag === 'next')
-            yield* recordSideEffect({
-              payload,
-              kind: 'git-tag-push',
-              subject: tag,
-              planned: { tag, remote: 'origin', force },
-              effect: gitService.pushTag(tag, 'origin', force).pipe(Effect.as(tag)),
-            })
-          }
-          return tag
-        }).pipe(
-          Effect.mapError(
-            (e) =>
-              new ExecutorTagError({
-                context: {
-                  tag,
-                  detail: e instanceof Error ? e.message : String(e),
-                },
-              }),
-          ),
-        ),
+        pushTag({
+          payload,
+          tag,
+          force:
+            publishSemantics?.forcePushTag ??
+            (payload.options.lifecycle === undefined && payload.options.tag === 'next'),
+        }),
         { after: createTags[i]! },
       )
     })
 
-    // Layer 4: Create GitHub releases (each depends on its corresponding pushTag)
-    const createGHReleases = payload.releases.map((release, i) => {
-      const nextVersion = Semver.fromString(release.nextVersion)
-      const tag = formatTag(Pkg.Moniker.parse(release.packageName), nextVersion)
-      const legacyCandidateDistTag =
-        payload.options.lifecycle === undefined && payload.options.tag === 'next'
-          ? 'next'
-          : undefined
-      const isPrereleaseVersion = Semver.getPrerelease(nextVersion) !== undefined
-      return node(
-        `CreateGHRelease:${tag}`,
-        Effect.gen(function* () {
-          if (payload.options.dryRun) {
-            yield* Effect.log(`[dry-run] Would create GH release: ${tag}`)
-            return tag
-          }
-
-          yield* Effect.log(`Creating GH release: ${tag}`)
-
-          // Generate changelog for release body
-          const changelog = yield* Notes.format({
-            scope: release.packageName,
-            commits: release.commits.map((c) => ({
-              ...c,
-              type: ConventionalCommits.Type.parse(c.type),
-            })),
-            newVersion: release.nextVersion,
-          })
-
-          const gh = yield* Github.Github
-
-          if (
-            publishSemantics?.githubReleaseStyle === 'dist-tagged' ||
-            legacyCandidateDistTag !== undefined
-          ) {
-            const distTag = publishSemantics?.distTag ?? legacyCandidateDistTag!
-            const exists = yield* gh.releaseExists(tag)
-
-            if (exists) {
-              yield* Effect.log(`Updating existing candidate release: ${tag}`)
-              const title = formatGithubReleaseTitle(
-                publishSemantics ?? legacyCandidateSemantics(distTag),
-                {
-                  packageName: release.packageName,
-                  version: release.nextVersion,
-                },
-              )
-              yield* recordSideEffect({
-                payload,
-                kind: 'github-release-update',
-                subject: tag,
-                planned: { tag, title, prerelease: true },
-                effect: gh
-                  .updateRelease(tag, { title, body: changelog.markdown })
-                  .pipe(Effect.as(tag)),
-              })
-            } else {
-              const title = formatGithubReleaseTitle(
-                publishSemantics ?? legacyCandidateSemantics(distTag),
-                {
-                  packageName: release.packageName,
-                  version: release.nextVersion,
-                },
-              )
-              yield* recordSideEffect({
-                payload,
-                kind: 'github-release-create',
-                subject: tag,
-                planned: { tag, title, prerelease: true },
-                effect: gh
-                  .createRelease({
-                    tag,
-                    title,
-                    body: changelog.markdown,
-                    prerelease: true,
-                  })
-                  .pipe(Effect.as(tag)),
-              })
-            }
-          } else {
-            const releaseSemantics =
-              publishSemantics ??
-              resolvePublishSemantics({
-                lifecycle: isPrereleaseVersion ? 'ephemeral' : 'official',
-                ...(payload.options.tag !== undefined ? { tag: payload.options.tag } : {}),
-              })
-            const title = formatGithubReleaseTitle(releaseSemantics, {
-              packageName: release.packageName,
-              version: release.nextVersion,
-            })
-            const prerelease = releaseSemantics.prerelease || isPrereleaseVersion
-            yield* recordSideEffect({
-              payload,
-              kind: 'github-release-create',
-              subject: tag,
-              planned: { tag, title, prerelease },
-              effect: gh
-                .createRelease({
-                  tag,
-                  title,
-                  body: changelog.markdown,
-                  ...(prerelease ? { prerelease: true } : {}),
-                })
-                .pipe(Effect.as(tag)),
-            })
-          }
-
-          return tag
-        }).pipe(
-          Effect.mapError(
-            (e) =>
-              new ExecutorGHReleaseError({
-                context: {
-                  tag,
-                  detail: e instanceof Error ? e.message : String(e),
-                },
-              }),
-          ),
-        ),
+    const createGHReleases = payload.releases.map((release, i) =>
+      node(
+        `CreateGHRelease:${tagForRelease(release)}`,
+        createGithubRelease({
+          payload,
+          publishSemantics,
+          release,
+        }),
         { after: pushTags[i]! },
-      )
-    })
+      ),
+    )
 
-    // Return handles for result collection
     return {
       publishes,
       verifyPublishes,

--- a/packages/release/src/api/executor/workflow/activities/git.ts
+++ b/packages/release/src/api/executor/workflow/activities/git.ts
@@ -1,0 +1,96 @@
+import { Git } from '@kitz/git'
+import { Effect } from 'effect'
+import { ExecutorTagError } from '../../errors.js'
+import type { ReleasePayloadType } from '../payload.js'
+import { recordSideEffect } from '../side-effects.js'
+
+export const createTag = (params: { readonly payload: ReleasePayloadType; readonly tag: string }) =>
+  Effect.gen(function* () {
+    if (params.payload.options.dryRun) {
+      yield* Effect.log(`[dry-run] Would create tag: ${params.tag}`)
+    } else {
+      yield* Effect.log(`Creating tag: ${params.tag}`)
+      const gitService = yield* Git.Git
+      yield* recordSideEffect({
+        payload: params.payload,
+        kind: 'git-tag-create',
+        subject: params.tag,
+        planned: { tag: params.tag, message: `Release ${params.tag}` },
+        effect: gitService
+          .createTag(params.tag, `Release ${params.tag}`)
+          .pipe(Effect.as(params.tag)),
+      })
+    }
+    return params.tag
+  }).pipe(
+    Effect.mapError(
+      (e) =>
+        new ExecutorTagError({
+          context: {
+            tag: params.tag,
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        }),
+    ),
+  )
+
+export const pushTag = (params: {
+  readonly payload: ReleasePayloadType
+  readonly tag: string
+  readonly force: boolean
+}) =>
+  Effect.gen(function* () {
+    if (params.payload.options.dryRun) {
+      yield* Effect.log(`[dry-run] Would push tag: ${params.tag}`)
+    } else {
+      yield* Effect.log(`Pushing tag: ${params.tag}`)
+      const gitService = yield* Git.Git
+      yield* recordSideEffect({
+        payload: params.payload,
+        kind: 'git-tag-push',
+        subject: params.tag,
+        planned: { tag: params.tag, remote: 'origin', force: params.force },
+        effect: gitService.pushTag(params.tag, 'origin', params.force).pipe(Effect.as(params.tag)),
+      })
+    }
+    return params.tag
+  }).pipe(
+    Effect.mapError(
+      (e) =>
+        new ExecutorTagError({
+          context: {
+            tag: params.tag,
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        }),
+    ),
+  )
+
+export const pushTagsAtomic = (params: {
+  readonly payload: ReleasePayloadType
+  readonly tags: readonly string[]
+}) =>
+  Effect.gen(function* () {
+    yield* Effect.log(`Pushing ${String(params.tags.length)} tags atomically`)
+    const gitService = yield* Git.Git
+    yield* recordSideEffect({
+      payload: params.payload,
+      kind: 'git-tag-push',
+      subject: params.tags.join(','),
+      planned: { tags: params.tags, remote: 'origin', atomic: true },
+      effect: gitService
+        .pushTagsAtomic(params.tags, 'origin', false)
+        .pipe(Effect.as(params.tags.join(','))),
+    })
+    return params.tags.join(',')
+  }).pipe(
+    Effect.mapError(
+      (e) =>
+        new ExecutorTagError({
+          context: {
+            tag: 'atomic-tag-push',
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        }),
+    ),
+  )

--- a/packages/release/src/api/executor/workflow/activities/github.ts
+++ b/packages/release/src/api/executor/workflow/activities/github.ts
@@ -1,0 +1,132 @@
+import { ConventionalCommits } from '@kitz/conventional-commits'
+import { Github } from '@kitz/github'
+import { Semver } from '@kitz/semver'
+import { Effect } from 'effect'
+import * as Notes from '../../../notes/__.js'
+import {
+  formatGithubReleaseTitle,
+  resolvePublishSemantics,
+  type PublishSemantics,
+} from '../../../publishing.js'
+import { ExecutorGHReleaseError } from '../../errors.js'
+import type { ReleasePayloadType } from '../payload.js'
+import { type ReleasePayloadEntry, tagForRelease } from '../release-info.js'
+import { recordSideEffect } from '../side-effects.js'
+
+const legacyCandidateSemantics = (distTag: string) =>
+  resolvePublishSemantics({
+    lifecycle: 'candidate',
+    tag: distTag,
+  })
+
+export const createGithubRelease = (params: {
+  readonly payload: ReleasePayloadType
+  readonly publishSemantics: PublishSemantics | undefined
+  readonly release: ReleasePayloadEntry
+}) =>
+  Effect.gen(function* () {
+    const nextVersion = Semver.fromString(params.release.nextVersion)
+    const tag = tagForRelease(params.release)
+    const legacyCandidateDistTag =
+      params.payload.options.lifecycle === undefined && params.payload.options.tag === 'next'
+        ? 'next'
+        : undefined
+    const isPrereleaseVersion = Semver.getPrerelease(nextVersion) !== undefined
+
+    if (params.payload.options.dryRun) {
+      yield* Effect.log(`[dry-run] Would create GH release: ${tag}`)
+      return tag
+    }
+
+    yield* Effect.log(`Creating GH release: ${tag}`)
+
+    const changelog = yield* Notes.format({
+      scope: params.release.packageName,
+      commits: params.release.commits.map((c) => ({
+        ...c,
+        type: ConventionalCommits.Type.parse(c.type),
+      })),
+      newVersion: params.release.nextVersion,
+    })
+
+    const gh = yield* Github.Github
+
+    if (
+      params.publishSemantics?.githubReleaseStyle === 'dist-tagged' ||
+      legacyCandidateDistTag !== undefined
+    ) {
+      const distTag = params.publishSemantics?.distTag ?? legacyCandidateDistTag!
+      const title = formatGithubReleaseTitle(
+        params.publishSemantics ?? legacyCandidateSemantics(distTag),
+        {
+          packageName: params.release.packageName,
+          version: params.release.nextVersion,
+        },
+      )
+      const exists = yield* gh.releaseExists(tag)
+
+      if (exists) {
+        yield* Effect.log(`Updating existing candidate release: ${tag}`)
+        yield* recordSideEffect({
+          payload: params.payload,
+          kind: 'github-release-update',
+          subject: tag,
+          planned: { tag, title, prerelease: true },
+          effect: gh.updateRelease(tag, { title, body: changelog.markdown }).pipe(Effect.as(tag)),
+        })
+      } else {
+        yield* recordSideEffect({
+          payload: params.payload,
+          kind: 'github-release-create',
+          subject: tag,
+          planned: { tag, title, prerelease: true },
+          effect: gh
+            .createRelease({
+              tag,
+              title,
+              body: changelog.markdown,
+              prerelease: true,
+            })
+            .pipe(Effect.as(tag)),
+        })
+      }
+    } else {
+      const releaseSemantics =
+        params.publishSemantics ??
+        resolvePublishSemantics({
+          lifecycle: isPrereleaseVersion ? 'ephemeral' : 'official',
+          ...(params.payload.options.tag !== undefined ? { tag: params.payload.options.tag } : {}),
+        })
+      const title = formatGithubReleaseTitle(releaseSemantics, {
+        packageName: params.release.packageName,
+        version: params.release.nextVersion,
+      })
+      const prerelease = releaseSemantics.prerelease || isPrereleaseVersion
+      yield* recordSideEffect({
+        payload: params.payload,
+        kind: 'github-release-create',
+        subject: tag,
+        planned: { tag, title, prerelease },
+        effect: gh
+          .createRelease({
+            tag,
+            title,
+            body: changelog.markdown,
+            ...(prerelease ? { prerelease: true } : {}),
+          })
+          .pipe(Effect.as(tag)),
+      })
+    }
+
+    return tag
+  }).pipe(
+    Effect.mapError(
+      (e) =>
+        new ExecutorGHReleaseError({
+          context: {
+            tag: tagForRelease(params.release),
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        }),
+    ),
+  )

--- a/packages/release/src/api/executor/workflow/activities/prepare.ts
+++ b/packages/release/src/api/executor/workflow/activities/prepare.ts
@@ -1,0 +1,83 @@
+import { Env } from '@kitz/env'
+import { Fs } from '@kitz/fs'
+import { Effect } from 'effect'
+import { ExecutorPublishError } from '../../errors.js'
+import {
+  artifactPathFor,
+  preparePackageArtifact,
+  PublishError,
+  type ReleaseInfo,
+} from '../../publish.js'
+import type { ReleasePayloadType } from '../payload.js'
+import { formatTag, type ReleasePayloadEntry, toReleaseInfo } from '../release-info.js'
+
+const assertRehearsedArtifactExists = (release: ReleaseInfo, planDigest: string | undefined) =>
+  Effect.gen(function* () {
+    const env = yield* Env.Env
+    const artifact = artifactPathFor(
+      env.cwd,
+      release,
+      planDigest === undefined ? undefined : { planDigest },
+    )
+    const artifactPath = artifact.toString()
+    const exists = yield* Fs.exists(artifact).pipe(Effect.orElseSucceed(() => false))
+    if (!exists) {
+      return yield* Effect.fail(
+        new PublishError({
+          context: {
+            package: release.package.path,
+            detail: `Rehearsed artifact is missing at ${artifactPath}. Run \`release rehearse\` before \`release apply\`.`,
+          },
+        }),
+      )
+    }
+
+    const bytes = yield* Fs.read(artifact)
+    if (bytes.length === 0) {
+      return yield* Effect.fail(
+        new PublishError({
+          context: {
+            package: release.package.path,
+            detail: `Rehearsed artifact is empty at ${artifactPath}. Run \`release rehearse\` before \`release apply\`.`,
+          },
+        }),
+      )
+    }
+  })
+
+export const prepareRelease = (params: {
+  readonly payload: ReleasePayloadType
+  readonly plannedReleases: readonly ReleaseInfo[]
+  readonly release: ReleasePayloadEntry
+}) =>
+  Effect.gen(function* () {
+    const releaseInfo = toReleaseInfo(params.release)
+    const tag = formatTag(releaseInfo.package.name, releaseInfo.nextVersion)
+
+    if (params.payload.options.dryRun) {
+      yield* Effect.log(`[dry-run] Would prepare ${tag}`)
+    } else if (params.payload.options.rehearsedArtifacts) {
+      yield* Effect.log(`Using rehearsed artifact for ${tag}...`)
+      yield* assertRehearsedArtifactExists(releaseInfo, params.payload.options.planDigest)
+    } else {
+      yield* Effect.log(`Preparing ${tag}...`)
+      yield* preparePackageArtifact(releaseInfo, params.plannedReleases, {
+        packageManager: params.payload.options.packDriver,
+        ...(params.payload.options.planDigest === undefined
+          ? {}
+          : { planDigest: params.payload.options.planDigest }),
+      })
+    }
+
+    return params.release.packageName
+  }).pipe(
+    Effect.mapError(
+      (e) =>
+        new ExecutorPublishError({
+          context: {
+            packageName: params.release.packageName,
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        }),
+    ),
+  )

--- a/packages/release/src/api/executor/workflow/activities/publish.ts
+++ b/packages/release/src/api/executor/workflow/activities/publish.ts
@@ -1,0 +1,64 @@
+import { Env } from '@kitz/env'
+import { Effect } from 'effect'
+import { ExecutorPublishError } from '../../errors.js'
+import { artifactPathFor, publishPreparedArtifact } from '../../publish.js'
+import type { ReleasePayloadType } from '../payload.js'
+import { formatTag, type ReleasePayloadEntry, toReleaseInfo } from '../release-info.js'
+import { recordSideEffect } from '../side-effects.js'
+
+export const publishRelease = (params: {
+  readonly payload: ReleasePayloadType
+  readonly publishTag: string | undefined
+  readonly release: ReleasePayloadEntry
+}) =>
+  Effect.gen(function* () {
+    const releaseInfo = toReleaseInfo(params.release)
+    const tag = formatTag(releaseInfo.package.name, releaseInfo.nextVersion)
+
+    if (params.payload.options.dryRun) {
+      yield* Effect.log(`[dry-run] Would publish ${tag}`)
+    } else {
+      const env = yield* Env.Env
+      yield* Effect.log(`Publishing ${tag}...`)
+      yield* recordSideEffect({
+        payload: params.payload,
+        kind: 'registry-publish',
+        subject: tag,
+        planned: {
+          packageName: params.release.packageName,
+          version: params.release.nextVersion,
+          distTag: params.publishTag ?? null,
+          registry: params.payload.options.registry ?? null,
+        },
+        effect: publishPreparedArtifact(
+          {
+            ...releaseInfo,
+            tarball: artifactPathFor(
+              env.cwd,
+              releaseInfo,
+              params.payload.options.planDigest === undefined
+                ? undefined
+                : { planDigest: params.payload.options.planDigest },
+            ),
+          },
+          {
+            ...(params.publishTag !== undefined ? { tag: params.publishTag } : {}),
+            ...(params.payload.options.registry && { registry: params.payload.options.registry }),
+            packageManager: params.payload.options.publishInvoker,
+          },
+        ).pipe(Effect.as(params.release.packageName)),
+      })
+    }
+
+    return params.release.packageName
+  }).pipe(
+    Effect.mapError(
+      (e) =>
+        new ExecutorPublishError({
+          context: {
+            packageName: params.release.packageName,
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        }),
+    ),
+  )

--- a/packages/release/src/api/executor/workflow/activities/verify.ts
+++ b/packages/release/src/api/executor/workflow/activities/verify.ts
@@ -1,0 +1,66 @@
+import { Effect } from 'effect'
+import { verifyRegistryPublication } from '../../registry-verification.js'
+import { ExecutorPublishError } from '../../errors.js'
+import type { ReleasePayloadType } from '../payload.js'
+import { type ReleasePayloadEntry, toReleaseInfo } from '../release-info.js'
+
+const toExecutorPublishError = (
+  release: ReleasePayloadEntry,
+  error: unknown,
+): ExecutorPublishError => {
+  if ((error as { readonly _tag?: string })._tag === 'ExecutorPublishError') {
+    return error as ExecutorPublishError
+  }
+
+  return new ExecutorPublishError({
+    context: {
+      packageName: release.packageName,
+      detail: error instanceof Error ? error.message : String(error),
+    },
+  })
+}
+
+export const verifyPublishedRelease = (params: {
+  readonly payload: ReleasePayloadType
+  readonly publishTag: string | undefined
+  readonly release: ReleasePayloadEntry
+}) =>
+  Effect.gen(function* () {
+    if (params.payload.options.dryRun) {
+      yield* Effect.log(
+        `[dry-run] Would verify registry version: ${params.release.packageName}@${params.release.nextVersion}`,
+      )
+      return params.release.packageName
+    }
+
+    yield* Effect.log(
+      `Verifying registry version: ${params.release.packageName}@${params.release.nextVersion}`,
+    )
+    const distTag = params.publishTag ?? 'latest'
+    const verification = yield* verifyRegistryPublication({
+      packageName: params.release.packageName,
+      nextVersion: params.release.nextVersion,
+      releaseInfo: toReleaseInfo(params.release),
+      distTag,
+      packDriver: params.payload.options.packDriver,
+      official: params.payload.options.lifecycle === 'official',
+      ...(params.payload.options.planDigest !== undefined
+        ? { planDigest: params.payload.options.planDigest }
+        : {}),
+      ...(params.payload.options.registry !== undefined
+        ? { registry: params.payload.options.registry }
+        : {}),
+    })
+    if (verification.issues.length > 0) {
+      return yield* Effect.fail(
+        new ExecutorPublishError({
+          context: {
+            packageName: params.release.packageName,
+            detail: verification.issues.map((issue) => issue.detail).join('\n'),
+          },
+        }),
+      )
+    }
+
+    return params.release.packageName
+  }).pipe(Effect.mapError((e) => toExecutorPublishError(params.release, e)))

--- a/packages/release/src/api/executor/workflow/idempotency.ts
+++ b/packages/release/src/api/executor/workflow/idempotency.ts
@@ -1,0 +1,31 @@
+import type { ReleasePayloadType } from './payload.js'
+
+export const releaseWorkflowIdempotencyKey = (payload: ReleasePayloadType): string =>
+  JSON.stringify({
+    options: {
+      dryRun: payload.options.dryRun,
+      tag: payload.options.tag ?? null,
+      registry: payload.options.registry ?? null,
+      planDigest: payload.options.planDigest ?? null,
+      rehearsedArtifacts: payload.options.rehearsedArtifacts,
+      atomicTagPush: payload.options.atomicTagPush,
+      lifecycle: payload.options.lifecycle ?? null,
+      trunk: payload.options.trunk ?? null,
+      packDriver: payload.options.packDriver,
+      publishInvoker: payload.options.publishInvoker,
+    },
+    releases: payload.releases
+      .toSorted((a, b) => a.packageName.localeCompare(b.packageName))
+      .map((release) => ({
+        packageName: release.packageName,
+        nextVersion: release.nextVersion,
+        currentVersion: release.currentVersion,
+        bump: release.bump,
+        dependsOn: release.dependsOn.toSorted(),
+        commits: release.commits.map((commit) => ({
+          hash: commit.hash,
+          type: commit.type,
+          breaking: commit.breaking,
+        })),
+      })),
+  })

--- a/packages/release/src/api/executor/workflow/payload.ts
+++ b/packages/release/src/api/executor/workflow/payload.ts
@@ -1,0 +1,41 @@
+import { Git } from '@kitz/git'
+import { Schema } from 'effect'
+import { Publishing } from '../../publishing.js'
+import { PublishDriverId } from '../../publishing/models/driver-id.js'
+import { LifecycleSchema } from '../../version/models/lifecycle.js'
+
+export const CommitEntrySchema = Schema.Struct({
+  type: Schema.String,
+  message: Schema.String,
+  hash: Git.Sha.Sha,
+  breaking: Schema.Boolean,
+})
+
+export const ReleaseSchema = Schema.Struct({
+  packageName: Schema.String,
+  packagePath: Schema.String,
+  currentVersion: Schema.OptionFromNullOr(Schema.String),
+  nextVersion: Schema.String,
+  bump: Schema.UndefinedOr(Schema.Literals(['major', 'minor', 'patch'])),
+  commits: Schema.Array(CommitEntrySchema),
+  dependsOn: Schema.Array(Schema.String),
+})
+
+export const ReleasePayload = Schema.Struct({
+  releases: Schema.Array(ReleaseSchema),
+  options: Schema.Struct({
+    dryRun: Schema.Boolean,
+    tag: Schema.optional(Schema.String),
+    registry: Schema.optional(Schema.String),
+    planDigest: Schema.optional(Schema.String),
+    rehearsedArtifacts: Schema.Boolean,
+    atomicTagPush: Schema.Boolean,
+    lifecycle: Schema.optional(LifecycleSchema),
+    publishing: Schema.optional(Publishing),
+    trunk: Schema.optional(Schema.String),
+    packDriver: PublishDriverId,
+    publishInvoker: PublishDriverId,
+  }),
+})
+
+export type ReleasePayloadType = typeof ReleasePayload.Type

--- a/packages/release/src/api/executor/workflow/pr-number.ts
+++ b/packages/release/src/api/executor/workflow/pr-number.ts
@@ -1,0 +1,18 @@
+import { Semver } from '@kitz/semver'
+import { Option, Schema } from 'effect'
+import { EphemeralSchema } from '../../version/models/ephemeral.js'
+import type { ReleasePayloadType } from './payload.js'
+
+export const resolvePayloadPrNumber = (payload: ReleasePayloadType): number | undefined => {
+  if (payload.options.lifecycle !== 'ephemeral') return undefined
+
+  for (const release of payload.releases) {
+    const prerelease = Semver.getPrerelease(Semver.fromString(release.nextVersion))
+    if (prerelease === undefined) continue
+
+    const decoded = Schema.decodeUnknownOption(EphemeralSchema)(prerelease.join('.'))
+    if (Option.isSome(decoded)) return decoded.value.prNumber
+  }
+
+  return undefined
+}

--- a/packages/release/src/api/executor/workflow/release-info.ts
+++ b/packages/release/src/api/executor/workflow/release-info.ts
@@ -1,0 +1,24 @@
+import { Fs } from '@kitz/fs'
+import { Pkg } from '@kitz/pkg'
+import { Semver } from '@kitz/semver'
+import type { ReleaseInfo } from '../publish.js'
+import type { ReleasePayloadType } from './payload.js'
+
+export type ReleasePayloadEntry = ReleasePayloadType['releases'][number]
+
+export const formatTag = (name: Pkg.Moniker.Moniker, version: Semver.Semver): string =>
+  Pkg.Pin.toString(Pkg.Pin.Exact.make({ name, version }))
+
+export const toReleaseInfo = (release: ReleasePayloadEntry): ReleaseInfo => ({
+  package: {
+    name: Pkg.Moniker.parse(release.packageName),
+    path: Fs.Path.AbsDir.fromString(release.packagePath),
+    scope: release.packageName.startsWith('@')
+      ? release.packageName.split('/')[1]!
+      : release.packageName,
+  },
+  nextVersion: Semver.fromString(release.nextVersion),
+})
+
+export const tagForRelease = (release: ReleasePayloadEntry): string =>
+  formatTag(Pkg.Moniker.parse(release.packageName), Semver.fromString(release.nextVersion))

--- a/packages/release/src/api/executor/workflow/side-effects.ts
+++ b/packages/release/src/api/executor/workflow/side-effects.ts
@@ -1,0 +1,51 @@
+import { Env } from '@kitz/env'
+import { Effect, FileSystem } from 'effect'
+import * as Journal from '../../journal.js'
+import type { ReleasePayloadType } from './payload.js'
+
+export const recordSideEffect = <E, R>(params: {
+  readonly payload: ReleasePayloadType
+  readonly kind: Journal.SideEffectInput['kind']
+  readonly subject: string
+  readonly planned: Readonly<Record<string, unknown>>
+  // oxlint-disable-next-line kitz/error/require-tagged-error-types -- side-effect recording preserves the wrapped operation's native error channel.
+  readonly effect: Effect.Effect<string, E, R>
+  // oxlint-disable-next-line kitz/error/require-tagged-error-types -- side-effect recording preserves the wrapped operation's native error channel.
+}): Effect.Effect<string, E, R | Env.Env | FileSystem.FileSystem> => {
+  if (params.payload.options.dryRun || params.payload.options.planDigest === undefined) {
+    return params.effect
+  }
+
+  return Effect.gen(function* () {
+    yield* Journal.appendSideEffect({
+      planDigest: params.payload.options.planDigest!,
+      kind: params.kind,
+      subject: params.subject,
+      planned: params.planned,
+      result: 'attempting',
+    }).pipe(Effect.orDie)
+    return yield* params.effect.pipe(
+      Effect.tap(() =>
+        Journal.appendSideEffect({
+          planDigest: params.payload.options.planDigest!,
+          kind: params.kind,
+          subject: params.subject,
+          planned: params.planned,
+          result: 'succeeded',
+        }).pipe(Effect.orDie),
+      ),
+      Effect.tapError((error) =>
+        Journal.appendSideEffect({
+          planDigest: params.payload.options.planDigest!,
+          kind: params.kind,
+          subject: params.subject,
+          planned: {
+            ...params.planned,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          result: 'failed',
+        }).pipe(Effect.orDie),
+      ),
+    )
+  })
+}

--- a/packages/release/src/cli/pr-preview.workflow-permissions.test.ts
+++ b/packages/release/src/cli/pr-preview.workflow-permissions.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { Yaml } from '@kitz/yaml'
+import { describe, expect, test } from 'bun:test'
+import { Schema } from 'effect'
+
+const Permissions = Schema.Record(Schema.String, Schema.String)
+const Workflow = Yaml.parseYaml().pipe(
+  Schema.decodeTo(
+    Schema.Struct({
+      permissions: Permissions,
+      jobs: Schema.Record(
+        Schema.String,
+        Schema.Struct({
+          permissions: Schema.optional(Permissions),
+        }),
+      ),
+    }),
+  ),
+)
+
+const workflow = Schema.decodeUnknownSync(Workflow)(
+  readFileSync(new URL('../../../../.github/workflows/pr.yml', import.meta.url), 'utf8'),
+)
+
+describe('release preview workflow permissions', () => {
+  test('can post the generated PR preview comment', () => {
+    const releasePreviewPermissions = workflow.jobs['release-preview']?.permissions
+
+    expect(workflow.permissions['issues']).toBe('write')
+    expect(
+      releasePreviewPermissions === undefined || releasePreviewPermissions['issues'] === 'write',
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Refs #259

## Summary
- Split `ReleaseWorkflow` from one executor monolith into focused payload, idempotency, release identity, side-effect, and activity modules.
- Added `executor/registry-verification` as the typed producer for registry observation, receipt, artifact manifest construction, `Clock` timestamps, and `@kitz/fs` tarball reads.
- Hardened workflow structure tests around graph-only imports, stable public exports, registry verification delegation, and typed `Fs.exists` / `Fs.read` rehearsed-artifact checks.

## Red tests and review
- `workflow.structure.test.ts` failed red before the registry producer/export fixes on direct verification ownership and accidental `tagForRelease` re-export.
- Herschel reviewed for FP, Effect, type safety, simplicity, compactness, durable workflow semantics, idempotency/resume safety, module boundaries, `@kitz/fs`, and public API surface.
- Review findings were resolved, including replacing direct `FileSystem` checks in the prepare activity with typed `@kitz/fs` operations; final closeout had no remaining findings.

## Verification
- `bun run --cwd packages/release test src/api/executor/workflow.structure.test.ts`
- `bun run --cwd packages/release check:types`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-5 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-5 bun run --cwd packages/release check:lint`
- `bun run --cwd packages/release test src/api/executor/workflow.structure.test.ts src/api/executor/_.test.ts src/api/executor/e2e.test.ts src/api/executor/resume.test.ts src/api/executor/graph.test.ts src/api/executor/status.test.ts src/api/workflow.integration.test.ts`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-5 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-5 bun run --cwd packages/release test`
