### PR TITLE
test(release): compact preview and workflow fixtures

### DIFF
--- a/packages/release/src/api/executor/_.test.ts
+++ b/packages/release/src/api/executor/_.test.ts
@@ -12,6 +12,7 @@ import { publishIntentFromSemantics } from '../release-contract.js'
 import { resolvePublishSemantics } from '../publishing.js'
 import { Plan } from '../planner/models/plan.js'
 import {
+  type Harness,
   decodeJsonRecordSync,
   decodeSemverFromManifest,
   makeHarness,
@@ -138,6 +139,29 @@ const expectRestoredCoreManifest = (manifestRaw: string) => {
   return manifest
 }
 
+const expectSingleReleaseTag = (plan: Plan) => {
+  const plannedRelease = plan.releases[0]
+  expect(plannedRelease).toBeDefined()
+  return tag(plannedRelease!.package.name, Semver.toString(plannedRelease!.nextVersion))
+}
+
+const seedExistingCandidateRelease = (candidateTag: string) =>
+  Effect.gen(function* () {
+    const gh = yield* Github.Github
+    yield* gh.createRelease({
+      tag: candidateTag,
+      title: '@kitz/core @next',
+      body: 'existing',
+      prerelease: true,
+    })
+  })
+
+const expectFirstPublishTag = (harness: Harness, expected: string) =>
+  Effect.gen(function* () {
+    const publishCalls = yield* Ref.get(harness.publishCalls)
+    expect(publishCalls[0]?.tag).toBe(expected)
+  })
+
 describe('Executor integration', () => {
   Test.live(
     'runs non-dry-run official workflow with mocked services and restores manifest semver',
@@ -237,8 +261,7 @@ describe('Executor integration', () => {
             npmTag: 'beta',
           }).pipe(Effect.provide(harness.workflowLayer))
 
-          const publishCalls = yield* Ref.get(harness.publishCalls)
-          expect(publishCalls[0]?.tag).toBe('beta')
+          yield* expectFirstPublishTag(harness, 'beta')
         }),
       ),
   )
@@ -249,12 +272,7 @@ describe('Executor integration', () => {
         const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
-        const plannedRelease = plan.releases[0]
-        expect(plannedRelease).toBeDefined()
-        const conflictingTag = tag(
-          plannedRelease!.package.name,
-          Semver.toString(plannedRelease!.nextVersion),
-        )
+        const conflictingTag = expectSingleReleaseTag(plan)
         yield* Ref.update(harness.gitState.tags, (tags) => [...tags, conflictingTag])
 
         const outcome = yield* execute(plan, { dryRun: false }).pipe(
@@ -460,23 +478,11 @@ describe('Executor integration', () => {
         })
 
         const plan = yield* planCandidate(workspacePackages).pipe(Effect.provide(harness.planLayer))
+        const candidateTag = expectSingleReleaseTag(plan)
 
-        const plannedRelease = plan.releases[0]
-        expect(plannedRelease).toBeDefined()
-        const candidateTag = tag(
-          plannedRelease!.package.name,
-          Semver.toString(plannedRelease!.nextVersion),
+        yield* seedExistingCandidateRelease(candidateTag).pipe(
+          Effect.provide(harness.workflowLayer),
         )
-
-        yield* Effect.gen(function* () {
-          const gh = yield* Github.Github
-          yield* gh.createRelease({
-            tag: candidateTag,
-            title: '@kitz/core @next',
-            body: 'existing',
-            prerelease: true,
-          })
-        }).pipe(Effect.provide(harness.workflowLayer))
 
         const result = yield* execute(plan, { dryRun: false, tag: 'next' }).pipe(
           Effect.provide(harness.workflowLayer),
@@ -502,8 +508,7 @@ describe('Executor integration', () => {
 
         yield* execute(plan, { dryRun: false }).pipe(Effect.provide(harness.workflowLayer))
 
-        const publishCalls = yield* Ref.get(harness.publishCalls)
-        expect(publishCalls[0]?.tag).toBe('next')
+        yield* expectFirstPublishTag(harness, 'next')
       }),
     ),
   )
@@ -524,8 +529,7 @@ describe('Executor integration', () => {
             candidateTag: 'candidate',
           }).pipe(Effect.provide(harness.workflowLayer))
 
-          const publishCalls = yield* Ref.get(harness.publishCalls)
-          expect(publishCalls[0]?.tag).toBe('candidate')
+          yield* expectFirstPublishTag(harness, 'candidate')
         }),
       ),
   )
