### PR TITLE
refactor(release): type lock errors and centralize clock

### DIFF
--- a/packages/release/src/api/__.ts
+++ b/packages/release/src/api/__.ts
@@ -47,6 +47,7 @@ export * as Renderer from './renderer/__.js'
 
 // Supporting modules
 export * as CommitPolicy from './commit-policy.js'
+export * as Clock from './clock.js'
 export * as Config from './config.js'
 export * as Digest from './digest.js'
 export * as Doctor from './doctor.js'

--- a/packages/release/src/api/analyzer/models/commit.ts
+++ b/packages/release/src/api/analyzer/models/commit.ts
@@ -81,6 +81,7 @@ const SYNTHETIC_SHA = Git.Sha.make('0000000')
  * Synthetic author for synthetic commits.
  */
 const SYNTHETIC_AUTHOR = Git.Author.make({ name: 'Release', email: 'release@local' })
+const SYNTHETIC_DATE = '1970-01-01T00:00:00.000Z'
 
 /**
  * Create a synthetic ReleaseCommit for cascade releases.
@@ -88,11 +89,15 @@ const SYNTHETIC_AUTHOR = Git.Author.make({ name: 'Release', email: 'release@loca
  * Used when a package needs a release due to dependency updates,
  * not direct commit changes.
  */
