### PR TITLE
test(release): compact artifact and executor fixtures

### DIFF
--- a/packages/release/src/api/artifact.test.ts
+++ b/packages/release/src/api/artifact.test.ts
@@ -51,6 +51,12 @@ const pkg = {
   scope: 'core',
   path: Fs.Path.AbsDir.fromString('/repo/packages/core/'),
 }
+const corePackageJsonPath = '/repo/packages/core/package.json'
+const coreManifest = (options?: Parameters<typeof makePackageJson>[2]) =>
+  makePackageJson('@kitz/core', '1.0.0', options)
+const coreDisk = (content = coreManifest()): Fs.Memory.DiskLayout => ({
+  [corePackageJsonPath]: content,
+})
 
 const tarball = Fs.Path.AbsFile.fromString('/repo/.release/artifacts/kitz-core-1.0.0.tgz')
 const tarballBytes = new Uint8Array([1, 2, 3, 4])
@@ -89,6 +95,21 @@ const contractedPlan = Plan.make({
   }),
 })
 
+const sourceSnapshot = PlanSourceSnapshot.make({
+  headSha: 'abc1234',
+  trunk: 'main',
+  releaseConfigDigest: sha256Text('config'),
+  releaseConfigDigestSource: 'canonical-effective-config',
+  lockfiles: [],
+  packageManager: {
+    name: 'bun',
+    version: '1.3.6',
+    binary: 'bun',
+    subcommands: { pack: true, publish: true },
+  },
+  toolVersions: { node: '22.14.0', bun: '1.3.6' },
+})
+
 const updatePublishIntent = (intent: PublishIntent, overrides: Partial<PublishIntent>) =>
   PublishIntent.make(Object.assign({}, intent, overrides))
 