@@ -542,23 +546,11 @@ describe('Executor integration', () => {
           const plan = yield* planCandidate(workspacePackages).pipe(
             Effect.provide(harness.planLayer),
           )
+          const candidateTag = expectSingleReleaseTag(plan)
 
-          const plannedRelease = plan.releases[0]
-          expect(plannedRelease).toBeDefined()
-          const candidateTag = tag(
-            plannedRelease!.package.name,
-            Semver.toString(plannedRelease!.nextVersion),
+          yield* seedExistingCandidateRelease(candidateTag).pipe(
+            Effect.provide(harness.workflowLayer),
           )
-
-          yield* Effect.gen(function* () {
-            const gh = yield* Github.Github
-            yield* gh.createRelease({
-              tag: candidateTag,
-              title: '@kitz/core @next',
-              body: 'existing',
-              prerelease: true,
-            })
-          }).pipe(Effect.provide(harness.workflowLayer))
 
           const result = yield* execute(plan, { dryRun: false, tag: 'candidate' }).pipe(
             Effect.provide(harness.workflowLayer),
@@ -586,13 +578,7 @@ describe('Executor integration', () => {
         const harness = yield* makeCoreHarness()
 
         const plan = yield* planCandidate(workspacePackages).pipe(Effect.provide(harness.planLayer))
-
-        const plannedRelease = plan.releases[0]
-        expect(plannedRelease).toBeDefined()
-        const candidateTag = tag(
-          plannedRelease!.package.name,
-          Semver.toString(plannedRelease!.nextVersion),
-        )
+        const candidateTag = expectSingleReleaseTag(plan)
 
         const result = yield* execute(plan, { dryRun: false, tag: 'candidate' }).pipe(
           Effect.provide(harness.workflowLayer),
@@ -633,11 +619,10 @@ describe('Executor integration', () => {
 
           expect(result.createdGHReleases).toHaveLength(1)
 
-          const publishCalls = yield* Ref.get(harness.publishCalls)
           const pushedTags = yield* Ref.get(harness.gitState.pushedTags)
           const createdReleases = yield* Ref.get(harness.githubState.createdReleases)
 
-          expect(publishCalls[0]?.tag).toBe('preview-42')
+          yield* expectFirstPublishTag(harness, 'preview-42')
           expect(pushedTags[0]).toMatchObject({ force: false })
           expect(createdReleases[0]?.title).toContain(' v0.0.0-pr.42.1.')
           expect(createdReleases[0]?.prerelease).toBe(true)
@@ -658,8 +643,7 @@ describe('Executor integration', () => {
 
         yield* execute(plan, { dryRun: false }).pipe(Effect.provide(harness.workflowLayer))
 
-        const publishCalls = yield* Ref.get(harness.publishCalls)
-        expect(publishCalls[0]?.tag).toBe('pr-42')
+        yield* expectFirstPublishTag(harness, 'pr-42')
       }),
     ),
   )

--- a/packages/release/src/api/workflow.integration.test.ts
+++ b/packages/release/src/api/workflow.integration.test.ts
@@ -39,6 +39,57 @@ const workspacePackages: Parameters<typeof planOfficial>[0] = [
 
 const tagCore = (version: string) => tag(Pkg.Moniker.parse('@kitz/core'), version)
 const quiet = <A, E, R>(effect: Effect.Effect<A, E, R>) => effect
+type HarnessOptions = Parameters<typeof makeHarness>[0]
+
+const coreGit: HarnessOptions['git'] = {
+  tags: [tagCore('1.0.0')],
+  commits: [Git.Memory.commit('feat(core): new API')],
+  isClean: true,
+}
+const coreDiskLayout = {
+  '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
+}
+const makeCoreHarness = (options?: {
+  readonly git?: Partial<HarnessOptions['git']>
+  readonly diskLayout?: Fs.Memory.DiskLayout
+  readonly failPackPackages?: readonly string[]
+  readonly failPublishPackages?: readonly string[]
+  readonly missingRegistryVersions?: readonly string[]
+  readonly observedDistTags?: Readonly<Record<string, string>>
+}) =>
+  makeHarness({
+    git: { ...coreGit, ...options?.git },
+    diskLayout: options?.diskLayout ?? coreDiskLayout,
+    ...(options?.failPackPackages ? { failPackPackages: options.failPackPackages } : {}),
+    ...(options?.failPublishPackages ? { failPublishPackages: options.failPublishPackages } : {}),
+    ...(options?.missingRegistryVersions
+      ? { missingRegistryVersions: options.missingRegistryVersions }
+      : {}),
+    ...(options?.observedDistTags ? { observedDistTags: options.observedDistTags } : {}),
+  })
+
+type FailureOutcome = {
+  readonly _tag: string
+  readonly failure?: {
+    readonly _tag: string
+    readonly context?: unknown
+  }
+}
+
+const expectFailure = (outcome: FailureOutcome, tag: string) => {
+  expect(outcome._tag).toBe('Failure')
+  if (outcome._tag !== 'Failure') throw new Error('expected failure')
+  expect(outcome.failure?._tag).toBe(tag)
+  return outcome.failure!
+}
+
+const expectRestoredCoreManifest = (manifestRaw: string) => {
+  const manifest = decodeJsonRecordSync(manifestRaw)
+  expect(
+    Semver.equivalence(decodeSemverFromManifest(manifest[`version`]), Semver.fromString('1.0.0')),
+  ).toBe(true)
+  return manifest
+}
 
 describe('Workflow integration', () => {
   Test.live(
@@ -46,16 +97,7 @@ describe('Workflow integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
-          })
+          const harness = yield* makeCoreHarness()
 
           const plan = yield* planOfficial(workspacePackages).pipe(
             Effect.provide(harness.planLayer),
@@ -96,13 +138,7 @@ describe('Workflow integration', () => {
           const manifestRaw = yield* Fs.readString(coreManifestPath).pipe(
             Effect.provide(harness.workflowLayer),
           )
-          const manifest = decodeJsonRecordSync(manifestRaw)
-          expect(
-            Semver.equivalence(
-              decodeSemverFromManifest(manifest[`version`]),
-              Semver.fromString('1.0.0'),
-            ),
-          ).toBe(true)
+          expectRestoredCoreManifest(manifestRaw)
         }),
       ),
   )
@@ -110,16 +146,7 @@ describe('Workflow integration', () => {
   Test.live('publishes rehearsed tarballs without re-packing during apply execution', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const rehearsedPath = `/repo/.release/artifacts/${digestForPlan(plan).value}/kitz-core-1.1.0.tgz`
@@ -200,16 +227,7 @@ describe('Workflow integration', () => {
   Test.live('dry-run execution reaches every side-effect layer without mutating services', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const result = yield* executeWorkflow(plan, { dryRun: true }).pipe(
@@ -231,16 +249,7 @@ describe('Workflow integration', () => {
   Test.live('fails before publish when a rehearsed artifact is missing', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const outcome = yield* executeWorkflow(plan, {
@@ -248,13 +257,10 @@ describe('Workflow integration', () => {
           rehearsedArtifacts: true,
         }).pipe(Effect.provide(harness.workflowLayer), Effect.result)
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPublishError')
-          if (outcome.failure._tag === 'ExecutorPublishError') {
-            expect(outcome.failure.context.detail).toContain('Rehearsed artifact is missing')
-          }
+        const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+          readonly context: { readonly detail: string }
         }
+        expect(failure.context.detail).toContain('Rehearsed artifact is missing')
 
         expect(yield* Ref.get(harness.publishCalls)).toHaveLength(0)
       }),
@@ -264,16 +270,7 @@ describe('Workflow integration', () => {
   Test.live('fails before publish when a rehearsed artifact is empty', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const rehearsedPath = `/repo/.release/artifacts/${digestForPlan(plan).value}/kitz-core-1.1.0.tgz`
@@ -286,13 +283,10 @@ describe('Workflow integration', () => {
           rehearsedArtifacts: true,
         }).pipe(Effect.provide(harness.workflowLayer), Effect.result)
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPublishError')
-          if (outcome.failure._tag === 'ExecutorPublishError') {
-            expect(outcome.failure.context.detail).toContain('Rehearsed artifact is empty')
-          }
+        const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+          readonly context: { readonly detail: string }
         }
+        expect(failure.context.detail).toContain('Rehearsed artifact is empty')
 
         expect(yield* Ref.get(harness.publishCalls)).toHaveLength(0)
       }),
@@ -377,14 +371,11 @@ describe('Workflow integration', () => {
           atomicTagPush: true,
         }).pipe(Effect.provide(harness.workflowLayer), Effect.result)
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorTagError')
-          if (outcome.failure._tag === 'ExecutorTagError') {
-            expect(outcome.failure.context.tag).toBe('atomic-tag-push')
-            expect(outcome.failure.context.detail).toContain('mock atomic push failure')
-          }
+        const failure = expectFailure(outcome, 'ExecutorTagError') as {
+          readonly context: { readonly tag: string; readonly detail: string }
         }
+        expect(failure.context.tag).toBe('atomic-tag-push')
+        expect(failure.context.detail).toContain('mock atomic push failure')
 
         const createdReleases = yield* Ref.get(harness.githubState.createdReleases)
         expect(createdReleases).toHaveLength(0)
@@ -395,15 +386,7 @@ describe('Workflow integration', () => {
   Test.live('stops before tags when post-publish registry verification fails', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
+        const harness = yield* makeCoreHarness({
           missingRegistryVersions: ['@kitz/core@1.1.0'],
         })
 
@@ -413,13 +396,10 @@ describe('Workflow integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPublishError')
-          if (outcome.failure._tag === 'ExecutorPublishError') {
-            expect(outcome.failure.context.detail).toContain('Registry does not show')
-          }
+        const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+          readonly context: { readonly detail: string }
         }
+        expect(failure.context.detail).toContain('Registry does not show')
 
         const createdTags = yield* Ref.get(harness.gitState.createdTags)
         expect(createdTags).toHaveLength(0)
@@ -430,17 +410,7 @@ describe('Workflow integration', () => {
   Test.live('stops before tags when registry observation contradicts the publish intent', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-          observedDistTags: { latest: '0.0.1' },
-        })
+        const harness = yield* makeCoreHarness({ observedDistTags: { latest: '0.0.1' } })
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const outcome = yield* executeWorkflow(plan, { dryRun: false }).pipe(
@@ -448,15 +418,10 @@ describe('Workflow integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPublishError')
-          if (outcome.failure._tag === 'ExecutorPublishError') {
-            expect(outcome.failure.context.detail).toContain(
-              'latest does not point at @kitz/core@1.1.0',
-            )
-          }
+        const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+          readonly context: { readonly detail: string }
         }
+        expect(failure.context.detail).toContain('latest does not point at @kitz/core@1.1.0')
 
         const createdTags = yield* Ref.get(harness.gitState.createdTags)
         expect(createdTags).toHaveLength(0)
@@ -467,16 +432,7 @@ describe('Workflow integration', () => {
   Test.live('fails preflight on conflicting tag and does not publish', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
         const plannedRelease = plan.releases[0]
@@ -492,13 +448,10 @@ describe('Workflow integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPreflightError')
-          if (outcome.failure._tag === 'ExecutorPreflightError') {
-            expect(outcome.failure.context.check).toBe('plan.tags-unique')
-          }
+        const failure = expectFailure(outcome, 'ExecutorPreflightError') as {
+          readonly context: { readonly check: string }
         }
+        expect(failure.context.check).toBe('plan.tags-unique')
 
         const publishAttempts = yield* Ref.get(harness.publishAttempts)
         expect(publishAttempts).toBe(0)
@@ -514,15 +467,7 @@ describe('Workflow integration', () => {
     () =>
       quiet(
         Effect.gen(function* () {
-          const harness = yield* makeHarness({
-            git: {
-              tags: [tagCore('1.0.0')],
-              commits: [Git.Memory.commit('feat(core): new API')],
-              isClean: true,
-            },
-            diskLayout: {
-              '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-            },
+          const harness = yield* makeCoreHarness({
             failPublishPackages: ['@kitz/core'],
           })
 
@@ -535,14 +480,11 @@ describe('Workflow integration', () => {
             Effect.result,
           )
 
-          expect(outcome._tag).toBe('Failure')
-          if (outcome._tag === 'Failure') {
-            expect(outcome.failure._tag).toBe('ExecutorPublishError')
-            if (outcome.failure._tag === 'ExecutorPublishError') {
-              expect(outcome.failure.context.packageName).toBe('@kitz/core')
-              expect(outcome.failure.context.detail).toContain('mock publish failure')
-            }
+          const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+            readonly context: { readonly packageName: string; readonly detail: string }
           }
+          expect(failure.context.packageName).toBe('@kitz/core')
+          expect(failure.context.detail).toContain('mock publish failure')
 
           const publishAttempts = yield* Ref.get(harness.publishAttempts)
           expect(publishAttempts).toBe(1)
@@ -553,13 +495,7 @@ describe('Workflow integration', () => {
           const manifestRaw = yield* Fs.readString(coreManifestPath).pipe(
             Effect.provide(harness.workflowLayer),
           )
-          const manifest = decodeJsonRecordSync(manifestRaw)
-          expect(
-            Semver.equivalence(
-              decodeSemverFromManifest(manifest[`version`]),
-              Semver.fromString('1.0.0'),
-            ),
-          ).toBe(true)
+          expectRestoredCoreManifest(manifestRaw)
         }),
       ),
   )
@@ -567,12 +503,7 @@ describe('Workflow integration', () => {
   Test.live('surfaces cleanup guidance when pack hooks exist and artifact preparation fails', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
+        const harness = yield* makeCoreHarness({
           diskLayout: {
             '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0', {
               imports: {
@@ -596,31 +527,18 @@ describe('Workflow integration', () => {
           Effect.result,
         )
 
-        expect(outcome._tag).toBe('Failure')
-        if (outcome._tag === 'Failure') {
-          expect(outcome.failure._tag).toBe('ExecutorPublishError')
-          if (outcome.failure._tag === 'ExecutorPublishError') {
-            expect(outcome.failure.context.detail).toContain('mock pack failure')
-            expect(outcome.failure.context.detail).toContain(
-              'Source package manifests were not mutated',
-            )
-            expect(outcome.failure.context.detail).toContain('Pack hooks detected (prepack)')
-            expect(outcome.failure.context.detail).toContain(
-              'plan.packages-runtime-targets-source-oriented',
-            )
-          }
+        const failure = expectFailure(outcome, 'ExecutorPublishError') as {
+          readonly context: { readonly detail: string }
         }
+        expect(failure.context.detail).toContain('mock pack failure')
+        expect(failure.context.detail).toContain('Source package manifests were not mutated')
+        expect(failure.context.detail).toContain('Pack hooks detected (prepack)')
+        expect(failure.context.detail).toContain('plan.packages-runtime-targets-source-oriented')
 
         const manifestRaw = yield* Fs.readString(coreManifestPath).pipe(
           Effect.provide(harness.workflowLayer),
         )
-        const manifest = decodeJsonRecordSync(manifestRaw)
-        expect(
-          Semver.equivalence(
-            decodeSemverFromManifest(manifest[`version`]),
-            Semver.fromString('1.0.0'),
-          ),
-        ).toBe(true)
+        const manifest = expectRestoredCoreManifest(manifestRaw)
         expect(manifest['imports']).toEqual({
           '#core': './src/_.ts',
         })
@@ -634,15 +552,8 @@ describe('Workflow integration', () => {
   Test.live('updates existing GitHub candidate release when tag option is next', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0'), tagCore('1.1.0-next.1')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
+        const harness = yield* makeCoreHarness({
+          git: { tags: [tagCore('1.0.0'), tagCore('1.1.0-next.1')] },
         })
 
         const plan = yield* planCandidate(workspacePackages).pipe(Effect.provide(harness.planLayer))
@@ -682,16 +593,8 @@ describe('Workflow integration', () => {
   Test.live('creates PR releases as GitHub prereleases without --tag next', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-            headSha: Git.Sha.make('abc1234'),
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
+        const harness = yield* makeCoreHarness({
+          git: { headSha: Git.Sha.make('abc1234') },
         })
 
         const plan = yield* planEphemeral(workspacePackages, { prNumber: 42 }).pipe(
@@ -715,16 +618,7 @@ describe('Workflow integration', () => {
   Test.live('legacy payloads without lifecycle create versioned GitHub releases', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         yield* ReleaseWorkflow.execute({
           releases: [
@@ -765,15 +659,7 @@ describe('Workflow integration', () => {
   Test.live('test harness registry probes model missing and unrecorded versions distinctly', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-            isClean: true,
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
+        const harness = yield* makeCoreHarness({
           missingRegistryVersions: ['@kitz/core@1.1.0'],
         })
 
@@ -802,15 +688,7 @@ describe('Workflow integration', () => {
   Test.live('observable workflow exposes graph in dry-run mode', () =>
     quiet(
       Effect.gen(function* () {
-        const harness = yield* makeHarness({
-          git: {
-            tags: [tagCore('1.0.0')],
-            commits: [Git.Memory.commit('feat(core): new API')],
-          },
-          diskLayout: {
-            '/repo/packages/core/package.json': makePackageJson('@kitz/core', '1.0.0'),
-          },
-        })
+        const harness = yield* makeCoreHarness()
 
         const plan = yield* planOfficial(workspacePackages).pipe(Effect.provide(harness.planLayer))
 

--- a/packages/release/src/cli/pr-preview.coverage.test.ts
+++ b/packages/release/src/cli/pr-preview.coverage.test.ts
@@ -234,6 +234,28 @@ const getFailureDetail = (error: unknown): string => {
 
 const assumePure = <A, E>(effect: Effect.Effect<A, E, unknown>) => effect as Effect.Effect<A, E>
 
+const diffLayer = (result: Parameters<typeof makeDiffSpawnerLayer>[0]) =>
+  Layer.mergeAll(Git.Memory.make({ root: '/repo' }), makeDiffSpawnerLayer(result))
+
+const runPreviewResult = (
+  options: Parameters<typeof runPrPreview>[0],
+  dependencies: RunPrPreviewDependencies = {},
+) =>
+  Effect.runPromise(
+    assumePure(runPrPreview(options, previewDeps(dependencies)).pipe(Effect.result)),
+  )
+
+type PreviewResult = Awaited<ReturnType<typeof runPreviewResult>>
+
+const expectPreviewFailure = (result: PreviewResult) => {
+  expect(result._tag).toBe('Failure')
+  if (result._tag !== 'Failure') {
+    throw new Error('expected preview to fail')
+  }
+
+  return result.failure
+}
+
 describe('pr preview coverage', () => {
   test('returns null for optional diff checks when the pull request base ref is missing', async () => {
     const result = await Effect.runPromise(
@@ -244,11 +266,7 @@ describe('pr preview coverage', () => {
         },
         packages: [corePackage],
         required: false,
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(Git.Memory.make({ root: '/repo' }), makeDiffSpawnerLayer({ stdout: '' })),
-        ),
-      ),
+      }).pipe(Effect.provide(diffLayer({ stdout: '' }))),
     )
 
     expect(result).toBeNull()
@@ -262,16 +280,13 @@ describe('pr preview coverage', () => {
         required: true,
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(
-            Git.Memory.make({ root: '/repo' }),
-            makeDiffSpawnerLayer({
-              stdout: [
-                'M\tpackages/core/src/index.ts',
-                'R100\tpackages/core/src/old.ts\tpackages/utils/src/index.ts',
-                'A\tREADME.md',
-              ].join('\n'),
-            }),
-          ),
+          diffLayer({
+            stdout: [
+              'M\tpackages/core/src/index.ts',
+              'R100\tpackages/core/src/old.ts\tpackages/utils/src/index.ts',
+              'A\tREADME.md',
+            ].join('\n'),
+          }),
         ),
       ),
     )
@@ -292,16 +307,7 @@ describe('pr preview coverage', () => {
         pullRequest,
         packages: [corePackage],
         required: false,
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Git.Memory.make({ root: '/repo' }),
-            makeDiffSpawnerLayer({
-              failure: new Error('diff exploded'),
-            }),
-          ),
-        ),
-      ),
+      }).pipe(Effect.provide(diffLayer({ failure: new Error('diff exploded') }))),
     )
 
     expect(result).toEqual({
@@ -316,17 +322,7 @@ describe('pr preview coverage', () => {
         pullRequest,
         packages: [corePackage],
         required: true,
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Git.Memory.make({ root: '/repo' }),
-            makeDiffSpawnerLayer({
-              failure: new Error('diff exploded'),
-            }),
-          ),
-        ),
-        Effect.result,
-      ),
+      }).pipe(Effect.provide(diffLayer({ failure: new Error('diff exploded') })), Effect.result),
     )
 
     expect(result._tag).toBe('Failure')
@@ -546,118 +542,68 @@ describe('pr preview coverage', () => {
   })
 
   test('fails early when no releasable packages are resolved', async () => {
-    const result = await Effect.runPromise(
-      assumePure(
-        runPrPreview(
-          {},
-          previewDeps({
-            resolvePackages: () => Effect.succeed([]),
-          }),
-        ).pipe(Effect.result),
-      ),
+    const failure = expectPreviewFailure(
+      await runPreviewResult({}, { resolvePackages: () => Effect.succeed([]) }),
     )
 
-    expect(result._tag).toBe('Failure')
-    if (result._tag !== 'Failure') {
-      throw new Error('expected preview to fail')
-    }
-
-    expect(getFailureDetail(result.failure)).toContain('No packages found')
+    expect(getFailureDetail(failure)).toContain('No packages found')
   })
 
   test('fails when pull-request context resolution fails', async () => {
-    const result = await Effect.runPromise(
-      assumePure(
-        runPrPreview(
-          {},
-          previewDeps({
-            resolvePullRequestContext: () =>
-              Effect.fail(
-                new Api.Explorer.ExplorerError({
-                  context: {
-                    detail: 'context exploded',
-                  },
-                }),
-              ),
-          }),
-        ).pipe(Effect.result),
+    const failure = expectPreviewFailure(
+      await runPreviewResult(
+        {},
+        {
+          resolvePullRequestContext: () =>
+            Effect.fail(
+              new Api.Explorer.ExplorerError({
+                context: { detail: 'context exploded' },
+              }),
+            ),
+        },
       ),
     )
 
-    expect(result._tag).toBe('Failure')
-    if (result._tag !== 'Failure') {
-      throw new Error('expected preview to fail')
-    }
-
-    expect(getFailureDetail(result.failure)).toContain('context exploded')
+    expect(getFailureDetail(failure)).toContain('context exploded')
   })
 
   test('fails when no open pull request can be resolved for the branch', async () => {
-    const result = await Effect.runPromise(
-      assumePure(
-        runPrPreview(
-          {},
-          previewDeps({
-            resolvePullRequestContext: () =>
-              Effect.succeed(makePullRequestContext({ pullRequest: null })),
-          }),
-        ).pipe(Effect.result),
+    const failure = expectPreviewFailure(
+      await runPreviewResult(
+        {},
+        {
+          resolvePullRequestContext: () =>
+            Effect.succeed(makePullRequestContext({ pullRequest: null })),
+        },
       ),
     )
 
-    expect(result._tag).toBe('Failure')
-    if (result._tag !== 'Failure') {
-      throw new Error('expected preview to fail')
-    }
-
-    expect(getFailureDetail(result.failure)).toContain('Could not resolve an open pull request')
+    expect(getFailureDetail(failure)).toContain('Could not resolve an open pull request')
   })
 
   test('fails when the runtime does not provide a GitHub token', async () => {
-    const result = await Effect.runPromise(
-      assumePure(
-        runPrPreview(
-          {},
-          previewDeps({
-            resolvePullRequestContext: () =>
-              Effect.succeed(makePullRequestContext({ token: null })),
-            exploreFromContext: () =>
-              Effect.succeed(
-                makeRuntime({
-                  credentials: null,
-                }),
-              ),
-          }),
-        ).pipe(Effect.result),
+    const failure = expectPreviewFailure(
+      await runPreviewResult(
+        {},
+        {
+          resolvePullRequestContext: () => Effect.succeed(makePullRequestContext({ token: null })),
+          exploreFromContext: () => Effect.succeed(makeRuntime({ credentials: null })),
+        },
       ),
     )
 
-    expect(result._tag).toBe('Failure')
-    if (result._tag !== 'Failure') {
-      throw new Error('expected preview to fail')
-    }
-
-    expect(result.failure).toBeInstanceOf(Github.GithubConfigError)
+    expect(failure).toBeInstanceOf(Github.GithubConfigError)
   })
 
   test('raises a blocking error in check-only mode when doctor checks fail', async () => {
-    const result = await Effect.runPromise(
-      assumePure(
-        runPrPreview(
-          { checkOnly: true },
-          previewDeps({
-            buildPreviewDoctorSummary: () => Effect.succeed({ blocking: true }),
-          }),
-        ).pipe(Effect.result),
+    const failure = expectPreviewFailure(
+      await runPreviewResult(
+        { checkOnly: true },
+        { buildPreviewDoctorSummary: () => Effect.succeed({ blocking: true }) },
       ),
     )
 
-    expect(result._tag).toBe('Failure')
-    if (result._tag !== 'Failure') {
-      throw new Error('expected preview to fail')
-    }
-
-    expect(result.failure).toBeInstanceOf(PreviewBlockingError)
+    expect(failure).toBeInstanceOf(PreviewBlockingError)
   })
 
   test('returns a checked result in check-only mode when doctor checks pass', async () => {


### PR DESCRIPTION
Part of #259, Item 10 follow-up after #269.

## What changed

- Compact `pr-preview.coverage.test.ts` around shared diff-layer, preview-result, and failure assertion helpers.
- Compact `workflow.integration.test.ts` around core workflow harness and failure/manifest assertion helpers while leaving malformed and multi-package atomic scenarios explicit.
- Compact `executor/_.test.ts` around candidate-tag, candidate-release seeding, and publish-tag assertion helpers.
- Preserve the existing oracle surface: exact failure tags, detail text checks, publish tag checks, GitHub release assertions, graph assertions, and side-effect refs remain targeted at their original scenarios.

## Measured impact

- `packages/release/src/cli/pr-preview.coverage.test.ts`: 855 -> 801 LOC.
- `packages/release/src/api/workflow.integration.test.ts`: 833 -> 711 LOC.
- `packages/release/src/api/executor/_.test.ts`: 746 -> 730 LOC.
- `packages/release/src` test total: 21801 -> 21609 LOC since #269.

## Review

Curie reviewed the final diff for FP, Effect service usage, type safety, simplicity, compactness, and oracle strength. Findings: none.

## Verification

- `bun run --cwd packages/release test src/cli/pr-preview.coverage.test.ts src/api/workflow.integration.test.ts src/api/executor/_.test.ts`
- `bun run --cwd packages/release check:types`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-6 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-6 bun run --cwd packages/release check:lint`
- `bun tools/run-format.ts --check packages/release/src/api/executor/_.test.ts packages/release/src/api/workflow.integration.test.ts packages/release/src/cli/pr-preview.coverage.test.ts`
- `GIT_DIR=/Users/jasonkuhrt/projects/jasonkuhrt/kitz/.git/worktrees/kitz-release-qa-loop-6 GIT_WORK_TREE=/Users/jasonkuhrt/.codex/worktrees/kitz-release-qa-loop-6 git diff --check`
- `bun run --cwd packages/release test`