-export const makeCascadeCommit = (scope: string, description: string): ReleaseCommit =>
+export const makeCascadeCommit = (
+  scope: string,
+  description: string,
+  date: string = SYNTHETIC_DATE,
+): ReleaseCommit =>
   ReleaseCommit.make({
     hash: SYNTHETIC_SHA,
     author: SYNTHETIC_AUTHOR,
-    date: new Date(),
+    date: new Date(date),
     message: ConventionalCommits.Commit.Single.make({
       type: ConventionalCommits.Type.parse('chore'),
       scopes: [scope],

--- a/packages/release/src/api/clock.ts
+++ b/packages/release/src/api/clock.ts
@@ -1,0 +1,6 @@
+import { Clock as EffectClock, Effect } from 'effect'
+
+export const isoStringFromEpochMillis = (epochMillis: number): string =>
+  new Date(epochMillis).toISOString()
+
+export const nowIso = Effect.map(EffectClock.currentTimeMillis, isoStringFromEpochMillis)

--- a/packages/release/src/api/coverage-low-surface.test.ts
+++ b/packages/release/src/api/coverage-low-surface.test.ts
@@ -340,7 +340,7 @@ describe('release low-surface coverage', () => {
       }),
     )
 
-    const plan = makePlan('official', [], [])
+    const plan = makePlan('official', [], [], '2026-01-01T00:00:00.000Z')
 
     expect(plan.lifecycle).toBe('official')
     expect(plan.releases).toHaveLength(0)

--- a/packages/release/src/api/executor/registry-verification.ts
+++ b/packages/release/src/api/executor/registry-verification.ts
@@ -3,7 +3,8 @@ import { Fs } from '@kitz/fs'
 import { NpmRegistry } from '@kitz/npm-registry'
 import { Pkg } from '@kitz/pkg'
 import { Semver } from '@kitz/semver'
-import { Clock, Effect } from 'effect'
+import { Effect } from 'effect'
+import * as ReleaseClock from '../clock.js'
 import { Digest, sha256Bytes } from '../digest.js'
 import type { PublishDriverId } from '../publishing/models/driver-id.js'
 import {
@@ -34,9 +35,6 @@ export interface RegistryPublicationVerification extends PublishVerificationResu
   readonly observation: RegistryObservation
 }
 
-const isoStringFromEpochMillis = (epochMillis: number): string =>
-  new Date(epochMillis).toISOString()
-
 export const verifyRegistryPublication = (request: RegistryPublicationRequest) =>
   Effect.gen(function* () {
     const env = yield* Env.Env
@@ -60,7 +58,7 @@ export const verifyRegistryPublication = (request: RegistryPublicationRequest) =
       packageName: Pkg.Moniker.parse(request.packageName),
       version: Semver.fromString(request.nextVersion),
       registry: request.registry ?? 'https://registry.npmjs.org/',
-      observedAt: isoStringFromEpochMillis(yield* Clock.currentTimeMillis),
+      observedAt: yield* ReleaseClock.nowIso,
       versionMetadata: observed.versionMetadata,
       distTags: { ...observed.distTags },
       ...(observed.tarballUrl !== undefined ? { tarballUrl: observed.tarballUrl } : {}),
@@ -80,7 +78,7 @@ export const verifyRegistryPublication = (request: RegistryPublicationRequest) =
       planDigest,
       tarballSha256,
       observation,
-      verifiedAt: isoStringFromEpochMillis(yield* Clock.currentTimeMillis),
+      verifiedAt: yield* ReleaseClock.nowIso,
     })
     const artifact = ArtifactManifest.make({
       schemaVersion: 1,

--- a/packages/release/src/api/journal.ts
+++ b/packages/release/src/api/journal.ts
@@ -2,6 +2,7 @@ import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
 import { Resource } from '@kitz/resource'
 import { Effect, FileSystem, Schema } from 'effect'
+import * as ReleaseClock from './clock.js'
 import { sha256Json } from './digest.js'
 import { jsonLinesFile } from './persistence.js'
 import { PlanDigest, SideEffectEntry, type SideEffectKind } from './release-contract.js'
@@ -16,6 +17,10 @@ export interface SideEffectInput {
   readonly planned: Readonly<Record<string, unknown>>
   readonly result: SideEffectEntry['result']
   readonly attemptedAt?: string
+}
+
+type TimedSideEffectInput = SideEffectInput & {
+  readonly attemptedAt: string
 }
 
 const entryDigestInput = (entry: SideEffectEntry): unknown => {
@@ -72,15 +77,17 @@ export const writeEntries = (
 ): Effect.Effect<void, Resource.ResourceError, FileSystem.FileSystem> =>
   journalResource.write(entries, path)
 
-export const makeEntry = (input: SideEffectInput, previous?: SideEffectEntry): SideEffectEntry => {
+export const makeEntry = (
+  input: TimedSideEffectInput,
+  previous?: SideEffectEntry,
+): SideEffectEntry => {
   const planDigest =
     typeof input.planDigest === 'string'
       ? PlanDigest.make({ algorithm: 'sha256', value: input.planDigest })
       : input.planDigest
-  const attemptedAt = input.attemptedAt ?? new Date().toISOString()
   return appendHash(
     {
-      entryId: `${input.kind}:${input.subject}:${input.result}:${attemptedAt}`,
+      entryId: `${input.kind}:${input.subject}:${input.result}:${input.attemptedAt}`,
       planDigest,
       kind: input.kind,
       subject: input.subject,
@@ -91,7 +98,7 @@ export const makeEntry = (input: SideEffectInput, previous?: SideEffectEntry): S
         planned: input.planned,
       }).value,
       planned: input.planned,
-      attemptedAt,
+      attemptedAt: input.attemptedAt,
       result: input.result,
     },
     previous,
@@ -106,7 +113,8 @@ export const appendSideEffect = (
     const path = journalPathFor(env.cwd, input.planDigest)
     const entries = yield* readEntries(path)
     const previous = entries.at(-1)
-    const entry = makeEntry(input, previous)
+    const attemptedAt = input.attemptedAt ?? (yield* ReleaseClock.nowIso)
+    const entry = makeEntry({ ...input, attemptedAt }, previous)
     yield* writeEntries(path, [...entries, entry])
     return entry
   })

--- a/packages/release/src/api/lock.test.ts
+++ b/packages/release/src/api/lock.test.ts
@@ -79,6 +79,9 @@ describe('release execution lock', () => {
     )
 
     expect(Exit.isFailure(result.exit)).toBe(true)
+    const failure = Option.getOrUndefined(Exit.findErrorOption(result.exit))
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toBe('publish failed')
     expect(Option.isNone(result.after)).toBe(true)
   })
 
@@ -102,5 +105,13 @@ describe('release execution lock', () => {
     )
 
     expect(Exit.isFailure(exit)).toBe(true)
+    const failure = Option.getOrUndefined(Exit.findErrorOption(exit))
+    expect(failure).toMatchObject({
+      _tag: 'ActiveReleaseLockError',
+      tags: ['kit', 'release', 'lock'],
+      context: {
+        planDigest: digest.value,
+      },
+    })
   })
 })

--- a/packages/release/src/api/lock.ts
+++ b/packages/release/src/api/lock.ts
@@ -1,12 +1,34 @@
+import { Err } from '@kitz/core'
 import { Env } from '@kitz/env'
 import { Fs } from '@kitz/fs'
 import { Resource } from '@kitz/resource'
-import { Effect, FileSystem, Option } from 'effect'
+import { Effect, FileSystem, Option, Schema as S } from 'effect'
 import { jsonFile } from './persistence.js'
 import { ExecutionLock, type PlanDigest, PrincipalRef } from './release-contract.js'
 
+const baseTags = ['kit', 'release', 'lock'] as const
 const lockDir = Fs.Path.RelDir.fromString('./.release/locks/')
 const lockResource = jsonFile(ExecutionLock)
+
+const ActiveReleaseLockErrorContext = S.Struct({
+  planDigest: S.String,
+  ownerId: S.String,
+  expiresAt: S.String,
+})
+
+export const ActiveReleaseLockError: Err.TaggedContextualErrorClass<
+  'ActiveReleaseLockError',
+  typeof baseTags,
+  typeof ActiveReleaseLockErrorContext,
+  undefined
+> = Err.TaggedContextualError('ActiveReleaseLockError', baseTags, {
+  context: ActiveReleaseLockErrorContext,
+  message: (ctx) => `Active release lock already exists for ${ctx.planDigest}`,
+})
+
+export type ActiveReleaseLockError = InstanceType<typeof ActiveReleaseLockError>
+
+export type LockError = ActiveReleaseLockError
 
 export interface LockIssue {
   readonly code: string
@@ -78,14 +100,24 @@ export const write = (
 
 export const acquireLocal = (
   params: LocalLockParams,
-): Effect.Effect<ExecutionLock, Error | Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
+): Effect.Effect<
+  ExecutionLock,
+  LockError | Resource.ResourceError,
+  Env.Env | FileSystem.FileSystem
+> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
     const path = lockPathFor(env.cwd, params.planDigest)
     const existing = yield* read(path)
     if (Option.isSome(existing) && validate(existing.value, params.now).length === 0) {
       return yield* Effect.fail(
-        new Error(`Active release lock already exists for ${params.planDigest.value}`),
+        new ActiveReleaseLockError({
+          context: {
+            planDigest: params.planDigest.value,
+            ownerId: existing.value.owner.id,
+            expiresAt: existing.value.expiresAt,
+          },
+        }),
       )
     }
     const lock = make({
@@ -119,7 +151,7 @@ export const withLocal = <A, E, R>(
 ): Effect.Effect<
   A,
   // oxlint-disable-next-line kitz/error/require-tagged-error-types -- withLocal preserves the wrapped effect's error channel exactly.
-  E | Error | Resource.ResourceError,
+  E | LockError | Resource.ResourceError,
   R | Env.Env | FileSystem.FileSystem
 > =>
   Effect.gen(function* () {

--- a/packages/release/src/api/planner/candidate.ts
+++ b/packages/release/src/api/planner/candidate.ts
@@ -32,12 +32,14 @@ const detectCascadesForCandidate = (
   primaryReleases: readonly Candidate[],
   dependencyGraph: import('../analyzer/cascade.js').DependencyGraph,
   tags: string[],
+  timestamp: string,
 ): readonly Candidate[] => {
   return mapOfficialCascades({
     packages,
     primaryReleases,
     dependencyGraph,
     tags,
+    timestamp,
     map: (cascade) => toCandidateRelease(cascade, tags),
   })
 }
@@ -79,6 +81,6 @@ export const candidate = (
       })
     },
     toSecondaryRelease: (release) => toCandidateRelease(release, analysis.tags),
-    toCascades: ({ packages, primaryReleases, dependencyGraph, tags }) =>
-      detectCascadesForCandidate(packages, primaryReleases, dependencyGraph, [...tags]),
+    toCascades: ({ packages, primaryReleases, dependencyGraph, tags, timestamp }) =>
+      detectCascadesForCandidate(packages, primaryReleases, dependencyGraph, [...tags], timestamp),
   })

--- a/packages/release/src/api/planner/cascade.ts
+++ b/packages/release/src/api/planner/cascade.ts
@@ -12,6 +12,8 @@ import { OfficialIncrement } from '../version/models/official-increment.js'
 import { Official } from './models/item-official.js'
 import type { Item } from './models/item.js'
 
+const syntheticCommitDate = '1970-01-01T00:00:00.000Z'
+
 /**
  * Result of cascade analysis for a single requested package identifier.
  *
@@ -95,6 +97,7 @@ export const detect = (
   primaryReleases: Item[],
   dependencyGraph: DependencyGraph,
   tags: string[],
+  timestamp: string = syntheticCommitDate,
 ): Official[] => {
   // Set of packages already getting released (use string form for Set/Map operations)
   const releasing = MutableHashSet.fromIterable(primaryReleases.map((r) => r.package.name.moniker))
@@ -149,6 +152,7 @@ export const detect = (
           makeCascadeCommit(
             pkg.scope,
             `Depends on ${primary.package.name.moniker}@${primary.nextVersion.toString()}`,
+            timestamp,
           ),
         )
       }
@@ -156,7 +160,7 @@ export const detect = (
 
     // If no triggers found, add a generic cascade commit
     if (cascadeCommits.length === 0) {
-      cascadeCommits.push(makeCascadeCommit(pkg.scope, 'Cascade release'))
+      cascadeCommits.push(makeCascadeCommit(pkg.scope, 'Cascade release', timestamp))
     }
 
     // Build version union
@@ -201,6 +205,7 @@ export const detectPublishDependencyClosure = (
   packages: readonly Package[],
   plannedItems: readonly Item[],
   tags: readonly string[],
+  timestamp: string = syntheticCommitDate,
 ): Effect.Effect<readonly Official[], Resource.ResourceError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const localPackageNames = packages.map((pkg) => pkg.name.moniker)
@@ -234,7 +239,11 @@ export const detectPublishDependencyClosure = (
         queue.push(dependencyName)
         closureReleases.push(
           makePatchRelease(dependencyPackage, tags, [
-            makeCascadeCommit(dependencyPackage.scope, `Runtime dependency of ${packageName}`),
+            makeCascadeCommit(
+              dependencyPackage.scope,
+              `Runtime dependency of ${packageName}`,
+              timestamp,
+            ),
           ]),
         )
       }

--- a/packages/release/src/api/planner/core.test.ts
+++ b/packages/release/src/api/planner/core.test.ts
@@ -2,7 +2,8 @@ import { Fs } from '@kitz/fs'
 import { Git } from '@kitz/git'
 import { Pkg } from '@kitz/pkg'
 import { Semver } from '@kitz/semver'
-import { Effect, HashMap, Option } from 'effect'
+import { Effect, HashMap, Layer, Option } from 'effect'
+import { TestClock } from 'effect/testing'
 import { describe, expect, test } from 'bun:test'
 import { Env } from '@kitz/env'
 import { Analysis, Impact, makeCascadeCommit } from '../analyzer/models/__.js'
@@ -189,6 +190,18 @@ describe('planner core', () => {
     expect(result.cascades.every((release) => release.nextVersion.toString() === '0.0.1')).toBe(
       true,
     )
+  })
+
+  test('plans read timestamps from Effect Clock', async () => {
+    const timestamp = '2026-05-14T01:02:03.000Z'
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(timestamp))
+        return yield* official(singleImpactAnalysis, { packages })
+      }).pipe(Effect.provide(Layer.mergeAll(workspaceLayer, TestClock.layer()))),
+    )
+
+    expect(result.timestamp).toBe(timestamp)
   })
 
   test('candidate planning preserves candidate typing and remaps cascade iterations', async () => {

--- a/packages/release/src/api/planner/core.ts
+++ b/packages/release/src/api/planner/core.ts
@@ -1,6 +1,7 @@
 import { FileSystem } from 'effect'
 import { Resource } from '@kitz/resource'
 import { Effect } from 'effect'
+import * as ReleaseClock from '../clock.js'
 import { buildDependencyGraph, type DependencyGraph } from '../analyzer/cascade.js'
 import type { Analysis, Impact } from '../analyzer/models/__.js'
 import type { Package } from '../analyzer/workspace.js'
@@ -22,6 +23,7 @@ interface CascadeParams<$lifecycle extends Lifecycle> {
   readonly primaryReleases: readonly PlannedItem<$lifecycle>[]
   readonly dependencyGraph: DependencyGraph
   readonly tags: readonly string[]
+  readonly timestamp: string
 }
 
 export interface PlanLifecycleParams<
@@ -45,6 +47,7 @@ export const mapOfficialCascades = <
   readonly primaryReleases: readonly $release[]
   readonly dependencyGraph: DependencyGraph
   readonly tags: readonly string[]
+  readonly timestamp: string
   readonly map: (cascade: Official) => $cascade
 }): readonly $cascade[] =>
   detectOfficialCascades(
@@ -52,6 +55,7 @@ export const mapOfficialCascades = <
     [...params.primaryReleases],
     params.dependencyGraph,
     [...params.tags],
+    params.timestamp,
   ).map(params.map)
 
 export const planLifecycle = <
@@ -61,6 +65,7 @@ export const planLifecycle = <
   params: PlanLifecycleParams<$lifecycle, $options>,
 ): Effect.Effect<PlanOf<$lifecycle>, Resource.ResourceError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
+    const timestamp = yield* ReleaseClock.nowIso
     const releases: PlannedItem<$lifecycle>[] = []
 
     for (const impact of params.analysis.impacts) {
@@ -74,15 +79,19 @@ export const planLifecycle = <
       primaryReleases: releases,
       dependencyGraph,
       tags: [...params.analysis.tags],
+      timestamp,
     })
     const dependencyReleases = yield* detectPublishDependencyClosure(
       [...params.packages],
       [...releases, ...cascades],
       [...params.analysis.tags],
+      timestamp,
     )
 
-    return make(params.lifecycle, releases, [
-      ...cascades,
-      ...dependencyReleases.map(params.toSecondaryRelease),
-    ])
+    return make(
+      params.lifecycle,
+      releases,
+      [...cascades, ...dependencyReleases.map(params.toSecondaryRelease)],
+      timestamp,
+    )
   })

--- a/packages/release/src/api/planner/ephemeral.ts
+++ b/packages/release/src/api/planner/ephemeral.ts
@@ -40,6 +40,7 @@ const detectCascadesForEphemeral = (
   primaryReleases: readonly Ephemeral[],
   dependencyGraph: import('../analyzer/cascade.js').DependencyGraph,
   tags: string[],
+  timestamp: string,
   prNumber: number,
   sha: Git.Sha.Sha,
 ): readonly Ephemeral[] => {
@@ -48,6 +49,7 @@ const detectCascadesForEphemeral = (
     primaryReleases,
     dependencyGraph,
     tags,
+    timestamp,
     map: (cascade) => toEphemeralRelease(cascade, tags, prNumber, sha),
   })
 }
@@ -125,12 +127,13 @@ export const ephemeral = (
         })
       },
       toSecondaryRelease: (release) => toEphemeralRelease(release, analysis.tags, prNumber, sha),
-      toCascades: ({ packages, primaryReleases, dependencyGraph, tags }) =>
+      toCascades: ({ packages, primaryReleases, dependencyGraph, tags, timestamp }) =>
         detectCascadesForEphemeral(
           packages,
           primaryReleases,
           dependencyGraph,
           [...tags],
+          timestamp,
           prNumber,
           sha,
         ),

--- a/packages/release/src/api/planner/models/plan.ts
+++ b/packages/release/src/api/planner/models/plan.ts
@@ -173,11 +173,12 @@ export const make = <$lifecycle extends Lifecycle>(
   lifecycle: $lifecycle,
   releases: PlannedItem<$lifecycle>[],
   cascades: PlannedItem<$lifecycle>[],
+  timestamp: string,
 ): PlanOf<$lifecycle> =>
   assertLifecycleConsistency(
     Plan.make({
       lifecycle,
-      timestamp: new Date().toISOString(),
+      timestamp,
       releases: [...releases],
       cascades: [...cascades],
     }),

--- a/packages/release/src/api/planner/official.ts
+++ b/packages/release/src/api/planner/official.ts
@@ -57,6 +57,6 @@ export const official = (
       })
     },
     toSecondaryRelease: (release) => release,
-    toCascades: ({ packages, primaryReleases, dependencyGraph, tags }) =>
-      detectCascades(packages, [...primaryReleases], dependencyGraph, [...tags]),
+    toCascades: ({ packages, primaryReleases, dependencyGraph, tags, timestamp }) =>
+      detectCascades(packages, [...primaryReleases], dependencyGraph, [...tags], timestamp),
   })

--- a/packages/release/src/api/planner/resource.ts
+++ b/packages/release/src/api/planner/resource.ts
@@ -30,7 +30,7 @@ export const PLANS_DIR = Fs.Path.fromString('./.release/plans/')
  * @example
  * ```ts
  * // Create and write a plan
- * const plan = Plan.make('official', releases, cascades)
+ * const plan = Plan.make('official', releases, cascades, timestamp)
  * yield* resource.write(plan, releaseDir)
  *
  * // Read a plan directly

--- a/packages/release/src/api/proof.test.ts
+++ b/packages/release/src/api/proof.test.ts
@@ -167,7 +167,7 @@ const gitLayer = (overrides: Partial<Git.GitService>): Layer.Layer<Git.Git> =>
 
 describe('proof artifact', () => {
   test('uncontracted plans produce blocking proof records', () => {
-    const proof = makeProofArtifact(plan)
+    const proof = makeProofArtifact(plan, '2026-05-13T00:00:00.000Z')
 
     expect(proof.records.map((record) => record.status)).toContain('unprovable')
     expect(proof.records.some((record) => record.dependsOn.includes('plan.digest'))).toBe(true)

--- a/packages/release/src/api/proof.ts
+++ b/packages/release/src/api/proof.ts
@@ -5,7 +5,8 @@ import { Github } from '@kitz/github'
 import { NpmRegistry } from '@kitz/npm-registry'
 import { Pkg } from '@kitz/pkg'
 import { Resource } from '@kitz/resource'
-import { Array as A, Clock, Effect, FileSystem, Option, Result, Schema } from 'effect'
+import { Array as A, Effect, FileSystem, Option, Result, Schema } from 'effect'
+import * as ReleaseClock from './clock.js'
 import { sha256Json } from './digest.js'
 import { jsonFile } from './persistence.js'
 import type { Plan } from './planner/models/plan.js'
@@ -516,7 +517,7 @@ const provenanceRecordForPlan = (
 
 export const makeProofArtifact = (
   plan: Plan,
-  now: string = new Date().toISOString(),
+  now: string,
   observations: ProofObservations = {},
 ): ProofArtifact => {
   const observedAt = observations.now ?? now
@@ -700,12 +701,10 @@ export const collectGithubObservations = (
     return Object.keys(githubReleaseExists).length > 0 ? { githubReleaseExists } : {}
   })
 
-export const hasBlockingProof = (proof: ProofArtifact): boolean => validateProof(proof).length > 0
+export const hasBlockingProof = (proof: ProofArtifact, now: string): boolean =>
+  validateProof(proof, now).length > 0
 
-export const validateProof = (
-  proof: ProofArtifact,
-  now: string = new Date().toISOString(),
-): readonly ProofIssue[] => {
+export const validateProof = (proof: ProofArtifact, now: string): readonly ProofIssue[] => {
   const ids = A.map(proof.records, (record) => record.id)
   const blocking = A.map(
     A.filter(
@@ -762,8 +761,8 @@ export const prove = (
 ): Effect.Effect<ProofArtifact, Resource.ResourceError, Env.Env | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const env = yield* Env.Env
-    const now = yield* Clock.currentTimeMillis
-    const proof = makeProofArtifact(plan, new Date(now).toISOString(), observations)
+    const now = yield* ReleaseClock.nowIso
+    const proof = makeProofArtifact(plan, now, observations)
     yield* write(proof, proofPathFor(env.cwd, plan))
     return proof
   })

--- a/packages/release/src/api/time-boundary.test.ts
+++ b/packages/release/src/api/time-boundary.test.ts
@@ -1,0 +1,74 @@
+import { Fs } from '@kitz/fs'
+import { Test } from '@kitz/test'
+import { describe, expect } from 'bun:test'
+import { Effect, type FileSystem, type PlatformError } from 'effect'
+import { FileSystemLayer } from '../platform.js'
+
+const sourceRoot = Fs.Path.AbsDir.fromString(new URL('../', import.meta.url).pathname)
+const sourceRootPath = sourceRoot.toString()
+
+const forbiddenTimeReads = [
+  {
+    pattern: /\bnew\s+Date\s*\(\s*\)|\bDate\.now\s*\(\s*\)/gu,
+    allowedIn: () => false,
+  },
+  {
+    pattern:
+      /\b(?:Clock|EffectClock)\.currentTimeMillis\b|import\s*\{[^}]*\bClock\b[^}]*\}\s*from\s*['"]effect['"]/gu,
+    allowedIn: (file: string) => file === 'api/clock.ts',
+  },
+] as const
+
+interface SourceFile {
+  readonly name: string
+  readonly source: string
+}
+
+const sourceFiles = (
+  dir: Fs.Path.AbsDir,
+): Effect.Effect<readonly SourceFile[], PlatformError.PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const entries = yield* Fs.read(dir)
+    const groups = yield* Effect.all(
+      entries.map((entry) =>
+        Effect.gen(function* () {
+          if (Fs.Path.AbsDir.is(entry)) return yield* sourceFiles(entry)
+          if (!Fs.Path.AbsFile.is(entry)) return []
+
+          const name = entry.toString().slice(sourceRootPath.length)
+          if (!name.endsWith('.ts') && !name.endsWith('.tsx')) return []
+          if (name.endsWith('.test.ts') || name.endsWith('.test.tsx')) return []
+
+          return [
+            {
+              name,
+              source: yield* Fs.readString(entry),
+            },
+          ]
+        }),
+      ),
+    )
+
+    return groups.flat()
+  })
+
+const lineForIndex = (source: string, index: number): number =>
+  source.slice(0, index).split('\n').length
+
+describe('release time boundary', () => {
+  Test.effect('production code reads wall-clock time through the release clock boundary', () =>
+    Effect.gen(function* () {
+      const offenders = (yield* sourceFiles(sourceRoot)).flatMap((file) =>
+        forbiddenTimeReads.flatMap((read) =>
+          read.allowedIn(file.name)
+            ? []
+            : [...file.source.matchAll(read.pattern)].map(
+                (match) => `${file.name}:${lineForIndex(file.source, match.index)}: ${match[0]}`,
+              ),
+        ),
+      )
+
+      expect(offenders).toEqual([])
+    }).pipe(Effect.provide(FileSystemLayer)),
+  )
+})

--- a/packages/release/src/cli/commands/apply.ts
+++ b/packages/release/src/cli/commands/apply.ts
@@ -80,13 +80,14 @@ export const apply = Command.make(
       }
       const publish = Api.Publishing.publishSemanticsFromIntent(intentResult.success)
       const planDigest = executablePlan.planDigest
+      const lockNow = yield* Api.Clock.nowIso
 
       const lockParams = {
         planDigest,
         ownerId: env.vars['USER'] ?? 'local-operator',
         ownerHost: env.vars['HOST'] ?? env.vars['HOSTNAME'] ?? 'local-host',
         ownerProcess: env.vars['KITZ_RELEASE_PROCESS_ID'] ?? 'local-process',
-        now: new Date().toISOString(),
+        now: lockNow,
       } satisfies Api.Lock.LocalLockParams
 
       // Confirmation prompt (unless --yes)
@@ -131,7 +132,7 @@ export const apply = Command.make(
               ...localObservations,
               ...githubObservations,
             })
-            if (Api.Proof.hasBlockingProof(proof)) {
+            if (Api.Proof.hasBlockingProof(proof, yield* Api.Clock.nowIso)) {
               yield* Console.error(
                 'Plan proof contains blocking records. Run `release prove` for detail.',
               )
@@ -151,7 +152,7 @@ export const apply = Command.make(
             )
             return false
           }
-          if (Api.Proof.hasBlockingProof(proof.value)) {
+          if (Api.Proof.hasBlockingProof(proof.value, yield* Api.Clock.nowIso)) {
             yield* Console.error('Plan-bound proof contains blocking records.')
             yield* Console.error(
               'Run `release prove` and resolve every failed or unprovable proof.',

--- a/packages/release/src/cli/commands/archive.ts
+++ b/packages/release/src/cli/commands/archive.ts
@@ -35,9 +35,10 @@ const archiveExport = Command.make(
         env.cwd,
         Fs.Path.RelFile.fromString(`./.release/archive/${digest.value}.kitz-release-audit.tgz`),
       )
+      const createdAt = yield* Api.Clock.nowIso
       const bundle = Api.AuditArchive.makeAuditArchive({
         planDigest: digest,
-        createdAt: new Date().toISOString(),
+        createdAt,
         payloads: [
           {
             path: Fs.Path.RelFile.fromString('./plan.json'),

--- a/packages/release/src/cli/commands/prove.ts
+++ b/packages/release/src/cli/commands/prove.ts
@@ -49,7 +49,7 @@ export const prove = Command.make(
       for (const record of proof.records) {
         yield* Console.log(`${record.status.padEnd(14)} ${record.id}`)
       }
-      if (Api.Proof.hasBlockingProof(proof)) return env.exit(1)
+      if (Api.Proof.hasBlockingProof(proof, yield* Api.Clock.nowIso)) return env.exit(1)
     }),
 ).pipe(
   Command.withDescription('Write plan-bound publishing proof'),

--- a/packages/release/src/promise-api.test.ts
+++ b/packages/release/src/promise-api.test.ts
@@ -63,7 +63,9 @@ describe('release promise api', () => {
     })
 
     expect(digestPlan(plan).algorithm).toBe('sha256')
-    expect(validateProof(proof).map((issue) => issue.code)).toContain('release.proof.unprovable')
+    expect(validateProof(proof, '2026-05-14T00:00:00.000Z').map((issue) => issue.code)).toContain(
+      'release.proof.unprovable',
+    )
     expect(inspectLegitimacy({ onRegistry: true, inJournal: true })).toBe(
       'registry-matches-journal',
     )


### PR DESCRIPTION
Part of #259, Item 8.

## Summary

- Add `Api.Clock` as the single release wall-clock boundary over Effect `Clock`.
- Thread explicit timestamps into release plans, proof validation/artifacts, journals, registry verification, archive/apply/prove command paths, and cascade synthetic commits.
- Replace raw active-lock `Error` failures with a schema-backed tagged `ActiveReleaseLockError` while preserving wrapped operation errors from `Api.Lock.withLocal`.
- Add a source guard that fails on direct zero-arg wall-clock reads and direct Effect clock usage outside the release clock boundary.

## Red tests captured

- `packages/release/src/api/lock.test.ts` expected active local lock acquisition to fail with `_tag: ActiveReleaseLockError`, tags, and lock context; it initially failed on raw `Error`.
- `packages/release/src/api/time-boundary.test.ts` initially failed on production `new Date()` reads in planner/proof/journal/analyzer/CLI code.
- `packages/release/src/api/planner/core.test.ts` used `TestClock` and initially showed plan timestamps still came from the real wall clock.

## Review

- Hooke reviewed the unstaged diff for FP, Effect correctness, type safety, simplicity, and compactness: no findings.
- Hooke noted the source guard did not block direct Effect clock imports outside `api/clock.ts`; this PR strengthens the guard to cover that case too.

## Verification

- `bun run --cwd packages/release test src/api/time-boundary.test.ts src/api/planner/core.test.ts src/api/lock.test.ts`
- `bun run --cwd packages/release test`
- `bun run --cwd packages/release check:types`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-6 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-6 bun run --cwd packages/release check:lint`
- `bun tools/run-format.ts --check packages/release/src/api/time-boundary.test.ts`
- `git diff --check`