@@ -100,6 +121,84 @@ const updateScriptPolicy = (policy: ScriptPolicy, overrides: Partial<ScriptPolic
 
 const updateArtifactManifest = (manifest: ArtifactManifest, overrides: Partial<ArtifactManifest>) =>
   ArtifactManifest.make(Object.assign({}, manifest, overrides))
+
+const makeContractedPlan = ({
+  source,
+  publishIntent = contractedPlan.publishIntent!,
+}: {
+  readonly source?: PlanSourceSnapshot
+  readonly publishIntent?: PublishIntent
+} = {}) =>
+  Plan.make({
+    lifecycle: contractedPlan.lifecycle,
+    timestamp: contractedPlan.timestamp,
+    releases: contractedPlan.releases,
+    cascades: contractedPlan.cascades,
+    ...(source === undefined ? {} : { source }),
+    publishIntent,
+  })
+
+const updateContractedArtifactPolicy = (overrides: Partial<ArtifactPolicy>): PublishIntent =>
+  updatePublishIntent(contractedPlan.publishIntent!, {
+    artifacts: updateArtifactPolicy(contractedPlan.publishIntent!.artifacts, overrides),
+  })
+
+const updateContractedScriptPolicy = (overrides: Partial<ScriptPolicy>): PublishIntent =>
+  updateContractedArtifactPolicy({
+    scriptPolicy: updateScriptPolicy(
+      contractedPlan.publishIntent!.artifacts.scriptPolicy,
+      overrides,
+    ),
+  })
+
+const updateContractedEnginePolicy = (
+  overrides: Parameters<typeof EnginePolicy.make>[0],
+): PublishIntent =>
+  updateContractedArtifactPolicy({
+    enginePolicy: EnginePolicy.make(overrides),
+  })
+
+const issueCodes = (issues: readonly { readonly code: string }[]) =>
+  issues.map((issue) => issue.code)
+
+const engineIssueCodes = (releasePlan: Plan, diskLayout: Fs.Memory.DiskLayout) =>
+  Effect.runPromise(
+    validateEnginePolicyForPlan(releasePlan).pipe(
+      Effect.provide(Fs.Memory.layer(diskLayout)),
+      Effect.map(issueCodes),
+    ),
+  )
+
+const scriptIssueCodes = (releasePlan: Plan, packageJson: string) =>
+  Effect.runPromise(
+    validateScriptPolicyForPlan(releasePlan).pipe(
+      Effect.provide(Fs.Memory.layer(coreDisk(packageJson))),
+      Effect.map(issueCodes),
+    ),
+  )
+
+const allowlistedPrepackPlan = (network: ScriptPolicy['network']) => {
+  const command = 'echo preparing'
+  const packageJson = coreManifest({ scripts: { prepack: command } })
+
+  return {
+    packageJson,
+    plan: makeContractedPlan({
+      publishIntent: updateContractedScriptPolicy({
+        default: 'allow-listed',
+        network,
+        allowlist: [
+          {
+            packageName: Pkg.Moniker.parse('@kitz/core'),
+            script: 'prepack',
+            commandSha256: sha256Text(command),
+            packageSourceDigest: sha256Text(packageJson),
+          },
+        ],
+      }),
+    }),
+  }
+}
 
 const artifact = {
   package: pkg,
@@ -124,9 +223,7 @@ const coreGit = {
   isClean: true,
 }
 
-const coreDiskLayout = {
-  '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-}
+const coreDiskLayout = coreDisk()
 
 const makeCoreHarness = (params?: {
   readonly diskLayout?: Fs.Memory.DiskLayout
@@ -458,21 +555,10 @@ describe('artifact manifest', () => {
   })
 
   test('rejects disallowed lifecycle scripts before rehearsal can pack artifacts', async () => {
-    const issues = await Effect.runPromise(
-      validateScriptPolicyForPlan(contractedPlan).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-              scripts: { prepack: 'echo preparing' },
-            }),
-          }),
-        ),
-      ),
-    )
+    const packageJson = coreManifest({ scripts: { prepack: 'echo preparing' } })
+    const issues = await scriptIssueCodes(contractedPlan, packageJson)
 
-    expect(issues.map((issue) => issue.code)).toEqual([
-      'release.artifact.lifecycle-script-disallowed',
-    ])
+    expect(issues).toEqual(['release.artifact.lifecycle-script-disallowed'])
 
     const rehearseError = await Effect.runPromise(
       rehearse(contractedPlan).pipe(
@@ -480,11 +566,7 @@ describe('artifact manifest', () => {
         Effect.provide(
           Layer.mergeAll(
             Env.Test({ cwd: Fs.Path.AbsDir.fromString('/repo/') }),
-            Fs.Memory.layer({
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-                scripts: { prepack: 'echo preparing' },
-              }),
-            }),
+            Fs.Memory.layer(coreDisk(packageJson)),
             Layer.succeed(NpmRegistry.NpmCli, {
               whoami: () => Effect.die('unexpected whoami'),
               pack: () => Effect.die('unexpected pack'),
@@ -508,262 +590,75 @@ describe('artifact manifest', () => {
   })
 
   test('accepts lifecycle scripts only when command and package source digests match', async () => {
-    const packageJson = makePackageJson('@kitz/core', '1.0.0', {
-      scripts: { prepack: 'echo preparing' },
-    })
-    const baseIntent = contractedPlan.publishIntent!
-    const publishIntent = updatePublishIntent(baseIntent, {
-      artifacts: updateArtifactPolicy(baseIntent.artifacts, {
-        scriptPolicy: updateScriptPolicy(baseIntent.artifacts.scriptPolicy, {
-          default: 'allow-listed',
-          network: 'declared-deny',
-          allowlist: [
-            {
-              packageName: Pkg.Moniker.parse('@kitz/core'),
-              script: 'prepack',
-              commandSha256: sha256Text('echo preparing'),
-              packageSourceDigest: sha256Text(packageJson),
-            },
-          ],
-        }),
-      }),
-    })
-    const allowedPlan = Plan.make({
-      lifecycle: contractedPlan.lifecycle,
-      timestamp: contractedPlan.timestamp,
-      releases: contractedPlan.releases,
-      cascades: contractedPlan.cascades,
-      publishIntent,
-    })
+    const { packageJson, plan } = allowlistedPrepackPlan('declared-deny')
 
-    const issues = await Effect.runPromise(
-      validateScriptPolicyForPlan(allowedPlan).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': packageJson,
-          }),
-        ),
-      ),
-    )
-
-    expect(issues).toEqual([])
+    expect(await scriptIssueCodes(plan, packageJson)).toEqual([])
   })
 
   test('allowlisted lifecycle scripts still require an explicit network-denial answer', async () => {
-    const packageJson = makePackageJson('@kitz/core', '1.0.0', {
-      scripts: { prepack: 'echo preparing' },
-    })
-    const baseIntent = contractedPlan.publishIntent!
-    const publishIntent = updatePublishIntent(baseIntent, {
-      artifacts: updateArtifactPolicy(baseIntent.artifacts, {
-        scriptPolicy: updateScriptPolicy(baseIntent.artifacts.scriptPolicy, {
-          default: 'allow-listed',
-          network: 'deny-enforced',
-          allowlist: [
-            {
-              packageName: Pkg.Moniker.parse('@kitz/core'),
-              script: 'prepack',
-              commandSha256: sha256Text('echo preparing'),
-              packageSourceDigest: sha256Text(packageJson),
-            },
-          ],
-        }),
-      }),
-    })
-    const allowlistedPlan = Plan.make({
-      lifecycle: contractedPlan.lifecycle,
-      timestamp: contractedPlan.timestamp,
-      releases: contractedPlan.releases,
-      cascades: contractedPlan.cascades,
-      publishIntent,
-    })
+    const { packageJson, plan } = allowlistedPrepackPlan('deny-enforced')
 
-    const issues = await Effect.runPromise(
-      validateScriptPolicyForPlan(allowlistedPlan).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': packageJson,
-          }),
-        ),
-      ),
-    )
-
-    expect(issues.map((issue) => issue.code)).toEqual([
+    expect(await scriptIssueCodes(plan, packageJson)).toEqual([
       'release.artifact.network-denial-unprovable',
     ])
   })
 
   test('enforces engine and package-manager policy before artifact construction', async () => {
-    const source = PlanSourceSnapshot.make({
-      headSha: 'abc1234',
-      trunk: 'main',
-      releaseConfigDigest: sha256Text('config'),
-      releaseConfigDigestSource: 'canonical-effective-config',
-      lockfiles: [],
-      packageManager: {
-        name: 'bun',
-        version: '1.3.6',
-        binary: 'bun',
-        subcommands: { pack: true, publish: true },
-      },
-      toolVersions: { node: '22.14.0', bun: '1.3.6' },
-    })
-    const strictPlan = Plan.make({
-      lifecycle: contractedPlan.lifecycle,
-      timestamp: contractedPlan.timestamp,
-      releases: contractedPlan.releases,
-      cascades: contractedPlan.cascades,
-      source,
-      publishIntent: updatePublishIntent(contractedPlan.publishIntent!, {
-        artifacts: updateArtifactPolicy(contractedPlan.publishIntent!.artifacts, {
-          enginePolicy: EnginePolicy.make({
-            node: 'match-runtime',
-            packageManager: 'match-plan',
-          }),
-        }),
+    const strictPlan = makeContractedPlan({
+      source: sourceSnapshot,
+      publishIntent: updateContractedEnginePolicy({
+        node: 'match-runtime',
+        packageManager: 'match-plan',
       }),
     })
 
-    const issues = await Effect.runPromise(
-      validateEnginePolicyForPlan(strictPlan).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-              engines: { node: '20.0.0' },
-              packageManager: 'pnpm@11.0.0',
-            }),
-          }),
-        ),
-      ),
+    const issues = await engineIssueCodes(
+      strictPlan,
+      coreDisk(coreManifest({ engines: { node: '20.0.0' }, packageManager: 'pnpm@11.0.0' })),
     )
 
-    expect(issues.map((issue) => issue.code)).toEqual([
+    expect(issues).toEqual([
       'release.artifact.engine-node-mismatch',
       'release.artifact.package-manager-mismatch',
     ])
 
-    const compatiblePlan = Plan.make({
-      lifecycle: strictPlan.lifecycle,
-      timestamp: strictPlan.timestamp,
-      releases: strictPlan.releases,
-      cascades: strictPlan.cascades,
-      source,
-      publishIntent: updatePublishIntent(strictPlan.publishIntent!, {
-        artifacts: updateArtifactPolicy(strictPlan.publishIntent!.artifacts, {
-          enginePolicy: EnginePolicy.make({
-            node: 'allow-compatible-range',
-            packageManager: 'allow-compatible-range',
-          }),
+    const compatibleIssues = await engineIssueCodes(
+      makeContractedPlan({
+        source: sourceSnapshot,
+        publishIntent: updateContractedEnginePolicy({
+          node: 'allow-compatible-range',
+          packageManager: 'allow-compatible-range',
         }),
       }),
-    })
-    const compatibleIssues = await Effect.runPromise(
-      validateEnginePolicyForPlan(compatiblePlan).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-              engines: { node: '>=22.0.0' },
-              packageManager: 'bun@^1.3.0',
-            }),
-          }),
-        ),
-      ),
+      coreDisk(coreManifest({ engines: { node: '>=22.0.0' }, packageManager: 'bun@^1.3.0' })),
     )
 
     expect(compatibleIssues).toEqual([])
   })
 
   test('reports all engine policy input failures before pack can run', async () => {
-    const source = PlanSourceSnapshot.make({
-      headSha: 'abc1234',
-      trunk: 'main',
-      releaseConfigDigest: sha256Text('config'),
-      releaseConfigDigestSource: 'canonical-effective-config',
-      lockfiles: [],
-      packageManager: {
-        name: 'bun',
-        version: '1.3.6',
-        binary: 'bun',
-        subcommands: { pack: true, publish: true },
-      },
-      toolVersions: { node: '22.14.0', bun: '1.3.6' },
-    })
-    const strictPlan = Plan.make({
-      lifecycle: contractedPlan.lifecycle,
-      timestamp: contractedPlan.timestamp,
-      releases: contractedPlan.releases,
-      cascades: contractedPlan.cascades,
-      source,
-      publishIntent: contractedPlan.publishIntent!,
-    })
-
-    const unreadable = await Effect.runPromise(
-      validateEnginePolicyForPlan(strictPlan).pipe(Effect.provide(Fs.Memory.layer({}))),
+    const strictPlan = makeContractedPlan({ source: sourceSnapshot })
+    const unreadable = await engineIssueCodes(strictPlan, {})
+    const malformed = await engineIssueCodes(strictPlan, coreDisk('{bad json'))
+    const missingSource = await engineIssueCodes(
+      makeContractedPlan(),
+      coreDisk(coreManifest({ engines: { node: '22.14.0' }, packageManager: 'bun@1.3.6' })),
     )
-    const malformed = await Effect.runPromise(
-      validateEnginePolicyForPlan(strictPlan).pipe(
-        Effect.provide(Fs.Memory.layer({ '/repo/packages/core/package.json': '{bad json' })),
-      ),
-    )
-    const missingSource = await Effect.runPromise(
-      validateEnginePolicyForPlan(
-        Plan.make({
-          lifecycle: strictPlan.lifecycle,
-          timestamp: strictPlan.timestamp,
-          releases: strictPlan.releases,
-          cascades: strictPlan.cascades,
-          publishIntent: strictPlan.publishIntent!,
+    const invalidComparable = await engineIssueCodes(
+      makeContractedPlan({
+        source: sourceSnapshot,
+        publishIntent: updateContractedEnginePolicy({
+          node: 'allow-compatible-range',
+          packageManager: 'allow-compatible-range',
         }),
-      ).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-              engines: { node: '22.14.0' },
-              packageManager: 'bun@1.3.6',
-            }),
-          }),
-        ),
+      }),
+      coreDisk(
+        coreManifest({ engines: { node: 'not-a-range' }, packageManager: 'bun@not-a-range' }),
       ),
     )
-    const invalidComparable = await Effect.runPromise(
-      validateEnginePolicyForPlan(
-        Plan.make({
-          lifecycle: strictPlan.lifecycle,
-          timestamp: strictPlan.timestamp,
-          releases: strictPlan.releases,
-          cascades: strictPlan.cascades,
-          source,
-          publishIntent: updatePublishIntent(strictPlan.publishIntent!, {
-            artifacts: updateArtifactPolicy(strictPlan.publishIntent!.artifacts, {
-              enginePolicy: EnginePolicy.make({
-                node: 'allow-compatible-range',
-                packageManager: 'allow-compatible-range',
-              }),
-            }),
-          }),
-        }),
-      ).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-              engines: { node: 'not-a-range' },
-              packageManager: 'bun@not-a-range',
-            }),
-          }),
-        ),
-      ),
-    )
-    const invalidStrict = await Effect.runPromise(
-      validateEnginePolicyForPlan(strictPlan).pipe(
-        Effect.provide(
-          Fs.Memory.layer({
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-              engines: { node: 'not-a-semver' },
-              packageManager: 'bun',
-            }),
-          }),
-        ),
-      ),
+    const invalidStrict = await engineIssueCodes(
+      strictPlan,
+      coreDisk(coreManifest({ engines: { node: 'not-a-semver' }, packageManager: 'bun' })),
     )
     const rehearseError = await Effect.runPromise(
       rehearse(strictPlan).pipe(
@@ -771,11 +666,7 @@ describe('artifact manifest', () => {
         Effect.provide(
           Layer.mergeAll(
             Env.Test({ cwd: Fs.Path.AbsDir.fromString('/repo/') }),
-            Fs.Memory.layer({
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
-                engines: { node: '20.0.0' },
-              }),
-            }),
+            Fs.Memory.layer(coreDisk(coreManifest({ engines: { node: '20.0.0' } }))),
             Layer.succeed(NpmRegistry.NpmCli, {
               whoami: () => Effect.die('unexpected whoami'),
               pack: () => Effect.die('unexpected pack'),
@@ -791,21 +682,17 @@ describe('artifact manifest', () => {
       ),
     )
 
-    expect(unreadable.map((issue) => issue.code)).toEqual([
-      'release.artifact.package-json-unreadable',
-    ])
-    expect(malformed.map((issue) => issue.code)).toEqual([
-      'release.artifact.package-json-malformed',
-    ])
-    expect(missingSource.map((issue) => issue.code)).toEqual([
+    expect(unreadable).toEqual(['release.artifact.package-json-unreadable'])
+    expect(malformed).toEqual(['release.artifact.package-json-malformed'])
+    expect(missingSource).toEqual([
       'release.artifact.engine-policy-source-missing',
       'release.artifact.package-manager-mismatch',
     ])
-    expect(invalidComparable.map((issue) => issue.code)).toEqual([
+    expect(invalidComparable).toEqual([
       'release.artifact.engine-node-mismatch',
       'release.artifact.package-manager-mismatch',
     ])
-    expect(invalidStrict.map((issue) => issue.code)).toEqual([
+    expect(invalidStrict).toEqual([
       'release.artifact.engine-node-mismatch',
       'release.artifact.package-manager-mismatch',
     ])

--- a/packages/release/src/api/executor/e2e.test.ts
+++ b/packages/release/src/api/executor/e2e.test.ts
@@ -720,45 +720,44 @@ const traceFromExecutionGraph = (graph: ExecutionGraph) =>
 
 // These scenarios run real pack/publish-style workflow steps and need CI headroom.
 const E2E_TEST_TIMEOUT_MS = 90_000
+const testE2E = <Error>(name: string, effect: () => Effect.Effect<void, Error, Scope.Scope>) =>
+  Test.live(name, () => quiet(effect()), E2E_TEST_TIMEOUT_MS)
 
 describe('Executor e2e', () => {
-  Test.live(
-    'renders the release workflow as an otel trace snapshot',
-    () =>
-      quiet(
-        Effect.gen(function* () {
-          const harness = yield* makeRealHarness({
-            packages: [
-              { name: '@kitz/a' },
-              { name: '@kitz/b', dependencies: { '@kitz/a': 'workspace:^' } },
-            ],
-            commits: [Git.Memory.commit('feat(a): add feature')],
-          })
+  testE2E('renders the release workflow as an otel trace snapshot', () =>
+    Effect.gen(function* () {
+      const harness = yield* makeRealHarness({
+        packages: [
+          { name: '@kitz/a' },
+          { name: '@kitz/b', dependencies: { '@kitz/a': 'workspace:^' } },
+        ],
+        commits: [Git.Memory.commit('feat(a): add feature')],
+      })
 
-          const plan = yield* planOfficial(harness.workspacePackages).pipe(
-            Effect.provide(harness.planLayer),
-          )
-          const workflowContext = yield* Layer.build(harness.workflowLayer)
-          const observable = yield* executeObservable(plan, {
-            dryRun: false,
-            dbPath: `${Fs.Path.toString(harness.rootDir)}.release/workflow.db`,
-          }).pipe(Effect.provide(workflowContext))
-          const result = yield* observable.execute.pipe(Effect.provide(workflowContext))
+      const plan = yield* planOfficial(harness.workspacePackages).pipe(
+        Effect.provide(harness.planLayer),
+      )
+      const workflowContext = yield* Layer.build(harness.workflowLayer)
+      const observable = yield* executeObservable(plan, {
+        dryRun: false,
+        dbPath: `${Fs.Path.toString(harness.rootDir)}.release/workflow.db`,
+      }).pipe(Effect.provide(workflowContext))
+      const result = yield* observable.execute.pipe(Effect.provide(workflowContext))
 
-          expect(result).toEqual({
-            releasedPackages: ['@kitz/a', '@kitz/b'],
-            createdTags: [
-              tag(Pkg.Moniker.parse('@kitz/a'), '1.1.0'),
-              tag(Pkg.Moniker.parse('@kitz/b'), '1.0.1'),
-            ],
-            createdGHReleases: [
-              tag(Pkg.Moniker.parse('@kitz/a'), '1.1.0'),
-              tag(Pkg.Moniker.parse('@kitz/b'), '1.0.1'),
-            ],
-          })
+      expect(result).toEqual({
+        releasedPackages: ['@kitz/a', '@kitz/b'],
+        createdTags: [
+          tag(Pkg.Moniker.parse('@kitz/a'), '1.1.0'),
+          tag(Pkg.Moniker.parse('@kitz/b'), '1.0.1'),
+        ],
+        createdGHReleases: [
+          tag(Pkg.Moniker.parse('@kitz/a'), '1.1.0'),
+          tag(Pkg.Moniker.parse('@kitz/b'), '1.0.1'),
+        ],
+      })
 
-          expect(Otel.print(traceFromExecutionGraph(observable.graph), { sort: 'input' }))
-            .toMatchInlineSnapshot(`
+      expect(Otel.print(traceFromExecutionGraph(observable.graph), { sort: 'input' }))
+        .toMatchInlineSnapshot(`
 "trace release.integration (20 spans)
 └─ [workflow] apply
    ├─ [workflow] stage 1
@@ -781,191 +780,171 @@ describe('Executor e2e', () => {
    └─ [workflow] stage 7
       └─ [github] createRelease {release.package.name=@kitz/b release.version=1.0.1 release.tag=@kitz/b@1.0.1}"
 `)
-        }),
-      ),
-    E2E_TEST_TIMEOUT_MS,
+    }),
   )
 
-  Test.live(
-    'resumes after a prepack failure without re-packing completed packages',
-    () =>
-      quiet(
-        Effect.gen(function* () {
-          const failingPackages: readonly FixturePackage[] = [
-            ...alphaPackages.slice(0, 2),
-            {
-              name: '@kitz/c',
-              scripts: {
-                prepack: "sh -c 'exit 23'",
-              },
-            },
-          ]
+  testE2E('resumes after a prepack failure without re-packing completed packages', () =>
+    Effect.gen(function* () {
+      const failingPackages: readonly FixturePackage[] = [
+        ...alphaPackages.slice(0, 2),
+        {
+          name: '@kitz/c',
+          scripts: {
+            prepack: "sh -c 'exit 23'",
+          },
+        },
+      ]
 
-          const harness = yield* makeRealHarness({
-            packages: failingPackages,
-            commits: [
-              Git.Memory.commit('feat(a): add feature'),
-              Git.Memory.commit('feat(b): add feature'),
-              Git.Memory.commit('feat(c): add feature'),
-            ],
-          })
+      const harness = yield* makeRealHarness({
+        packages: failingPackages,
+        commits: [
+          Git.Memory.commit('feat(a): add feature'),
+          Git.Memory.commit('feat(b): add feature'),
+          Git.Memory.commit('feat(c): add feature'),
+        ],
+      })
 
-          const plan = yield* planOfficial(harness.workspacePackages).pipe(
-            Effect.provide(harness.planLayer),
-          )
+      const plan = yield* planOfficial(harness.workspacePackages).pipe(
+        Effect.provide(harness.planLayer),
+      )
 
-          expect(plan.releases.map((item) => item.package.name.moniker).toSorted()).toEqual([
-            '@kitz/a',
-            '@kitz/b',
-            '@kitz/c',
-          ])
+      expect(plan.releases.map((item) => item.package.name.moniker).toSorted()).toEqual([
+        '@kitz/a',
+        '@kitz/b',
+        '@kitz/c',
+      ])
 
-          const workflowContext = yield* Layer.build(harness.workflowLayer)
+      const workflowContext = yield* Layer.build(harness.workflowLayer)
 
-          const firstRun = yield* execute(plan, { dryRun: false }).pipe(
-            Effect.provide(workflowContext),
-            Effect.result,
-          )
+      const firstRun = yield* execute(plan, { dryRun: false }).pipe(
+        Effect.provide(workflowContext),
+        Effect.result,
+      )
 
-          expect(firstRun._tag).toBe('Failure')
-          expect(yield* Ref.get(harness.packCalls)).toEqual(['@kitz/a', '@kitz/b', '@kitz/c'])
-          expect(yield* Ref.get(harness.publishCalls)).toEqual([])
+      expect(firstRun._tag).toBe('Failure')
+      expect(yield* Ref.get(harness.packCalls)).toEqual(['@kitz/a', '@kitz/b', '@kitz/c'])
+      expect(yield* Ref.get(harness.publishCalls)).toEqual([])
 
-          const failingPackageJsonPath = harness.packageJsonPaths['@kitz/c']!
-          yield* withFileSystem(
-            Fs.write(
-              failingPackageJsonPath,
-              makePackageJson({
-                name: '@kitz/c',
-              }),
-            ),
-          ).pipe(Effect.orDie)
+      const failingPackageJsonPath = harness.packageJsonPaths['@kitz/c']!
+      yield* withFileSystem(
+        Fs.write(
+          failingPackageJsonPath,
+          makePackageJson({
+            name: '@kitz/c',
+          }),
+        ),
+      ).pipe(Effect.orDie)
 
-          const secondRun = yield* resume(plan, { dryRun: false }).pipe(
-            Effect.provide(workflowContext),
-            Effect.result,
-          )
+      const secondRun = yield* resume(plan, { dryRun: false }).pipe(
+        Effect.provide(workflowContext),
+        Effect.result,
+      )
 
-          expect(secondRun._tag).toBe('Success')
-          if (secondRun._tag === 'Success') {
-            expect(secondRun.success.releasedPackages).toEqual(['@kitz/a', '@kitz/b', '@kitz/c'])
-          }
+      expect(secondRun._tag).toBe('Success')
+      if (secondRun._tag === 'Success') {
+        expect(secondRun.success.releasedPackages).toEqual(['@kitz/a', '@kitz/b', '@kitz/c'])
+      }
 
-          expect(yield* Ref.get(harness.packCalls)).toEqual([
-            '@kitz/a',
-            '@kitz/b',
-            '@kitz/c',
-            '@kitz/c',
-          ])
-          expect(yield* Ref.get(harness.publishCalls)).toEqual(['@kitz/a', '@kitz/b', '@kitz/c'])
-        }),
-      ),
-    E2E_TEST_TIMEOUT_MS,
+      expect(yield* Ref.get(harness.packCalls)).toEqual([
+        '@kitz/a',
+        '@kitz/b',
+        '@kitz/c',
+        '@kitz/c',
+      ])
+      expect(yield* Ref.get(harness.publishCalls)).toEqual(['@kitz/a', '@kitz/b', '@kitz/c'])
+    }),
   )
 
   for (const scenario of hookFailureScenarios) {
-    Test.live(
-      scenario.name,
-      () =>
-        quiet(
-          Effect.gen(function* () {
-            const packages = withScripts(graphPackages, scenario.packageName, scenario.scripts)
-            const harness = yield* makeRealHarness({
-              packages,
-              commits: graphCommits,
-            })
+    testE2E(scenario.name, () =>
+      Effect.gen(function* () {
+        const packages = withScripts(graphPackages, scenario.packageName, scenario.scripts)
+        const harness = yield* makeRealHarness({
+          packages,
+          commits: graphCommits,
+        })
 
-            const plan = yield* planOfficial(harness.workspacePackages).pipe(
-              Effect.provide(harness.planLayer),
-            )
+        const plan = yield* planOfficial(harness.workspacePackages).pipe(
+          Effect.provide(harness.planLayer),
+        )
 
-            assertGraphPlan(plan)
+        assertGraphPlan(plan)
 
-            const workflowContext = yield* Layer.build(harness.workflowLayer)
+        const workflowContext = yield* Layer.build(harness.workflowLayer)
 
-            const firstRun = yield* execute(plan, { dryRun: false }).pipe(
-              Effect.provide(workflowContext),
-              Effect.result,
-            )
+        const firstRun = yield* execute(plan, { dryRun: false }).pipe(
+          Effect.provide(workflowContext),
+          Effect.result,
+        )
 
-            expect(firstRun._tag).toBe('Failure')
-            expect(yield* Ref.get(harness.packCalls)).toEqual(scenario.firstPackCalls)
-            expect(yield* Ref.get(harness.publishCalls)).toEqual([])
+        expect(firstRun._tag).toBe('Failure')
+        expect(yield* Ref.get(harness.packCalls)).toEqual(scenario.firstPackCalls)
+        expect(yield* Ref.get(harness.publishCalls)).toEqual([])
 
-            const fixedPackage = fixtureByName(graphPackages, scenario.packageName)
-            yield* withFileSystem(
-              Fs.write(
-                harness.packageJsonPaths[scenario.packageName]!,
-                makePackageJson(fixedPackage),
-              ),
-            ).pipe(Effect.orDie)
+        const fixedPackage = fixtureByName(graphPackages, scenario.packageName)
+        yield* withFileSystem(
+          Fs.write(harness.packageJsonPaths[scenario.packageName]!, makePackageJson(fixedPackage)),
+        ).pipe(Effect.orDie)
 
-            const secondRun = yield* resume(plan, { dryRun: false }).pipe(
-              Effect.provide(workflowContext),
-              Effect.result,
-            )
+        const secondRun = yield* resume(plan, { dryRun: false }).pipe(
+          Effect.provide(workflowContext),
+          Effect.result,
+        )
 
-            expect(secondRun._tag).toBe('Success')
-            if (secondRun._tag === 'Success') {
-              expect(secondRun.success).toEqual<typeof graphResult>(graphResult)
-            }
+        expect(secondRun._tag).toBe('Success')
+        if (secondRun._tag === 'Success') {
+          expect(secondRun.success).toEqual<typeof graphResult>(graphResult)
+        }
 
-            expect(yield* Ref.get(harness.packCalls)).toEqual(scenario.finalPackCalls)
-            expect(yield* Ref.get(harness.publishCalls)).toEqual(graphResult.releasedPackages)
-          }),
-        ),
-      E2E_TEST_TIMEOUT_MS,
+        expect(yield* Ref.get(harness.packCalls)).toEqual(scenario.finalPackCalls)
+        expect(yield* Ref.get(harness.publishCalls)).toEqual(graphResult.releasedPackages)
+      }),
     )
   }
 
   for (const scenario of publishFailureScenarios) {
-    Test.live(
-      scenario.name,
-      () =>
-        quiet(
-          Effect.gen(function* () {
-            const harness = yield* makeRealHarness({
-              packages: graphPackages,
-              commits: graphCommits,
-              failPublishPackages: [scenario.packageName],
-            })
+    testE2E(scenario.name, () =>
+      Effect.gen(function* () {
+        const harness = yield* makeRealHarness({
+          packages: graphPackages,
+          commits: graphCommits,
+          failPublishPackages: [scenario.packageName],
+        })
 
-            const plan = yield* planOfficial(harness.workspacePackages).pipe(
-              Effect.provide(harness.planLayer),
-            )
+        const plan = yield* planOfficial(harness.workspacePackages).pipe(
+          Effect.provide(harness.planLayer),
+        )
 
-            assertGraphPlan(plan)
+        assertGraphPlan(plan)
 
-            const workflowContext = yield* Layer.build(harness.workflowLayer)
+        const workflowContext = yield* Layer.build(harness.workflowLayer)
 
-            const firstRun = yield* execute(plan, { dryRun: false }).pipe(
-              Effect.provide(workflowContext),
-              Effect.result,
-            )
+        const firstRun = yield* execute(plan, { dryRun: false }).pipe(
+          Effect.provide(workflowContext),
+          Effect.result,
+        )
 
-            expect(firstRun._tag).toBe('Failure')
-            expect(yield* Ref.get(harness.packCalls)).toEqual(graphResult.releasedPackages)
-            expect(yield* Ref.get(harness.publishCalls)).toEqual(scenario.firstPublishCalls)
-            expect(yield* Ref.get(harness.gitState.createdTags)).toEqual([])
-            yield* assertGraphTarballsExist(harness.rootDir, digestForPlan(plan).value)
+        expect(firstRun._tag).toBe('Failure')
+        expect(yield* Ref.get(harness.packCalls)).toEqual(graphResult.releasedPackages)
+        expect(yield* Ref.get(harness.publishCalls)).toEqual(scenario.firstPublishCalls)
+        expect(yield* Ref.get(harness.gitState.createdTags)).toEqual([])
+        yield* assertGraphTarballsExist(harness.rootDir, digestForPlan(plan).value)
 
-            yield* Ref.set(harness.failPublishPackages, [])
+        yield* Ref.set(harness.failPublishPackages, [])
 
-            const secondRun = yield* resume(plan, { dryRun: false }).pipe(
-              Effect.provide(workflowContext),
-              Effect.result,
-            )
+        const secondRun = yield* resume(plan, { dryRun: false }).pipe(
+          Effect.provide(workflowContext),
+          Effect.result,
+        )
 
-            expect(secondRun._tag).toBe('Success')
-            if (secondRun._tag === 'Success') {
-              expect(secondRun.success).toEqual<typeof graphResult>(graphResult)
-            }
+        expect(secondRun._tag).toBe('Success')
+        if (secondRun._tag === 'Success') {
+          expect(secondRun.success).toEqual<typeof graphResult>(graphResult)
+        }
 
-            expect(yield* Ref.get(harness.packCalls)).toEqual(graphResult.releasedPackages)
-            expect(yield* Ref.get(harness.publishCalls)).toEqual(scenario.finalPublishCalls)
-          }),
-        ),
-      E2E_TEST_TIMEOUT_MS,
+        expect(yield* Ref.get(harness.packCalls)).toEqual(graphResult.releasedPackages)
+        expect(yield* Ref.get(harness.publishCalls)).toEqual(scenario.finalPublishCalls)
+      }),
     )
   }
 })


### PR DESCRIPTION
Part of #259, Item 10.

## What changed

- Compact `artifact.test.ts` around shared release-contract fixtures for package manifests, memory disks, contracted plans, script-policy issue codes, and engine-policy issue codes.
- Compact `executor/e2e.test.ts` with a typed `testE2E` wrapper for the repeated `Test.live(... quiet(effect), E2E_TEST_TIMEOUT_MS)` shape.
- Preserve the existing oracle surface: same issue-code assertions, rehearsal failure guards, call ordering checks, trace snapshot, resume behavior, and side-effect boundaries.

## Measured impact

- `packages/release/src/api/artifact.test.ts`: 900 -> 787 LOC.
- `packages/release/src/api/executor/e2e.test.ts`: 971 -> 950 LOC.
- `packages/release/src` test total: 21935 -> 21801 LOC.

## Review

Euler reviewed the diff for FP, Effect, type safety, simplicity, compactness, and oracle strength. Findings: none.

## Verification

- `bun run --cwd packages/release test src/api/artifact.test.ts src/api/executor/e2e.test.ts`
- `bun run --cwd packages/release check:types`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-6 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-6 bun run --cwd packages/release check:lint`
- `bun tools/run-format.ts --check packages/release/src/api/artifact.test.ts packages/release/src/api/executor/e2e.test.ts`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-6 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-6 git diff --check`
- `bun run --cwd packages/release test`
